### PR TITLE
Adds `break` and `continue` tags.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,8 @@ extern crate regex;
 
 use std::collections::HashMap;
 use lexer::Element;
-use tags::{assign_tag, comment_block, raw_block, for_block, if_block, capture_block};
+use tags::{assign_tag, break_tag, continue_tag,
+           comment_block, raw_block, for_block, if_block, capture_block};
 use std::default::Default;
 use error::Result;
 
@@ -162,6 +163,8 @@ pub fn parse(text: &str, options: LiquidOptions) -> Result<Template> {
     let tokens = try!(lexer::tokenize(&text));
 
     options.register_tag("assign", Box::new(assign_tag));
+    options.register_tag("break", Box::new(break_tag));
+    options.register_tag("continue", Box::new(continue_tag));
 
     options.register_block("raw",     Box::new(raw_block));
     options.register_block("if",      Box::new(if_block));

--- a/src/tags/interrupt_tags.rs
+++ b/src/tags/interrupt_tags.rs
@@ -1,0 +1,141 @@
+use error::{Error, Result};
+use context::{Context, Interrupt};
+use Token;
+use LiquidOptions;
+use Renderable;
+
+struct Break;
+
+impl Renderable for Break {
+    fn render(&self, context: &mut Context) -> Result<Option<String>> {
+        context.set_interrupt(Interrupt::Break);
+        Ok(None)
+    }
+}
+
+pub fn break_tag(_tag_name: &str,
+                 arguments: &[Token],
+                 _options: &LiquidOptions) -> Result<Box<Renderable>> {
+
+    // no arguments should be supplied, trying to supply them is an error
+    if arguments.len() > 0 {
+        return Error::parser("%}", arguments.first());
+    }
+    return Ok(Box::new(Break));
+}
+
+struct Continue;
+
+impl Renderable for Continue {
+    fn render(&self, context: &mut Context) -> Result<Option<String>> {
+        context.set_interrupt(Interrupt::Continue);
+        Ok(None)
+    }
+}
+
+pub fn continue_tag(_tag_name: &str,
+                    arguments: &[Token],
+                    _options: &LiquidOptions) -> Result<Box<Renderable>> {
+    // no arguments should be supplied, trying to supply them is an error
+    if arguments.len() > 0 {
+        return Error::parser("%}", arguments.first());
+    }
+    return Ok(Box::new(Continue));
+}
+
+
+#[cfg(test)]
+mod test {
+    use Context;
+    use LiquidOptions;
+    use Renderable;
+    use parse;
+
+    #[test]
+    fn test_simple_break() {
+        let text = concat!(
+            "{% for i in (0..10) %}",
+            "enter-{{i}};",
+            "{% if i == 2 %}break-{{i}}\n{% break %}{% endif %}",
+            "exit-{{i}}\n",
+            "{% endfor %}");
+        let template = parse(text, LiquidOptions::default()).unwrap();
+
+        let mut ctx = Context::new();
+        let output = template.render(&mut ctx);
+        assert_eq!(output.unwrap(), Some(concat!(
+            "enter-0;exit-0\n",
+            "enter-1;exit-1\n",
+            "enter-2;break-2\n").to_owned()
+        ));
+    }
+
+    #[test]
+    fn test_nested_break() {
+        // assert that a {% break %} only breaks out of the innermost loop
+        let text = concat!(
+            "{% for outer in (0..3) %}",
+                "enter-{{outer}}; ",
+                "{% for inner in (6..10) %}",
+                    "{% if inner == 8 %}break, {% break %}{% endif %}",
+                    "{{ inner }}, ",
+                "{% endfor %}",
+                "exit-{{outer}}\n",
+            "{% endfor %}");
+        let template = parse(text, LiquidOptions::default()).unwrap();
+
+        let mut ctx = Context::new();
+        let output = template.render(&mut ctx);
+        assert_eq!(output.unwrap(), Some(concat!(
+            "enter-0; 6, 7, break, exit-0\n",
+            "enter-1; 6, 7, break, exit-1\n",
+            "enter-2; 6, 7, break, exit-2\n").to_owned()
+        ));
+    }
+
+    #[test]
+    fn test_simple_continue() {
+        let text = concat!(
+            "{% for i in (0..5) %}",
+            "enter-{{i}};",
+            "{% if i == 2 %}continue-{{i}}\n{% continue %}{% endif %}",
+            "exit-{{i}}\n",
+            "{% endfor %}");
+        let template = parse(text, LiquidOptions::default()).unwrap();
+
+        let mut ctx = Context::new();
+        let output = template.render(&mut ctx);
+        assert_eq!(output.unwrap(), Some(concat!(
+            "enter-0;exit-0\n",
+            "enter-1;exit-1\n",
+            "enter-2;continue-2\n",
+            "enter-3;exit-3\n",
+            "enter-4;exit-4\n").to_owned()
+        ));
+    }
+
+    #[test]
+    fn test_nested_continue() {
+        // assert that a {% continue %} only jumps out of the innermost loop
+        let text = concat!(
+            "{% for outer in (0..3) %}",
+                "enter-{{outer}}; ",
+                "{% for inner in (6..10) %}",
+                    "{% if inner == 8 %}continue, {% continue %}{% endif %}",
+                    "{{ inner }}, ",
+                "{% endfor %}",
+                "exit-{{outer}}\n",
+            "{% endfor %}");
+        let template = parse(text, LiquidOptions::default()).unwrap();
+
+        let mut ctx = Context::new();
+        let output = template.render(&mut ctx);
+        assert_eq!(output.unwrap(), Some(concat!(
+            "enter-0; 6, 7, continue, 9, exit-0\n",
+            "enter-1; 6, 7, continue, 9, exit-1\n",
+            "enter-2; 6, 7, continue, 9, exit-2\n").to_owned()
+        ));
+    }
+
+
+}

--- a/src/tags/mod.rs
+++ b/src/tags/mod.rs
@@ -1,6 +1,7 @@
 mod assign_tag;
 mod capture_block;
 mod if_block;
+mod interrupt_tags;
 mod for_block;
 mod raw_block;
 mod comment_block;
@@ -11,3 +12,5 @@ pub use self::comment_block::comment_block;
 pub use self::raw_block::raw_block;
 pub use self::for_block::for_block;
 pub use self::if_block::if_block;
+pub use self::interrupt_tags::break_tag;
+pub use self::interrupt_tags::continue_tag;

--- a/src/template.rs
+++ b/src/template.rs
@@ -20,6 +20,14 @@ impl Renderable for Template {
             if let Some(ref x) = try!(el.render(context)) {
                 buf = buf + x;
             }
+
+            // Did the last element we processed set an interrupt? If so, we
+            // need to abandon the rest of our child elements and just
+            // return what we've got. This is usually in response to a
+            // `break` or `continue` tag being rendered.
+            if context.interrupted() {
+                break;
+            }
         }
         Ok(Some(buf))
     }


### PR DESCRIPTION
Adds the notion of an "interrupt" - a signal in the rendering context that stops all rendering and returns the rendered content back up the call stack. When the stack unwind hits a for_loop, it resets the
interrupt and continues processing as directed - either breaking out of the loop or continuing on to the next iteration.

The `break` and `continue` tags are then implemented on top of this interrupt construct. This is pretty much how the shopify implementation handles the same problem.

Also adds support for nested tags in the parser (e.g. nested `for_loop`, `if`, etc). Prior to this, the parser would truncate the children at the inner `end` tag.