### PR TITLE
Adds for_loop iteration over a range of numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ let template = liquid::parse("{{'hello' | shout}}", Default::default()).unwrap()
 let mut context = Context::new();
 
 // create our custom shout filter
-context.filters.insert("shout".to_owned(), Box::new(|input, _args| {
+context.add_filter("shout", Box::new(|input, _args| {
     if let &Value::Str(ref s) = input {
       Ok(Value::Str(s.to_uppercase()))
     } else {

--- a/src/context.rs
+++ b/src/context.rs
@@ -2,10 +2,15 @@ use std::collections::HashMap;
 use value::Value;
 use filters::Filter;
 
+type ValueMap = HashMap<String, Value>;
+
 #[derive(Default)]
 pub struct Context {
-    values: HashMap<String, Value>,
-    pub filters: HashMap<String, Box<Filter>>,
+    stack: Vec<ValueMap>,
+    globals: ValueMap,
+
+    // Public for backwards compatability
+    pub filters: HashMap<String, Box<Filter>>
 }
 
 impl Context {
@@ -14,8 +19,8 @@ impl Context {
     /// # Examples
     ///
     /// ```
-    /// # use liquid::{Value, Context};
-    /// let mut ctx = Context::new();
+    /// # use liquid::Context;
+    /// let ctx = Context::new();
     /// assert_eq!(ctx.get_val("test"), None);
     /// ```
     pub fn new() -> Context {
@@ -31,14 +36,85 @@ impl Context {
         Context::with_values_and_filters(HashMap::new(), filters)
     }
 
-    pub fn with_values_and_filters(values: HashMap<String, Value>, filters: HashMap<String, Box<Filter>>) -> Context {
+    pub fn with_values_and_filters(values: HashMap<String, Value>,
+                                   filters: HashMap<String, Box<Filter>>) -> Context {
         Context {
-            values: values,
-            filters: filters,
+            stack: vec!(HashMap::new()),
+            globals: values,
+            filters: filters
         }
     }
 
-    /// Gets a value from the rendering context.
+    pub fn add_filter(&mut self, name: &str, filter: Box<Filter>) {
+        self.filters.insert(name.to_owned(), filter);
+    }
+
+    pub fn get_filter<'b>(&'b self, name: &str) -> Option<&'b Box<Filter>> {
+        self.filters.get(name)
+    }
+
+    /// Creates a new variable scope chained to a parent scope.
+    pub fn push_scope(&mut self) {
+        self.stack.push(HashMap::new())
+    }
+
+    /// Removes the topmost stack frame from the local variable stack.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if popping the topmost frame results in an
+    /// empty stack. Given that a context is created with a top-level stack
+    /// frame already in place, empyting the stack should never happen in a
+    /// well-formed program.
+    pub fn pop_scope(&mut self) {
+        if let None = self.stack.pop() {
+            panic!("Pop leaves empty stack")
+        }
+    }
+
+    /// Sets up a new stack frame, executes the supplied function and then
+    /// tears the stack frame down before returning the function's result
+    /// to the caller.
+    ///
+    /// # Examples
+    /// ```
+    /// # use liquid::{Value, Context};
+    /// let mut ctx = Context::new();
+    /// ctx.set_val("test", Value::Num(42f32));
+    /// ctx.with_new_scope(|mut stack_frame| {
+    ///   // stack_frame inherits values from its parent context
+    ///   assert_eq!(stack_frame.get_val("test"), Some(&Value::Num(42f32)));
+    ///
+    ///   // but can (optionally) override them
+    ///   stack_frame.set_local_val("test", Value::Num(3.14f32));
+    ///   assert_eq!(stack_frame.get_val("test"), Some(&Value::Num(3.14f32)));
+    /// });
+    /// // the original value is unchanged once the scope exits
+    /// assert_eq!(ctx.get_val("test"), Some(&Value::Num(42f32)));
+    /// ```
+    pub fn with_new_scope<RvalT, FnT>(&mut self, f: FnT) -> RvalT
+        where FnT : FnOnce(&mut Context) -> RvalT {
+        self.push_scope();
+        let result = f(self);
+        self.pop_scope();
+        result
+    }
+
+    /// Internal part of get_val. Walks the scope stack to try and find the
+    /// reqested variable, and failing that checks the global pool.
+    fn get<'a>(&'a self, name: &str) -> Option<&'a Value> {
+        for frame in self.stack.iter().rev() {
+            if let rval @ Some(_) = frame.get(name) {
+                return rval
+            }
+        }
+        return self.globals.get(name)
+    }
+
+    /// Gets a value from the rendering context. The name value can be a
+    /// dot-separated path to a value. A value will only be returned if
+    /// each link in the chain (excluding the final name) refers to a
+    /// value of type Object.
     ///
     /// # Examples
     ///
@@ -48,21 +124,37 @@ impl Context {
     /// ctx.set_val("test", Value::Num(42f32));
     /// assert_eq!(ctx.get_val("test").unwrap(), &Value::Num(42f32));
     /// ```
-    pub fn get_val(&self, name: &str) -> Option<&Value> {
-        let mut it = name.split('.');
-        let mut ret = self.values.get(it.next().unwrap_or(""));
-        for id in it {
-            match ret {
-                Some(&Value::Object(ref x)) => ret = x.get(id),
+    pub fn get_val<'b>(&'b self, name: &str) -> Option<&'b Value> {
+        let mut path = name.split('.');
+        let key = path.next().unwrap_or("");
+        let mut rval = self.get(key);
+
+        // walk the chain of Object values, as specified by the path
+        // passed in name
+        for id in path {
+            match rval {
+                Some(&Value::Object(ref x)) => rval = x.get(id),
                 _ => return None,
             }
         }
-        ret
+
+        rval
+    }
+
+    /// Sets a value in the global context.
+    pub fn set_val(&mut self, name: &str, val: Value) -> Option<Value> {
+        self.globals.insert(name.to_owned(), val)
     }
 
     /// Sets a value to the rendering context.
     /// Note that it needs to be wrapped in a liquid::Value.
     ///
+    /// # Panics
+    ///
+    /// Panics if there is no frame on the local values stack. Context
+    /// instances are created with a top-level stack frame in place, so
+    /// this should never happen in a well-formed program.
+    ///
     /// # Examples
     ///
     /// ```
@@ -71,16 +163,50 @@ impl Context {
     /// ctx.set_val("test", Value::Num(42f32));
     /// assert_eq!(ctx.get_val("test").unwrap(), &Value::Num(42f32));
     /// ```
-    pub fn set_val(&mut self, name: &str, val: Value) -> Option<Value> {
-        self.values.insert(name.to_owned(), val)
+    pub fn set_local_val(&mut self, name: &str, val: Value) -> Option<Value> {
+        match self.stack.last_mut() {
+            Some(frame) => frame.insert(name.to_owned(), val),
+            None => panic!("Cannot insert into an empty stack")
+        }
     }
 }
 
-#[test]
-fn test_get_val() {
-    let mut ctx = Context::new();
-    let mut post = HashMap::new();
-    post.insert("number".to_owned(), Value::Num(42f32));
-    ctx.set_val("post", Value::Object(post));
-    assert_eq!(ctx.get_val("post.number").unwrap(), &Value::Num(42f32));
+#[cfg(test)]
+mod test {
+    use super::Context;
+    use value::Value;
+    use std::collections::HashMap;
+
+    #[test]
+    fn get_val() {
+        let mut ctx = Context::new();
+        let mut post = HashMap::new();
+        post.insert("number".to_owned(), Value::Num(42f32));
+        ctx.set_val("post", Value::Object(post));
+        assert_eq!(ctx.get_val("post.number").unwrap(), &Value::Num(42f32));
+    }
+
+    #[test]
+    fn scoped_variables() {
+        let mut ctx = Context::new();
+        ctx.set_val("test", Value::Num(42f32));
+        assert_eq!(ctx.get_val("test").unwrap(), &Value::Num(42f32));
+
+        ctx.with_new_scope(|mut new_scope|{
+            // assert that values are chained to the parent scope
+            assert_eq!(new_scope.get_val("test").unwrap(), &Value::Num(42f32));
+
+            // set a new local value, and assert that it overrides the previous value
+            new_scope.set_local_val("test", Value::Num(3.14f32));
+            assert_eq!(new_scope.get_val("test").unwrap(), &Value::Num(3.14f32));
+
+            // sat a new val that we will pick up outside the scope
+            new_scope.set_val("global", Value::str("some value"));
+        });
+
+        // assert that the value has reverted to the old one
+        assert_eq!(ctx.get_val("test").unwrap(), &Value::Num(42f32));
+        assert_eq!(ctx.get_val("global").unwrap(), &Value::str("some value"));
+    }
 }
+

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -13,6 +13,12 @@ pub enum FilterError {
     InvalidArgument(u16, String), // (position, "expected / given ")
 }
 
+impl FilterError {
+    pub fn invalid_type<T>(s: &str) -> Result<T, FilterError> {
+        Err(FilterError::InvalidType(s.to_owned()))
+    }
+}
+
 impl fmt::Display for FilterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,8 +80,7 @@ impl Default for ErrorMode {
 ///
 /// ## Minimal Example
 /// ```
-/// # use liquid::{Renderable, LiquidOptions, Context, Error, Tag};
-/// # use liquid::lexer::Token;
+/// # use liquid::{Renderable, LiquidOptions, Context, Error};
 /// struct HelloWorld;
 ///
 /// impl Renderable for HelloWorld {
@@ -91,7 +90,7 @@ impl Default for ErrorMode {
 /// }
 ///
 /// let mut options : LiquidOptions = Default::default();
-/// options.tags.insert("hello_world".to_owned(), Box::new(|tag_name, arguments, options| {
+/// options.tags.insert("hello_world".to_owned(), Box::new(|_tag_name, _arguments, _options| {
 ///      Box::new(HelloWorld)
 /// }));
 ///
@@ -130,7 +129,7 @@ pub struct LiquidOptions {
 /// ```
 /// use liquid::{Renderable, LiquidOptions, Context};
 ///
-/// let template = liquid::parse("Liquid!", Default::default()).unwrap();
+/// let template = liquid::parse("Liquid!", LiquidOptions::default()).unwrap();
 /// let mut data = Context::new();
 /// let output = template.render(&mut data);
 /// assert_eq!(output.unwrap(), Some("Liquid!".to_owned()));

--- a/src/output.rs
+++ b/src/output.rs
@@ -41,7 +41,7 @@ impl Renderable for Output {
             VarOrVal::Var(ref x) => context.get_val(&*x.name()),
         };
         for filter in &self.filters {
-            let f = match context.filters.get(&filter.name) {
+            let f = match context.get_filter(&filter.name) {
                 Some(x) => x,
                 None => {
                     return Err(Error::Render(format!("Filter {} not implemented", &filter.name)))

--- a/src/tags/for_block.rs
+++ b/src/tags/for_block.rs
@@ -89,7 +89,7 @@ impl Renderable for For {
 
             range_len => {
                 let mut ret = String::default();
-                context.with_new_scope(|mut scope| {
+                context.run_in_scope(|mut scope| {
                     let mut helper_vars : HashMap<String, Value> = HashMap::new();
                     helper_vars.insert("length".to_owned(), Value::Num(range_len as f32));
 
@@ -305,6 +305,21 @@ mod test{
         assert_eq!(
             output.unwrap(),
             Some("#1 test 42, #2 test 43, #3 test 44, #4 test 45, ".to_string()));
+    }
+
+    #[test]
+    fn degenerate_range_is_safe() {
+        // make sure that a degenerate range (i.e. where max < min)
+        // doesn't result in an infinte loop
+        let text = concat!(
+            "{% for x in (10 .. 0) %}",
+            "{{x}}",
+            "{% endfor %}"
+        );
+        let template = parse(text, Default::default()).unwrap();
+        let mut context = Context::new();
+        let output = template.render(&mut context);
+        assert_eq!(output.unwrap(), Some("".to_string()));
     }
 
     #[test]

--- a/src/tags/for_block.rs
+++ b/src/tags/for_block.rs
@@ -1,41 +1,143 @@
 use Renderable;
 use context::Context;
 use LiquidOptions;
-use lexer::{Token, Element};
-use lexer::Token::Identifier;
+use lexer::Element;
+use lexer::Token::{self, Identifier, OpenRound, CloseRound, NumberLiteral, DotDot, Colon};
 use parser::parse;
 use template::Template;
 use value::Value;
 use error::{Error, Result};
+use lexer::Element::Tag;
 
-#[cfg(test)]
-use std::default::Default;
-#[cfg(test)]
-use lexer::tokenize;
+use std::collections::HashMap;
+use std::slice::Iter;
+
+enum Range {
+    Array (String),
+    Counted (Token, Token)
+}
 
 struct For {
     var_name: String,
-    array_id: String,
-    inner: Template,
+    range: Range,
+    item_template: Template,
+    else_template: Option<Template>,
+    limit: Option<usize>,
+    offset: usize,
+    reversed: bool
 }
 
-fn get_array(context: &mut Context, array_id: &str) -> Result<Vec<Value>> {
+fn get_array(context: &Context, array_id: &str) -> Result<Vec<Value>> {
     match context.get_val(array_id) {
         Some(&Value::Array(ref x)) => Ok(x.clone()),
         x => Err(Error::Render(format!("Tried to iterate over {:?}, which is not supported.", x))),
     }
 }
 
+fn get_number(context: &Context, id: &str) -> Result<f32> {
+    match context.get_val(id) {
+        Some(&Value::Num(ref x)) => Ok(*x),
+        Some(ref x) => Err(Error::Render(format!("{:?} is not a number.", x))),
+        None => Err(Error::Render(format!("No such variable {}.", id)))
+    }
+}
+
+fn token_as_int(token: &Token, context: &Context) -> Result<isize> {
+    let value = match token {
+        &Identifier(ref id) => try!(get_number(context, id)),
+        &NumberLiteral(ref n) => *n,
+        _ => {
+            let msg = format!("Expecting identifier or number, found {:?}", token);
+            return Err(Error::Render(msg));
+        }
+    };
+    Ok(value as isize)
+}
+
 impl Renderable for For {
     fn render(&self, context: &mut Context) -> Result<Option<String>> {
-        let arr = try!(get_array(context, &self.array_id));
-        let mut ret = String::new();
-        for i in arr {
-            context.set_val(&self.var_name, i);
-            ret = ret + &try!(self.inner.render(context)).unwrap_or("".to_owned());
+        let mut range = match self.range {
+            Range::Array(ref array_id) => {
+                try!(get_array(context, array_id))
+            },
+
+            Range::Counted(ref start_token, ref stop_token) => {
+                let start = try!(token_as_int(start_token, context));
+                let stop = try!(token_as_int(stop_token, context));
+                (start..stop).map(|x| Value::Num(x as f32)).collect()
+            }
+        };
+
+        let end = match self.limit {
+            Some(n) => self.offset + n,
+            None => range.len()
+        };
+
+        let slice = &mut range[self.offset .. end];
+        if self.reversed {
+            slice.reverse();
+        };
+
+        match slice.len() {
+            0 => {
+                if let Some(ref t) = self.else_template {
+                    t.render(context)
+                } else {
+                    Ok(None)
+                }
+            },
+
+            range_len => {
+                let mut ret = String::default();
+                context.with_new_scope(|mut scope| {
+                    let mut helper_vars : HashMap<String, Value> = HashMap::new();
+                    helper_vars.insert("length".to_owned(), Value::Num(range_len as f32));
+
+                    for (i, v) in slice.iter().enumerate() {
+                        helper_vars.insert("index0".to_owned(), Value::Num(i as f32));
+                        helper_vars.insert("index".to_owned(), Value::Num((i + 1) as f32));
+                        helper_vars.insert("rindex0".to_owned(), Value::Num((range_len - i - 1) as f32));
+                        helper_vars.insert("rindex".to_owned(), Value::Num((range_len - i) as f32));
+                        helper_vars.insert("first".to_owned(), Value::Bool(i == 0));
+                        helper_vars.insert("last".to_owned(), Value::Bool(i == (range_len-1)));
+
+                        scope.set_local_val("for_loop", Value::Object(helper_vars.clone()));
+                        scope.set_local_val(&self.var_name, v.clone());
+                        let inner = try!(self.item_template.render(&mut scope)).unwrap_or("".to_owned());
+                        ret = ret + &inner;
+                    }
+
+                    Ok(Some(ret))
+                })
+            }
         }
-        Ok(Some(ret))
     }
+}
+
+fn parser_err<T>(expected: &str, actual: Option<&Token>) -> Result<T> {
+  Err(Error::Parser(format!("Expected {}, found {:?}", expected, actual)))
+}
+
+/// Extracts an attribute with an integer value from the token stream 
+fn int_attr<'a>(args: &mut Iter<'a, Token>) -> Result<Option<usize>> {
+    match args.next() {
+        Some(&Colon) => (),
+        x => return parser_err(":", x)
+    };
+
+    match args.next() {
+        Some(&NumberLiteral(ref n)) => Ok(Some(*n as usize)),
+        x => return parser_err("number", x)
+    }
+}
+
+fn range_end_point<'a>(args: &mut Iter<'a, Token>) -> Result<Token> {
+    let t = match args.next() {
+        Some(id @ &NumberLiteral(_)) => id.clone(),
+        Some(id @ &Identifier(_)) => id.clone(),
+        x => return parser_err("number | Identifier", x)
+    };
+    Ok(t)
 }
 
 pub fn for_block(_tag_name: &str,
@@ -44,48 +146,301 @@ pub fn for_block(_tag_name: &str,
                  options: &LiquidOptions)
                  -> Result<Box<Renderable>> {
     let mut args = arguments.iter();
-
-    let inner = try!(parse(&tokens, options));
-
     let var_name = match args.next() {
         Some(&Identifier(ref x)) => x.clone(),
-        x => return Err(Error::Parser(format!("Expected an identifier, found {:?}", x))),
+        x => return parser_err("Identifier", x)
     };
 
     match args.next() {
         Some(&Identifier(ref x)) if x == "in" => (),
-        x => return Err(Error::Parser(format!("Expected 'in', found {:?}", x))),
+        x => return parser_err("\'in\'", x),
+    };
+
+    let range = match args.next() {
+        Some(&Identifier(ref x)) => Range::Array(x.clone()),
+        Some(&OpenRound) => {
+            // this might be a range, let's try and see
+            let start = try!(range_end_point(&mut args));
+
+            match args.next() {
+                Some(&DotDot) => (),
+                x => return parser_err("..", x)
+            };
+
+            let stop = try!(range_end_point(&mut args));
+
+            match args.next() {
+                Some(&CloseRound) => (),
+                x => return parser_err(")", x)
+            };
+
+            Range::Counted (start, stop)
+        },
+        x => return parser_err("Identifier or (", x),
+    };
+
+    // now we get to check for parameters...
+    let mut limit : Option<usize> = None;
+    let mut offset : usize = 0;
+    let mut reversed = false;
+
+    while let Some(token) = args.next() {
+        match token {
+            &Identifier(ref attr) => {
+                match attr.as_ref() {
+                    "limit" => limit = try!(int_attr(&mut args)),
+                    "offset" => offset = try!(int_attr(&mut args)).unwrap_or(0),
+                    "reversed" => reversed = true,
+                    _ => return parser_err("limit | offset | reversed", Some(token))
+                }
+            },
+            _ => {
+                return parser_err("Identifier", Some(token))
+            }
+        }
     }
 
-    // TODO implement ranges
-    let array_id = match args.next() {
-        Some(&Identifier(ref x)) => x.clone(),
-        x => return Err(Error::Parser(format!("Expected an identifier, found {:?}", x))),
+    let else_tag = vec![Identifier("else".to_owned())];
+    let is_not_else = |x : &&Element| {
+        match *x {
+            &Tag(ref tokens, _) => *tokens != else_tag,
+            _ => true
+        }
+    };
+
+    // finally, collect the templates for the item, and the optional "else"
+    // block
+    let item_tokens : Vec<Element> = tokens.iter()
+                                           .take_while(&is_not_else)
+                                           .cloned()
+                                           .collect();
+    let item_template = Template::new(try!(parse(&item_tokens, options)));
+
+    let else_tokens : Vec<Element> = tokens.iter()
+                                           .skip_while(&is_not_else)
+                                           .skip(1)
+                                           .cloned()
+                                           .collect();
+    let else_template = match &else_tokens {
+        ts if ts.is_empty() => None,
+        ts => Some(Template::new(try!(parse(ts, options))))
     };
 
     Ok(Box::new(For {
         var_name: var_name,
-        array_id: array_id,
-        inner: Template::new(inner),
+        range: range,
+        item_template: item_template,
+        else_template: else_template,
+        limit: limit,
+        offset: offset,
+        reversed: reversed
     }))
 }
 
-#[test]
-fn test_for() {
-    let options: LiquidOptions = Default::default();
-    let for_tag = for_block("for",
-                            &[Identifier("name".to_owned()),
-                              Identifier("in".to_owned()),
-                              Identifier("array".to_owned())],
-                            tokenize("test {{name}} ").unwrap(),
-                            &options);
+#[cfg(test)]
+mod test{
+    use super::for_block;
+    use parse;
+    use LiquidOptions;
+    use Renderable;
+    use lexer::Token::{Identifier, OpenRound, CloseRound, NumberLiteral, DotDot};
+    use lexer::tokenize;
+    use value::Value;
+    use std::default::Default;
+    use context::Context;
 
-    let mut data: Context = Default::default();
-    data.set_val("array",
-                 Value::Array(vec![Value::Num(22f32),
-                                   Value::Num(23f32),
-                                   Value::Num(24f32),
-                                   Value::Str("wat".to_owned())]));
-    assert_eq!(for_tag.unwrap().render(&mut data).unwrap(),
-               Some("test 22 test 23 test 24 test wat ".to_owned()));
+    #[test]
+    fn loop_over_array() {
+        let options: LiquidOptions = Default::default();
+        let for_tag = for_block("for",
+                                &[Identifier("name".to_owned()),
+                                  Identifier("in".to_owned()),
+                                  Identifier("array".to_owned())],
+                                tokenize("test {{name}} ").unwrap(),
+                                &options);
+
+        let mut data: Context = Default::default();
+        data.set_val("array",
+                     Value::Array(vec![Value::Num(22f32),
+                                       Value::Num(23f32),
+                                       Value::Num(24f32),
+                                       Value::Str("wat".to_owned())]));
+        assert_eq!(for_tag.unwrap().render(&mut data).unwrap(),
+                   Some("test 22 test 23 test 24 test wat ".to_owned()));
+    }
+
+
+    #[test]
+    fn loop_over_range_literals() {
+        let options: LiquidOptions = Default::default();
+        let for_tag = for_block("for",
+                                &[Identifier("name".to_owned()),
+                                  Identifier("in".to_owned()),
+                                  OpenRound,
+                                  NumberLiteral(42f32),
+                                  DotDot,
+                                  NumberLiteral(46f32),
+                                  CloseRound],
+                                tokenize("#{{for_loop.index}} test {{name}} | ").unwrap(),
+                                &options);
+
+        let mut data: Context = Default::default();
+        assert_eq!(for_tag.unwrap().render(&mut data).unwrap(),
+                   Some("#1 test 42 | #2 test 43 | #3 test 44 | #4 test 45 | ".to_owned()));
+    }
+
+    #[test]
+    fn loop_over_range_vars() {
+        let text = concat!(
+            "{% for x in (alpha .. omega) %}",
+            "#{{for_loop.index}} test {{x}}, ",
+            "{% endfor %}"
+        );
+
+        let template = parse(text, Default::default()).unwrap();
+        let mut context = Context::new();
+        context.set_val("alpha", Value::Num(42f32));
+        context.set_val("omega", Value::Num(46f32));
+        let output = template.render(&mut context);
+        assert_eq!(
+            output.unwrap(),
+            Some("#1 test 42, #2 test 43, #3 test 44, #4 test 45, ".to_string()));
+    }
+
+    #[test]
+    fn limited_loop() {
+        let text = concat!(
+            "{% for i in (1..100) limit:2 %}",
+            "{{ i }} ",
+            "{% endfor %}");
+        let template = parse(text, Default::default()).unwrap();
+        let mut context = Context::new();
+        let output = template.render(&mut context);
+        assert_eq!(output.unwrap(), Some("1 2 ".to_string()));
+    }
+
+    #[test]
+    fn offset_loop() {
+        let text = concat!(
+            "{% for i in (1..10) offset:4 %}",
+            "{{ i }} ",
+            "{% endfor %}");
+        let template = parse(text, Default::default()).unwrap();
+        let mut context = Context::new();
+        let output = template.render(&mut context);
+        assert_eq!(output.unwrap(), Some("5 6 7 8 9 ".to_string()));
+    }
+
+    #[test]
+    fn offset_and_limited_loop() {
+        let text = concat!(
+            "{% for i in (1..10) offset:4 limit:2 %}",
+            "{{ i }} ",
+            "{% endfor %}");
+        let template = parse(text, Default::default()).unwrap();
+        let mut context = Context::new();
+        let output = template.render(&mut context);
+        assert_eq!(output.unwrap(), Some("5 6 ".to_string()));
+    }
+
+    #[test]
+    fn reversed_loop() {
+        let text = concat!(
+            "{% for i in (1..10) reversed %}",
+            "{{ i }} ",
+            "{% endfor %}");
+        let template = parse(text, Default::default()).unwrap();
+        let mut context = Context::new();
+        let output = template.render(&mut context);
+        assert_eq!(output.unwrap(), Some("9 8 7 6 5 4 3 2 1 ".to_string()));
+    }
+
+    #[test]
+    fn sliced_and_reversed_loop() {
+        let text = concat!(
+            "{% for i in (1..10) reversed offset:1 limit:5%}",
+            "{{ i }} ",
+            "{% endfor %}");
+        let template = parse(text, Default::default()).unwrap();
+        let mut context = Context::new();
+        let output = template.render(&mut context);
+        assert_eq!(output.unwrap(), Some("6 5 4 3 2 ".to_string()));
+    }
+
+    #[test]
+    fn empty_loop_invokes_else_template() {
+        let text = concat!(
+            "{% for i in (1..10) limit:0 %}",
+            "{{ i }} ",
+            "{% else %}",
+            "There are no items!",
+            "{% endfor %}");
+
+        let template = parse(text, Default::default()).unwrap();
+        let mut context = Context::new();
+        let output = template.render(&mut context);
+        assert_eq!(output.unwrap(), Some("There are no items!".to_string()));
+    }
+
+    #[test]
+    fn loop_variables() {
+        let options: LiquidOptions = Default::default();
+        let for_tag = for_block("for",
+                                &[Identifier("v".to_owned()),
+                                  Identifier("in".to_owned()),
+                                  OpenRound,
+                                  NumberLiteral(100f32),
+                                  DotDot,
+                                  NumberLiteral(103f32),
+                                  CloseRound],
+                                tokenize(concat!(
+                                         "length: {{for_loop.length}}, ",
+                                         "index: {{for_loop.index}}, ",
+                                         "index0: {{for_loop.index0}}, ",
+                                         "rindex: {{for_loop.rindex}}, ",
+                                         "rindex0: {{for_loop.rindex0}}, ",
+                                         "value: {{v}}, ",
+                                         "first: {{for_loop.first}}, ",
+                                         "last: {{for_loop.last}}\n")).unwrap(),
+                                &options);
+
+        let mut data: Context = Default::default();
+        assert_eq!(for_tag.unwrap().render(&mut data).unwrap(),
+                   Some(concat!(
+                    "length: 3, index: 1, index0: 0, rindex: 3, rindex0: 2, value: 100, first: true, last: false\n",
+                    "length: 3, index: 2, index0: 1, rindex: 2, rindex0: 1, value: 101, first: false, last: false\n",
+                    "length: 3, index: 3, index0: 2, rindex: 1, rindex0: 0, value: 102, first: false, last: true\n",
+                    ).to_owned()));
+    }
+
+
+    #[test]
+    fn use_filters() {
+        use filters::FilterError;
+
+        let options: LiquidOptions = Default::default();
+        let for_tag = for_block("for",
+                                &[Identifier("name".to_owned()),
+                                  Identifier("in".to_owned()),
+                                  Identifier("array".to_owned())],
+                                tokenize("test {{name | shout}} ").unwrap(),
+                                &options);
+
+        let mut data: Context = Default::default();
+        data.add_filter("shout", Box::new(|input, _args| {
+            if let &Value::Str(ref s) = input {
+                Ok(Value::Str(s.to_uppercase()))
+            } else {
+                FilterError::invalid_type("Expected a string")
+            }
+        }));
+
+        data.set_val("array",
+                     Value::Array(vec![Value::str("alpha"),
+                                       Value::str("beta"),
+                                       Value::str("gamma")
+                                       ]));
+        assert_eq!(for_tag.unwrap().render(&mut data).unwrap(),
+                   Some("test ALPHA test BETA test GAMMA ".to_owned()));
+    }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -9,11 +9,11 @@ pub struct Template {
 
 impl Renderable for Template {
     fn render(&self, context: &mut Context) -> Result<Option<String>> {
-        context.filters.insert("size".to_owned(), Box::new(size));
-        context.filters.insert("upcase".to_owned(), Box::new(upcase));
-        context.filters.insert("minus".to_owned(), Box::new(minus));
-        context.filters.insert("plus".to_owned(), Box::new(plus));
-        context.filters.insert("replace".to_owned(), Box::new(replace));
+        context.add_filter("size",    Box::new(size));
+        context.add_filter("upcase",  Box::new(upcase));
+        context.add_filter("minus",   Box::new(minus));
+        context.add_filter("plus",    Box::new(plus));
+        context.add_filter("replace", Box::new(replace));
 
         let mut buf = String::new();
         for el in &self.elements {

--- a/src/value.rs
+++ b/src/value.rs
@@ -11,7 +11,26 @@ pub enum Value {
     Str(String),
     Object(HashMap<String, Value>),
     Array(Vec<Value>),
+    Bool(bool)
 }
+
+impl Value {
+    pub fn str(val: &str) -> Value {
+        Value::Str(val.to_owned())
+    }
+
+    pub fn is_truthy(&self) -> bool {
+        match *self {
+            Value::Bool(x) => x,
+            _ => true
+        }
+    }
+
+    pub fn is_falsey(&self) -> bool {
+        !self.is_truthy()
+    }
+}
+
 
 // TODO implement for object and array
 // TODO clean this up
@@ -20,6 +39,7 @@ impl PartialOrd<Value> for Value {
         match (self, other) {
             (&Value::Num(x), &Value::Num(y)) => x.partial_cmp(&y),
             (&Value::Str(ref x), &Value::Str(ref y)) => x.partial_cmp(y),
+            (&Value::Bool(x), &Value::Bool(y)) => x.partial_cmp(&y),
             _ => None,
         }
     }
@@ -27,6 +47,7 @@ impl PartialOrd<Value> for Value {
         match (self, other) {
             (&Value::Num(x), &Value::Num(y)) => x.lt(&y),
             (&Value::Str(ref x), &Value::Str(ref y)) => x.lt(y),
+            (&Value::Bool(x), &Value::Bool(y)) => x.lt(&y),
             _ => false,
         }
     }
@@ -34,6 +55,7 @@ impl PartialOrd<Value> for Value {
         match (self, other) {
             (&Value::Num(x), &Value::Num(y)) => x.le(&y),
             (&Value::Str(ref x), &Value::Str(ref y)) => x.le(y),
+            (&Value::Bool(x), &Value::Bool(y)) => x.le(&y),
             _ => false,
         }
     }
@@ -41,6 +63,7 @@ impl PartialOrd<Value> for Value {
         match (self, other) {
             (&Value::Num(x), &Value::Num(y)) => x.gt(&y),
             (&Value::Str(ref x), &Value::Str(ref y)) => x.gt(y),
+            (&Value::Bool(x), &Value::Bool(y)) => x.gt(&y),
             _ => false,
         }
     }
@@ -48,6 +71,7 @@ impl PartialOrd<Value> for Value {
         match (self, other) {
             (&Value::Num(x), &Value::Num(y)) => x.ge(&y),
             (&Value::Str(ref x), &Value::Str(ref y)) => x.ge(y),
+            (&Value::Bool(x), &Value::Bool(y)) => x.ge(&y),
             _ => false,
         }
     }
@@ -56,6 +80,7 @@ impl PartialOrd<Value> for Value {
 impl ToString for Value {
     fn to_string(&self) -> String {
         match *self {
+            Value::Bool(ref x) => x.to_string(),
             Value::Num(ref x) => x.to_string(),
             Value::Str(ref x) => x.to_owned(),
             Value::Array(ref x) => {
@@ -99,6 +124,27 @@ mod test {
     fn test_array_to_string() {
         let val = Value::Array(vec![Value::Num(3f32), Value::Str("test".to_owned()), Value::Num(5.3)]);
         assert_eq!(&val.to_string(), "3, test, 5.3");
+    }
+
+    #[test]
+    fn booleans_have_ruby_truthiness() {
+        assert_eq!(true, Value::Bool(true).is_truthy());
+        assert_eq!(true, Value::Bool(false).is_falsey());
+
+        assert_eq!(false, Value::Bool(true).is_falsey());
+        assert_eq!(false, Value::Bool(false).is_truthy());
+    }
+
+    #[test]
+    fn strings_have_ruby_truthiness() {
+        assert_eq!(true, Value::str("All strings are truthy").is_truthy());
+        assert_eq!(true, Value::str("").is_truthy());
+    }
+
+    #[test]
+    fn numbers_have_ruby_truthiness() {
+        assert_eq!(true, Value::Num(42f32).is_truthy());
+        assert_eq!(true, Value::Num(0f32).is_truthy());
     }
 
     // TODO make a test for object, remember values are in arbitrary orders in HashMaps

--- a/tests/custom_blocks.rs
+++ b/tests/custom_blocks.rs
@@ -17,7 +17,7 @@ fn run() {
         numbers: Vec<f32>
     }
     impl Renderable for Multiply{
-        fn render(&self, _context: &mut Context) -> Result<Option<String>, Error>{
+        fn render(&self, _context: &mut Context) -> Result<Option<String>, Error> {
             let x = self.numbers.iter().fold(1f32, |a, &b| a * b);
             Ok(Some(x.to_string()))
         }
@@ -49,4 +49,3 @@ fn run() {
     let output = template.render(&mut data);
     assert_eq!(output.unwrap(), Some("wat\nworld\n15{{multiply 5 3}} test".to_string()));
 }
-


### PR DESCRIPTION
The iterated-over range is treated as a created-on-the-fly array of
Value instances, and iterated over the same way as an array stored in
a value. This seemed like the least-awful way of doing using the same
code to render both cases.

Also:
 * Adds the for_loop helper variables as described in "Liquid for
   Designers"
 * Adds the notion of a context scope that can be pushed and popped like
   a stack frame, which is used to automatically clean up the loop
   variables when the loop exits. Implemented as chain of context
   objects, with each deferring to a parent if a variable or filter
   lookup fails.
 * Adds a boolean Value type in an attempt to better mirror Ruby's notion
   truthiness