### PR TITLE
Adds assignment tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ impl Renderable for Shout {
 let mut options : LiquidOptions = Default::default();
 
 // initialize the tag and pass a closure that will return a new Shout renderable
-options.tags.insert("shout".to_owned(), Box::new(|_tag_name, arguments, _options| {
-    Box::new(Shout{text: arguments[0].to_string()})
+options.register_tag("shout", Box::new(|_tag_name, arguments, _options| {
+    Ok(Box::new(Shout{text: arguments[0].to_string()}))
 }));
 
 // use our new tag

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use token::Token;
+
 use std::result;
 use std::error;
 use std::fmt;
@@ -14,6 +16,17 @@ pub enum Error {
     Render(String),
     Filter(FilterError),
     Other(String),
+}
+
+impl Error {
+    pub fn parser<T>(expected: &str, actual: Option<&Token>) -> Result<T> {
+        Err(Error::Parser(
+            format!("Expected {}, found {:?}", expected, actual)))
+    }
+
+    pub fn renderer<T>(msg: &str) -> Result<T> {
+        Err(Error::Render(msg.to_owned()))
+    }
 }
 
 impl From<String> for Error {

--- a/src/tags/assign_tag.rs
+++ b/src/tags/assign_tag.rs
@@ -1,0 +1,98 @@
+use Renderable;
+use context::Context;
+use LiquidOptions;
+use parser::expect;
+use token::Token::{self, Identifier, Assignment, StringLiteral, NumberLiteral, BooleanLiteral};
+use error::{Error, Result};
+
+struct Assign {
+    dst: String,
+    src: Token
+}
+
+impl Renderable for Assign {
+    fn render(&self, context: &mut Context) -> Result<Option<String>> {
+        let value = match try!(context.evaluate(&self.src)) {
+            Some(v) => v,
+            None => return Error::renderer(
+                &format!("No such value {:?}", self.src))
+        };
+
+        context.set_val(&self.dst, value);
+        Ok(None)
+    }
+}
+
+pub fn assign_tag(_tag_name: &str,
+                  arguments: &[Token],
+                  _options: &LiquidOptions) -> Result<Box<Renderable>> {
+    let mut args = arguments.iter();
+    let dst = match args.next() {
+        Some(&Identifier(ref id)) => id.clone(),
+        x => return Error::parser("Identifier", x)
+    };
+
+    try!(expect(&mut args, Assignment));
+
+    let src = match args.next() {
+        x @ Some(&Identifier(_)) |
+        x @ Some(&StringLiteral(_)) |
+        x @ Some(&NumberLiteral(_)) |
+        x @ Some(&BooleanLiteral(_)) => { x.unwrap().clone() },
+        x @ Some(_) | x @ None =>
+            return Error::parser("Identifier | String | Number | Boolean", x)
+    };
+
+    Ok(Box::new(Assign {
+        dst: dst,
+        src: src
+    }))
+}
+
+#[cfg(test)]
+mod test {
+    use parse;
+    use Renderable;
+    use context::Context;
+    use value::Value;
+
+    #[test]
+    fn assignment_in_loop_persists_on_loop_exit() {
+        let text = concat!(
+            "{% assign freestyle = false %}",
+            "{% for t in tags %}{% if t == 'freestyle' %}",
+            "{% assign freestyle = true %}",
+            "{% endif %}{% endfor %}",
+            "{% if freestyle %}",
+            "<p>Freestyle!</p>",
+            "{% endif %}");
+        let template = parse(text, Default::default()).unwrap();
+
+        /* test one: no matching value in `tags` */ {
+            let mut context = Context::new();
+            context.set_val("tags", Value::Array(vec!(
+                Value::str("alpha"),
+                Value::str("beta"),
+                Value::str("gamma")
+            )));
+
+            let output = template.render(&mut context);
+            assert_eq!(context.get_val("freestyle"), Some(&Value::Bool(false)));
+            assert_eq!(output.unwrap(), Some("".to_string()));
+        }
+
+        /* test two: matching value in `tags` */ {
+            let mut context = Context::new();
+            context.set_val("tags", Value::Array(vec!(
+                Value::str("alpha"),
+                Value::str("beta"),
+                Value::str("freestyle"),
+                Value::str("gamma")
+            )));
+
+            let output = template.render(&mut context);
+            assert_eq!(context.get_val("freestyle"), Some(&Value::Bool(true)));
+            assert_eq!(output.unwrap(), Some("<p>Freestyle!</p>".to_string()));
+        }
+    }
+}

--- a/src/tags/comment_block.rs
+++ b/src/tags/comment_block.rs
@@ -1,7 +1,8 @@
 use Renderable;
 use context::Context;
 use LiquidOptions;
-use lexer::{Token, Element};
+use token::Token;
+use lexer::Element;
 use error::Result;
 
 struct Comment;

--- a/src/tags/mod.rs
+++ b/src/tags/mod.rs
@@ -1,8 +1,10 @@
+mod assign_tag;
 mod if_block;
 mod for_block;
 mod raw_block;
 mod comment_block;
 
+pub use self::assign_tag::assign_tag;
 pub use self::comment_block::comment_block;
 pub use self::raw_block::raw_block;
 pub use self::for_block::for_block;

--- a/src/tags/raw_block.rs
+++ b/src/tags/raw_block.rs
@@ -1,7 +1,7 @@
 use Renderable;
 use context::Context;
 use LiquidOptions;
-use lexer::Token;
+use token::Token;
 use lexer::Element::{self, Expression, Tag, Raw};
 use error::Result;
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,0 +1,67 @@
+use self::Token::*;
+use self::ComparisonOperator::*;
+use std::fmt;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ComparisonOperator {
+    Equals,
+    NotEquals,
+    LessThan,
+    GreaterThan,
+    LessThanEquals,
+    GreaterThanEquals,
+    Contains,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Token {
+    Pipe,
+    Dot,
+    Colon,
+    Comma,
+    OpenSquare,
+    CloseSquare,
+    OpenRound,
+    CloseRound,
+    Question,
+    Dash,
+    Assignment,
+
+    Identifier(String),
+    StringLiteral(String),
+    NumberLiteral(f32),
+    BooleanLiteral(bool),
+    DotDot,
+    Comparison(ComparisonOperator),
+}
+
+impl fmt::Display for Token {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let out = match *self {
+            Pipe => "|".to_owned(),
+            Dot => ".".to_owned(),
+            Colon => ":".to_owned(),
+            Comma => ",".to_owned(),
+            OpenSquare => "[".to_owned(),
+            CloseSquare => "]".to_owned(),
+            OpenRound => "(".to_owned(),
+            CloseRound => ")".to_owned(),
+            Question => "?".to_owned(),
+            Dash => "-".to_owned(),
+            DotDot => "..".to_owned(),
+            Assignment => "=".to_owned(),
+
+            Comparison(Equals) => "==".to_owned(),
+            Comparison(NotEquals) => "!=".to_owned(),
+            Comparison(LessThanEquals) => "<=".to_owned(),
+            Comparison(GreaterThanEquals) => ">=".to_owned(),
+            Comparison(LessThan) => "<".to_owned(),
+            Comparison(GreaterThan) => ">".to_owned(),
+            Comparison(Contains) => "contains".to_owned(),
+            Identifier(ref x) | StringLiteral(ref x) => x.clone(),
+            NumberLiteral(ref x) => x.to_string(),
+            BooleanLiteral(ref x) => x.to_string()
+        };
+        write!(f, "{}", out)
+    }
+}


### PR DESCRIPTION
Addresses Issue #14. Another monster pullreq, sorry. 

In addition to adding the `assign` tag, it also

* Adds context::evaluate() to provide a centralized way of interpreting tokens as values, looking up values from the context as necessary. Modelled on the original Ruby source.
* Moves the definition of `Token` from the lexer into its own module to avoid circular imports.
* Adds some constructor functions for liquid::Error to declutter the call site when returning error values
* Adds Result to the tag parser function signature to allow tag parser to signal failure if necessary
* Adds `parser::expect()` to check that a given token appears in the token stream of a parser when you don't actually care about capturing that value,
* Adds an implicit RHS to the condition parser for `If`, so that it can now parse the "Liquid for designers" examples for `assign` in order to use them as a unit test,
* Pushes the notion of Ruby truthiness for Values into a custom implementaion of PartialEq for `Value`s, to help with the implicit `== true` in an if block.