### PR TITLE
Implementing filters for capitalize, downcase, first, last, prepend, append and pluralize

### DIFF
--- a/src/filters.rs
+++ b/src/filters.rs
@@ -85,6 +85,19 @@ pub fn capitalize(input: &Value, _args: &[Value]) -> FilterResult {
     }
 }
 
+
+pub fn pluralize(input: &Value, args: &[Value]) -> FilterResult {
+
+    if args.len() != 2 {
+        return Err(InvalidArgumentCount(format!("expected 2, {} given", args.len())));
+    }
+    match *input {
+        Num(1f32) => Ok(args[0].clone()),
+        Num(_) => Ok(args[1].clone()),
+        _ => Err(InvalidType("Number expected".to_owned())),
+    }
+}
+
 pub fn minus(input: &Value, args: &[Value]) -> FilterResult {
 
     let num = match *input {
@@ -273,6 +286,15 @@ mod tests {
         assert_eq!(unit!(capitalize, tos!("hello world​")),
                    tos!("Hello World​"));
 
+    }
+
+    #[test]
+    fn unit_pluralize() {
+        assert_eq!(unit!(pluralize, Num(1f32), &[tos!("one"), tos!("many")]),
+                   tos!("one"));
+
+       assert_eq!(unit!(pluralize, Num(2f32), &[tos!("one"), tos!("many")]),
+                  tos!("many"));
     }
 
     #[test]

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -61,6 +61,14 @@ pub fn upcase(input: &Value, _args: &[Value]) -> FilterResult {
 }
 
 
+pub fn downcase(input: &Value, _args: &[Value]) -> FilterResult {
+    match *input {
+        Str(ref s) => Ok(Str(s.to_lowercase())),
+        _ => Err(InvalidType("String expected".to_owned())),
+    }
+}
+
+
 pub fn capitalize(input: &Value, _args: &[Value]) -> FilterResult {
     match *input {
         Str(ref s) => Ok(Str(s.char_indices().fold(String::new(), |word, (_, chr)| {
@@ -197,6 +205,13 @@ mod tests {
         assert_eq!(unit!(upcase, tos!("abc")), tos!("ABC"));
         assert_eq!(unit!(upcase, tos!("Hello World 21")),
                    tos!("HELLO WORLD 21"));
+    }
+
+    #[test]
+    fn unit_downcase() {
+        assert_eq!(unit!(downcase, tos!("Abc")), tos!("abc"));
+        assert_eq!(unit!(downcase, tos!("Hello World 21")),
+                   tos!("hello world 21"));
     }
 
     #[test]

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -183,6 +183,17 @@ pub fn prepend(input: &Value, args: &[Value]) -> FilterResult {
     }
 }
 
+
+pub fn append(input: &Value, args: &[Value]) -> FilterResult {
+    match *input {
+        Str(ref x) => match args.first() {
+                        Some(&Str(ref a)) => Ok(Str(format!("{}{}", x, a))),
+                        _ => return Err(InvalidArgument(0, "Str expected".to_owned())),
+                    },
+        _ => Err(InvalidType("String expected".to_owned())),
+    }
+}
+
 pub fn first(input: &Value, _args: &[Value]) -> FilterResult {
     match *input {
         Str(ref x) => match x.chars().next() {
@@ -323,11 +334,16 @@ mod tests {
                    tos!("foofoo"));
     }
 
-
     #[test]
     fn unit_prepend() {
         assert_eq!(unit!(prepend, tos!("barbar"), &[tos!("foo")]),
                    tos!("foobarbar"));
+    }
+
+    #[test]
+    fn unit_append() {
+        assert_eq!(unit!(append, tos!("sam"), &[tos!("son")]),
+                   tos!("samson"));
     }
 
     #[test]

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -73,10 +73,12 @@ pub fn capitalize(input: &Value, _args: &[Value]) -> FilterResult {
     match *input {
         Str(ref s) => Ok(Str(s.char_indices().fold(String::new(), |word, (_, chr)| {
             let next_char = match word.chars().last() {
-                Some(last) => match last.is_whitespace() {
-                    true => chr.to_uppercase().next().unwrap(),
-                    false => chr,
-                },
+                Some(last) =>
+                    if last.is_whitespace() {
+                        chr.to_uppercase().next().unwrap()
+                    } else {
+                        chr
+                    },
                 _ => chr.to_uppercase().next().unwrap(),
             }.to_string();
             word + &next_char

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -198,6 +198,7 @@ mod tests {
     fn unit_size() {
         assert_eq!(unit!(size, tos!("abc")), Num(3f32));
         assert_eq!(unit!(size, tos!("this has 22 characters")), Num(22f32));
+        assert_eq!(unit!(size, Array(vec![Num(0f32), Num(1f32), Num(2f32), Num(3f32), Num(4f32)])), Num(5f32));
     }
 
     #[test]

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -173,6 +173,16 @@ pub fn replace(input: &Value, args: &[Value]) -> FilterResult {
     }
 }
 
+pub fn prepend(input: &Value, args: &[Value]) -> FilterResult {
+    match *input {
+        Str(ref x) => match args.first() {
+                        Some(&Str(ref a)) => Ok(Str(format!("{}{}", a, x))),
+                        _ => return Err(InvalidArgument(0, "Str expected".to_owned())),
+                    },
+        _ => Err(InvalidType("String expected".to_owned())),
+    }
+}
+
 pub fn first(input: &Value, _args: &[Value]) -> FilterResult {
     match *input {
         Str(ref x) => match x.chars().next() {
@@ -311,6 +321,13 @@ mod tests {
     fn unit_replace() {
         assert_eq!(unit!(replace, tos!("barbar"), &[tos!("bar"), tos!("foo")]),
                    tos!("foofoo"));
+    }
+
+
+    #[test]
+    fn unit_prepend() {
+        assert_eq!(unit!(prepend, tos!("barbar"), &[tos!("foo")]),
+                   tos!("foobarbar"));
     }
 
     #[test]

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -184,6 +184,18 @@ pub fn first(input: &Value, _args: &[Value]) -> FilterResult {
     }
 }
 
+
+pub fn last(input: &Value, _args: &[Value]) -> FilterResult {
+    match *input {
+        Str(ref x) => match x.chars().last() {
+                Some(c) => Ok(Str(c.to_string())),
+                _ => Ok(Str("".to_owned()))
+            },
+        Array(ref x) => Ok(x.last().unwrap_or(&Str("".to_owned())).to_owned()),
+        _ => Err(InvalidType("String or Array expected".to_owned())),
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -308,4 +320,10 @@ mod tests {
         assert_eq!(unit!(first, Array(vec![])), tos!(""));
     }
 
+    #[test]
+    fn unit_last() {
+        assert_eq!(unit!(last, Array(vec![Num(0f32), Num(1f32), Num(2f32), Num(3f32), Num(4f32)])), Num(4f32));
+        assert_eq!(unit!(last, Array(vec![tos!("test"), tos!("last")])), tos!("last"));
+        assert_eq!(unit!(last, Array(vec![])), tos!(""));
+    }
 }

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -60,6 +60,23 @@ pub fn upcase(input: &Value, _args: &[Value]) -> FilterResult {
     }
 }
 
+
+pub fn capitalize(input: &Value, _args: &[Value]) -> FilterResult {
+    match *input {
+        Str(ref s) => Ok(Str(s.char_indices().fold(String::new(), |word, (_, chr)| {
+            let next_char = match word.chars().last() {
+                Some(last) => match last.is_whitespace() {
+                    true => chr.to_uppercase().next().unwrap(),
+                    false => chr,
+                },
+                _ => chr.to_uppercase().next().unwrap(),
+            }.to_string();
+            word + &next_char
+        }))),
+        _ => Err(InvalidType("String expected".to_owned())),
+    }
+}
+
 pub fn minus(input: &Value, args: &[Value]) -> FilterResult {
 
     let num = match *input {
@@ -180,6 +197,22 @@ mod tests {
         assert_eq!(unit!(upcase, tos!("abc")), tos!("ABC"));
         assert_eq!(unit!(upcase, tos!("Hello World 21")),
                    tos!("HELLO WORLD 21"));
+    }
+
+    #[test]
+    fn unit_capitalize() {
+        assert_eq!(unit!(capitalize, tos!("abc")), tos!("Abc"));
+        assert_eq!(unit!(capitalize, tos!("hello world 21")),
+                   tos!("Hello World 21"));
+
+        // sure that Umlauts work
+        assert_eq!(unit!(capitalize, tos!("über ètat, y̆es?")),
+                    tos!("Über Ètat, Y\u{306}es?"));
+
+        // Weird UTF-8 White space is kept – this is a no-break whitespace!
+        assert_eq!(unit!(capitalize, tos!("hello world​")),
+                   tos!("Hello World​"));
+
     }
 
     #[test]

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -173,6 +173,17 @@ pub fn replace(input: &Value, args: &[Value]) -> FilterResult {
     }
 }
 
+pub fn first(input: &Value, _args: &[Value]) -> FilterResult {
+    match *input {
+        Str(ref x) => match x.chars().next() {
+                Some(c) => Ok(Str(c.to_string())),
+                _ => Ok(Str("".to_owned()))
+            },
+        Array(ref x) => Ok(x.first().unwrap_or(&Str("".to_owned())).to_owned()),
+        _ => Err(InvalidType("String or Array expected".to_owned())),
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -288,6 +299,13 @@ mod tests {
     fn unit_replace() {
         assert_eq!(unit!(replace, tos!("barbar"), &[tos!("bar"), tos!("foo")]),
                    tos!("foofoo"));
+    }
+
+    #[test]
+    fn unit_first() {
+        assert_eq!(unit!(first, Array(vec![Num(0f32), Num(1f32), Num(2f32), Num(3f32), Num(4f32)])), Num(0f32));
+        assert_eq!(unit!(first, Array(vec![tos!("test"), tos!("two")])), tos!("test"));
+        assert_eq!(unit!(first, Array(vec![])), tos!(""));
     }
 
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,6 +1,6 @@
 use Renderable;
 use context::Context;
-use filters::{size, upcase, downcase, capitalize, minus, plus, times, devided_by, ceil, floor, round, first, replace};
+use filters::{size, upcase, downcase, capitalize, minus, plus, times, devided_by, ceil, floor, round, first, last, replace};
 use error::Result;
 
 pub struct Template {
@@ -21,6 +21,7 @@ impl Renderable for Template {
         context.add_filter("floor", Box::new(floor));
         context.add_filter("round", Box::new(round));
         context.add_filter("first".to_owned(), Box::new(first));
+        context.add_filter("last".to_owned(), Box::new(last));
         context.add_filter("replace", Box::new(replace));
 
         let mut buf = String::new();

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,6 +1,6 @@
 use Renderable;
 use context::Context;
-use filters::{size, upcase, minus, plus, replace, times, divided_by, ceil, floor, round};
+use filters::{size, upcase, capitalize, minus, plus, replace};
 use error::Result;
 
 pub struct Template {
@@ -11,6 +11,7 @@ impl Renderable for Template {
     fn render(&self, context: &mut Context) -> Result<Option<String>> {
         context.add_filter("size", Box::new(size));
         context.add_filter("upcase", Box::new(upcase));
+        context.filters.insert("capitalize".to_owned(), Box::new(capitalize));
         context.add_filter("minus", Box::new(minus));
         context.add_filter("plus", Box::new(plus));
         context.add_filter("times", Box::new(times));

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,6 +1,6 @@
 use Renderable;
 use context::Context;
-use filters::{size, upcase, downcase, capitalize, minus, plus, times, devided_by, ceil, floor, round, prepend, first, last, replace};
+use filters::{size, upcase, downcase, capitalize, minus, plus, times, devided_by, ceil, floor, round, prepend, append, first, last, replace};
 use error::Result;
 
 pub struct Template {
@@ -23,6 +23,7 @@ impl Renderable for Template {
         context.add_filter("first".to_owned(), Box::new(first));
         context.add_filter("last".to_owned(), Box::new(last));
         context.add_filter("prepend".to_owned(), Box::new(prepend));
+        context.add_filter("append".to_owned(), Box::new(append));
         context.add_filter("replace", Box::new(replace));
 
         let mut buf = String::new();

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,6 +1,6 @@
 use Renderable;
 use context::Context;
-use filters::{size, upcase, downcase, capitalize, minus, plus, times, devided_by, ceil, floor, round, first, last, replace};
+use filters::{size, upcase, downcase, capitalize, minus, plus, times, devided_by, ceil, floor, round, prepend, first, last, replace};
 use error::Result;
 
 pub struct Template {
@@ -22,6 +22,7 @@ impl Renderable for Template {
         context.add_filter("round", Box::new(round));
         context.add_filter("first".to_owned(), Box::new(first));
         context.add_filter("last".to_owned(), Box::new(last));
+        context.add_filter("prepend".to_owned(), Box::new(prepend));
         context.add_filter("replace", Box::new(replace));
 
         let mut buf = String::new();

--- a/src/template.rs
+++ b/src/template.rs
@@ -12,8 +12,8 @@ impl Renderable for Template {
 
         context.add_filter("size", Box::new(size));
         context.add_filter("upcase", Box::new(upcase));
-        context.add_filter("downcase".to_owned(), Box::new(downcase));
-        context.add_filter("capitalize".to_owned(), Box::new(capitalize));
+        context.add_filter("downcase", Box::new(downcase));
+        context.add_filter("capitalize", Box::new(capitalize));
         context.add_filter("minus", Box::new(minus));
         context.add_filter("plus", Box::new(plus));
         context.add_filter("times", Box::new(times));
@@ -21,12 +21,12 @@ impl Renderable for Template {
         context.add_filter("ceil", Box::new(ceil));
         context.add_filter("floor", Box::new(floor));
         context.add_filter("round", Box::new(round));
-        context.add_filter("first".to_owned(), Box::new(first));
-        context.add_filter("last".to_owned(), Box::new(last));
-        context.add_filter("prepend".to_owned(), Box::new(prepend));
-        context.add_filter("append".to_owned(), Box::new(append));
+        context.add_filter("first", Box::new(first));
+        context.add_filter("last", Box::new(last));
+        context.add_filter("prepend", Box::new(prepend));
+        context.add_filter("append", Box::new(append));
         context.add_filter("replace", Box::new(replace));
-        context.add_filter("pluralize".to_owned(), Box::new(pluralize));
+        context.add_filter("pluralize", Box::new(pluralize));
 
         let mut buf = String::new();
         for el in &self.elements {

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,6 +1,6 @@
 use Renderable;
 use context::Context;
-use filters::{size, upcase, downcase, capitalize, minus, plus, times, devided_by, ceil, floor, round, replace};
+use filters::{size, upcase, downcase, capitalize, minus, plus, times, devided_by, ceil, floor, round, first, replace};
 use error::Result;
 
 pub struct Template {
@@ -9,7 +9,6 @@ pub struct Template {
 
 impl Renderable for Template {
     fn render(&self, context: &mut Context) -> Result<Option<String>> {
-<<<<<<< e6a2f7ffa4b50a5bf55dbeb8dff30eb8588d703c
         context.add_filter("size", Box::new(size));
         context.add_filter("upcase", Box::new(upcase));
         context.add_filter("downcase".to_owned(), Box::new(downcase));
@@ -21,6 +20,7 @@ impl Renderable for Template {
         context.add_filter("ceil", Box::new(ceil));
         context.add_filter("floor", Box::new(floor));
         context.add_filter("round", Box::new(round));
+        context.add_filter("first".to_owned(), Box::new(first));
         context.add_filter("replace", Box::new(replace));
 
         let mut buf = String::new();

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,6 +1,6 @@
 use Renderable;
 use context::Context;
-use filters::{size, upcase, downcase, capitalize, minus, plus, times, devided_by, ceil, floor, round, prepend, append, first, last, pluralize, replace};
+use filters::{size, upcase, downcase, capitalize, minus, plus, times, divided_by, ceil, floor, round, prepend, append, first, last, pluralize, replace};
 use error::Result;
 
 pub struct Template {

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,6 +1,6 @@
 use Renderable;
 use context::Context;
-use filters::{size, upcase, capitalize, minus, plus, replace};
+use filters::{size, upcase, downcase, capitalize, minus, plus, times, devided_by, ceil, floor, round, replace};
 use error::Result;
 
 pub struct Template {
@@ -9,9 +9,11 @@ pub struct Template {
 
 impl Renderable for Template {
     fn render(&self, context: &mut Context) -> Result<Option<String>> {
+<<<<<<< e6a2f7ffa4b50a5bf55dbeb8dff30eb8588d703c
         context.add_filter("size", Box::new(size));
         context.add_filter("upcase", Box::new(upcase));
-        context.filters.insert("capitalize".to_owned(), Box::new(capitalize));
+        context.add_filter("downcase".to_owned(), Box::new(downcase));
+        context.add_filter("capitalize".to_owned(), Box::new(capitalize));
         context.add_filter("minus", Box::new(minus));
         context.add_filter("plus", Box::new(plus));
         context.add_filter("times", Box::new(times));

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,6 +1,6 @@
 use Renderable;
 use context::Context;
-use filters::{size, upcase, downcase, capitalize, minus, plus, times, devided_by, ceil, floor, round, prepend, append, first, last, replace};
+use filters::{size, upcase, downcase, capitalize, minus, plus, times, devided_by, ceil, floor, round, prepend, append, first, last, pluralize, replace};
 use error::Result;
 
 pub struct Template {
@@ -9,6 +9,7 @@ pub struct Template {
 
 impl Renderable for Template {
     fn render(&self, context: &mut Context) -> Result<Option<String>> {
+
         context.add_filter("size", Box::new(size));
         context.add_filter("upcase", Box::new(upcase));
         context.add_filter("downcase".to_owned(), Box::new(downcase));
@@ -25,6 +26,7 @@ impl Renderable for Template {
         context.add_filter("prepend".to_owned(), Box::new(prepend));
         context.add_filter("append".to_owned(), Box::new(append));
         context.add_filter("replace", Box::new(replace));
+        context.add_filter("pluralize".to_owned(), Box::new(pluralize));
 
         let mut buf = String::new();
         for el in &self.elements {

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -170,3 +170,17 @@ pub fn prepend() {
     let output = template.render(&mut data);
     assert_eq!(output.unwrap(), Some("fifobar2bar".to_string()));
 }
+
+
+#[test]
+pub fn append() {
+    let text = "{{ text | append: 'lifo' }}";
+    let options : LiquidOptions = Default::default();
+    let template = parse(&text, options).unwrap();
+
+    let mut data = Context::new();
+    data.set_val("text", Value::Str("roobarb".to_string()));
+
+    let output = template.render(&mut data);
+    assert_eq!(output.unwrap(), Some("roobarblifo".to_string()));
+}

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -117,6 +117,34 @@ pub fn first() {
 
 
 #[test]
+pub fn last() {
+    let text = "{{ list | last }}";
+    let options : LiquidOptions = Default::default();
+    let template = parse(&text, options).unwrap();
+
+    // array of numbers
+    let mut data = Context::new();
+    data.set_val("list", Value::Array(vec![Value::Num(12f32), Value::Num(100f32)]));
+
+    let output = template.render(&mut data);
+    assert_eq!(output.unwrap(), Some("100".to_string()));
+
+    // array of strings
+    let mut data = Context::new();
+    data.set_val("list", Value::Array(vec![Value::Str("first".to_owned()), Value::Str("second".to_owned())]));
+
+    let output = template.render(&mut data);
+    assert_eq!(output.unwrap(), Some("second".to_string()));
+
+    let mut data = Context::new();
+    data.set_val("list", Value::Str("last".to_owned()));
+
+    let output = template.render(&mut data);
+    assert_eq!(output.unwrap(), Some("t".to_string()));
+}
+
+
+#[test]
 pub fn replace() {
     let text = "{{ text | replace: 'bar', 'foo' }}";
     let options : LiquidOptions = Default::default();

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -48,6 +48,33 @@ pub fn capitalize() {
     assert_eq!(output.unwrap(), Some("Hello World".to_string()));
 }
 
+
+#[test]
+pub fn pluralize() {
+    let text = "{{ count | pluralize: 'one', 'many'}}";
+    let options : LiquidOptions = Default::default();
+    let template = parse(&text, options).unwrap();
+
+    let mut data = Context::new();
+    data.set_val("count", Value::Num(1f32));
+
+    let output = template.render(&mut data);
+    assert_eq!(output.unwrap(), Some("one".to_string()));
+
+
+    let mut data = Context::new();
+    data.set_val("count", Value::Num(0f32));
+
+    let output = template.render(&mut data);
+    assert_eq!(output.unwrap(), Some("many".to_string()));
+
+    let mut data = Context::new();
+    data.set_val("count", Value::Num(10f32));
+
+    let output = template.render(&mut data);
+    assert_eq!(output.unwrap(), Some("many".to_string()));
+}
+
 #[test]
 pub fn minus() {
     let text = "{{ num | minus : 2 }}";

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -89,6 +89,34 @@ pub fn minus_error() {
 }
 
 #[test]
+pub fn first() {
+    let text = "{{ nums | first }}";
+    let options : LiquidOptions = Default::default();
+    let template = parse(&text, options).unwrap();
+
+    // array of numbers
+    let mut data = Context::new();
+    data.set_val("nums", Value::Array(vec![Value::Num(12f32), Value::Num(1f32)]));
+
+    let output = template.render(&mut data);
+    assert_eq!(output.unwrap(), Some("12".to_string()));
+
+    // array of strings
+    let mut data = Context::new();
+    data.set_val("nums", Value::Array(vec![Value::Str("first".to_owned())]));
+
+    let output = template.render(&mut data);
+    assert_eq!(output.unwrap(), Some("first".to_string()));
+
+    let mut data = Context::new();
+    data.set_val("nums", Value::Str("first".to_owned()));
+
+    let output = template.render(&mut data);
+    assert_eq!(output.unwrap(), Some("f".to_string()));
+}
+
+
+#[test]
 pub fn replace() {
     let text = "{{ text | replace: 'bar', 'foo' }}";
     let options : LiquidOptions = Default::default();

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -22,6 +22,20 @@ pub fn upcase() {
 
 
 #[test]
+pub fn downcase() {
+    let text = "{{ text | downcase}}";
+    let options : LiquidOptions = Default::default();
+    let template = parse(&text, options).unwrap();
+
+    let mut data = Context::new();
+    data.set_val("text", Value::Str("HELLO tHeRe".to_string()));
+
+    let output = template.render(&mut data);
+    assert_eq!(output.unwrap(), Some("hello there".to_string()));
+}
+
+
+#[test]
 pub fn capitalize() {
     let text = "{{ text | capitalize}}";
     let options : LiquidOptions = Default::default();

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -156,3 +156,17 @@ pub fn replace() {
     let output = template.render(&mut data);
     assert_eq!(output.unwrap(), Some("foo2foo".to_string()));
 }
+
+
+#[test]
+pub fn prepend() {
+    let text = "{{ text | prepend: 'fifo' }}";
+    let options : LiquidOptions = Default::default();
+    let template = parse(&text, options).unwrap();
+
+    let mut data = Context::new();
+    data.set_val("text", Value::Str("bar2bar".to_string()));
+
+    let output = template.render(&mut data);
+    assert_eq!(output.unwrap(), Some("fifobar2bar".to_string()));
+}

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -20,6 +20,20 @@ pub fn upcase() {
     assert_eq!(output.unwrap(), Some("HELLO".to_string()));
 }
 
+
+#[test]
+pub fn capitalize() {
+    let text = "{{ text | capitalize}}";
+    let options : LiquidOptions = Default::default();
+    let template = parse(&text, options).unwrap();
+
+    let mut data = Context::new();
+    data.set_val("text", Value::Str("hello world".to_string()));
+
+    let output = template.render(&mut data);
+    assert_eq!(output.unwrap(), Some("Hello World".to_string()));
+}
+
 #[test]
 pub fn minus() {
     let text = "{{ num | minus : 2 }}";


### PR DESCRIPTION
This implements the a few more filters.

Specifically it adds:

  - [x] capitalize - capitalize words in the input sentence
  - [x] downcase - convert an input string to lowercase
  - [x] first - get the first element of the passed in array
  - [x] last - get the last element of the passed in array
  - [x] prepend - prepend a string e.g. {{ 'bar' | prepend:'foo' }} #=> 'foobar'
  - [x] pluralize - return the second word if the input is not 1, otherwise return the first word e.g. {{ 3 | pluralize: 'item', 'items' }} #=> 'items'
  - [x] append - append a string e.g. {{ 'foo' | append:'bar' }} #=> 'foobar'
slice - slice a string. Takes an offset and length, e.g. {{ "hello" | slice: -3, 3 }} #=> llo


References #11