### PR TITLE
convert some unwrap() to expect(format!(...))

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -64,10 +64,10 @@ pub fn tokenize(text: &str) -> Vec<Element> {
     split_blocks(text).iter().map(|block| {
         if TAG.is_match(*block) {
             let caps = TAG.captures(*block).unwrap();
-            Tag(granularize(caps.at(1).unwrap()), block.to_string())
+            Tag(granularize(caps.at(1).expect("Empty tag")), block.to_string())
         }else if EXPRESSION.is_match(*block) {
             let caps = EXPRESSION.captures(*block).unwrap();
-            Expression(granularize(caps.at(1).unwrap()), block.to_string())
+            Expression(granularize(caps.at(1).expect("Empty expression")), block.to_string())
         }else{
             Raw(block.to_string())
         }
@@ -110,7 +110,7 @@ fn granularize(block: &str) -> Vec<Token>{
             x if DOTDOT.is_match(x) => DotDot,
             x if SINGLE_STRING_LITERAL.is_match(x) => StringLiteral(x[1..x.len() -1].to_string()),
             x if DOUBLE_STRING_LITERAL.is_match(x) => StringLiteral(x[1..x.len() -1].to_string()),
-            x if NUMBER_LITERAL.is_match(x) => NumberLiteral(x.parse::<f32>().unwrap()),
+            x if NUMBER_LITERAL.is_match(x) => NumberLiteral(x.parse::<f32>().expect(&format!("Could not parse {:?} as float", x))),
             x if IDENTIFIER.is_match(x) => Identifier(x.to_string()),
             x => panic!("{} is not a valid identifier", x)
         })

--- a/src/output.rs
+++ b/src/output.rs
@@ -29,8 +29,8 @@ pub struct Output{
 impl Renderable for Output {
     fn render (&self, context: &mut Context) -> Option<String>{
         let mut entry = match self.entry  {
-            VarOrVal::Val(ref x) => x.render(context).unwrap(),
-            VarOrVal::Var(ref x) => x.render(context).unwrap()
+            VarOrVal::Val(ref x) => x.render(context).expect(&format!("Could not render {:?}", x)),
+            VarOrVal::Var(ref x) => x.render(context).expect(&format!("Could not render {:?}", x))
         };
         for filter in self.filters.iter(){
             let f = match context.filters.get(&filter.name) {


### PR DESCRIPTION
`unwrap()` produces panics with no explanation, and on some platforms there are no line numbers in the backtrace even in debug builds (rust-lang/rust#24346). `expect()` with an informative message is a much better user experience.

I didn't convert all instances -- I assume `Regex::new` isn't going to fail since it is used with constants, so I left those. And in a lot of cases the relevant condition is checked -- for instance `if x.contains_key(y) { do_something(x.get(y).unwrap()) }` -- however, these patterns should ideally be refactored to use `match`or other methods to avoid unwrapping.