### PR TITLE
implement join filter

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -3,6 +3,7 @@ use context::Context;
 use filters::{size, upcase, downcase, capitalize, minus, plus, times, divided_by, ceil, floor,
               round, prepend, append, first, last, pluralize, replace};
 use filters::split;
+use filters::join;
 use error::Result;
 
 pub struct Template {
@@ -30,6 +31,7 @@ impl Renderable for Template {
         context.add_filter("replace", Box::new(replace));
         context.add_filter("pluralize", Box::new(pluralize));
         context.add_filter("split", Box::new(split));
+        context.add_filter("join", Box::new(join));
 
         let mut buf = String::new();
         for el in &self.elements {

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -239,3 +239,16 @@ pub fn split_no_comma() {
     let output = template.render(&mut data);
     assert_eq!(output.unwrap(), Some("LETTER: a\nLETTER: b\nLETTER: c\n".to_string()));
 }
+
+#[test]
+// Split on 1 string and re-join on another
+pub fn split_then_join() {
+    let text = "{{ 'a~b~c' | split:'~' | join:', ' }}";
+    let options : LiquidOptions = Default::default();
+    let template = parse(&text, options).unwrap();
+
+    let mut data = Context::new();
+
+    let output = template.render(&mut data);
+    assert_eq!(output.unwrap(), Some("a, b, c".to_string()));
+}


### PR DESCRIPTION
needed to pull in the `itertools` crate since there doesn't
seem to be a good way to do a string join in Rust w/o tons of
code.  I'm open to suggestions for doing this w/o the crate
addition.

Also not a huge fan of the Array validation/unwrapping implementation.
Also open to suggestions.

But it works!