### PR TITLE
Add support for relative paths

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ use lexer::Element;
 use tags::{assign_tag, include_tag, break_tag, continue_tag, comment_block, raw_block, for_block,
            if_block, capture_block};
 use std::default::Default;
+use std::path::PathBuf;
 use error::Result;
 
 pub use value::Value;
@@ -124,7 +125,7 @@ pub type Tag = Fn(&str, &[Token], &LiquidOptions) -> Result<Box<Renderable>>;
 pub type Block = Fn(&str, &[Token], Vec<Element>, &LiquidOptions) -> Result<Box<Renderable>>;
 
 /// Any object (tag/block) that can be rendered by liquid must implement this trait.
-pub trait Renderable{
+pub trait Renderable {
     fn render(&self, context: &mut Context) -> Result<Option<String>>;
 }
 
@@ -132,7 +133,7 @@ pub trait Renderable{
 pub struct LiquidOptions {
     pub blocks: HashMap<String, Box<Block>>,
     pub tags: HashMap<String, Box<Tag>>,
-    pub relative_path: String,
+    pub file_system: Option<PathBuf>,
     pub error_mode: ErrorMode,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,7 @@ pub trait Renderable{
 pub struct LiquidOptions {
     pub blocks: HashMap<String, Box<Block>>,
     pub tags: HashMap<String, Box<Tag>>,
+    pub relative_path: String,
     pub error_mode: ErrorMode,
 }
 

--- a/src/tags/include_tag.rs
+++ b/src/tags/include_tag.rs
@@ -10,7 +10,7 @@ use error::{Result, Error};
 
 use std::fs::File;
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 struct Include {
     partial: Template,
@@ -23,8 +23,8 @@ impl Renderable for Include {
 }
 
 fn parse_partial<P: AsRef<Path>>(path: P, options: &LiquidOptions) -> Result<Template> {
-    let relative_path = Path::new(&options.relative_path);
-    let path = relative_path.join(path);
+    let file_system = &options.file_system.clone().unwrap_or(PathBuf::new());
+    let path = file_system.join(path);
 
     // check if file exists
     if !path.exists() {
@@ -61,13 +61,12 @@ mod test {
     use parse;
     use error::Error;
     use LiquidOptions;
+    use std::path::PathBuf;
 
-    fn options () -> LiquidOptions {
+    fn options() -> LiquidOptions {
         LiquidOptions {
-            blocks: Default::default(),
-            tags: Default::default(),
-            relative_path: "tests/fixtures/input".to_owned(),
-            error_mode: Default::default(),
+            file_system: Some(PathBuf::from("tests/fixtures/input")),
+            ..Default::default()
         }
     }
 
@@ -89,7 +88,8 @@ mod test {
         assert!(output.is_err());
         if let Err(Error::Other(val)) = output {
             assert_eq!(format!("{}", val),
-                       "\"tests/fixtures/input/file_does_not_exist.liquid\" does not exist".to_owned());
+                       "\"tests/fixtures/input/file_does_not_exist.liquid\" does not exist"
+                           .to_owned());
         } else {
             assert!(false);
         }

--- a/src/tags/include_tag.rs
+++ b/src/tags/include_tag.rs
@@ -23,7 +23,7 @@ impl Renderable for Include {
 }
 
 fn parse_partial<P: AsRef<Path>>(path: P, options: &LiquidOptions) -> Result<Template> {
-    let file_system = &options.file_system.clone().unwrap_or(PathBuf::new());
+    let file_system = options.file_system.clone().unwrap_or(PathBuf::new());
     let path = file_system.join(path);
 
     // check if file exists

--- a/tests/custom_blocks.rs
+++ b/tests/custom_blocks.rs
@@ -12,7 +12,7 @@ use std::default::Default;
 #[test]
 fn run() {
     struct Multiply {
-        numbers: Vec<f32>
+        numbers: Vec<f32>,
     }
 
     impl Renderable for Multiply {
@@ -24,31 +24,36 @@ fn run() {
 
     fn multiply_tag(_tag_name: &str,
                     arguments: &[Token],
-                    _options: &LiquidOptions) ->
-        Result<Box<Renderable>, Error> {
+                    _options: &LiquidOptions)
+                    -> Result<Box<Renderable>, Error> {
 
-        let numbers = arguments.iter().filter_map( |x| {
-            match x {
-                &Token::NumberLiteral(ref num) => Some(*num),
-                _ => None
-            }
-        }).collect();
-        Ok(Box::new(Multiply{numbers: numbers}))
+        let numbers = arguments.iter()
+                               .filter_map(|x| {
+                                   match x {
+                                       &Token::NumberLiteral(ref num) => Some(*num),
+                                       _ => None,
+                                   }
+                               })
+                               .collect();
+        Ok(Box::new(Multiply { numbers: numbers }))
     }
 
     let mut options = LiquidOptions {
         blocks: Default::default(),
         tags: Default::default(),
-        relative_path: Default::default(),
+        file_system: Default::default(),
         error_mode: Default::default(),
     };
     options.register_tag("multiply", Box::new(multiply_tag));
 
-    let template = parse("wat\n{{hello}}\n{{multiply 5 3}}{%raw%}{{multiply 5 3}}{%endraw%} test", options).unwrap();
+    let template = parse("wat\n{{hello}}\n{{multiply 5 3}}{%raw%}{{multiply 5 3}}{%endraw%} test",
+                         options)
+                       .unwrap();
 
-    let mut data = Context::new() ;
+    let mut data = Context::new();
     data.set_val("hello", Value::Str("world".to_string()));
 
     let output = template.render(&mut data);
-    assert_eq!(output.unwrap(), Some("wat\nworld\n15{{multiply 5 3}} test".to_string()));
+    assert_eq!(output.unwrap(),
+               Some("wat\nworld\n15{{multiply 5 3}} test".to_string()));
 }

--- a/tests/custom_blocks.rs
+++ b/tests/custom_blocks.rs
@@ -39,7 +39,8 @@ fn run() {
     let mut options = LiquidOptions {
         blocks: Default::default(),
         tags: Default::default(),
-        error_mode: Default::default()
+        relative_path: Default::default(),
+        error_mode: Default::default(),
     };
     options.register_tag("multiply", Box::new(multiply_tag));
 


### PR DESCRIPTION
This allows a user of `liquid-rust` to do the following:
```
let options = LiquidOptions {
            blocks: Default::default(),
            tags: Default::default(),
            relative_path: "tests/fixtures/input".to_owned(),
            error_mode: Default::default(),
        };
let text = "{% include example.txt %}";
let template = parse(text, options).unwrap();

let mut context = Context::new();
assert_eq!(template.render(&mut context).unwrap(),
                   Some("5 wot wot\n".to_owned()));
```

This will allow `cobalt.rs` to supply the build path to liquid so the include paths can be more readable and less repetative.