### PR TITLE
Sort filters

### DIFF
--- a/src/filters.rs
+++ b/src/filters.rs
@@ -63,14 +63,12 @@ pub fn upcase(input: &Value, _args: &[Value]) -> FilterResult {
     }
 }
 
-
 pub fn downcase(input: &Value, _args: &[Value]) -> FilterResult {
     match *input {
         Str(ref s) => Ok(Str(s.to_lowercase())),
         _ => Err(InvalidType("String expected".to_owned())),
     }
 }
-
 
 pub fn capitalize(input: &Value, _args: &[Value]) -> FilterResult {
     match *input {
@@ -93,7 +91,6 @@ pub fn capitalize(input: &Value, _args: &[Value]) -> FilterResult {
         _ => Err(InvalidType("String expected".to_owned())),
     }
 }
-
 
 pub fn pluralize(input: &Value, args: &[Value]) -> FilterResult {
 
@@ -207,7 +204,6 @@ pub fn prepend(input: &Value, args: &[Value]) -> FilterResult {
     }
 }
 
-
 pub fn append(input: &Value, args: &[Value]) -> FilterResult {
     match *input {
         Str(ref x) => {
@@ -232,7 +228,6 @@ pub fn first(input: &Value, _args: &[Value]) -> FilterResult {
         _ => Err(InvalidType("String or Array expected".to_owned())),
     }
 }
-
 
 pub fn last(input: &Value, _args: &[Value]) -> FilterResult {
     match *input {
@@ -350,7 +345,6 @@ pub fn sort(input: &Value, args: &[Value]) -> FilterResult {
 
     }
 }
-
 
 pub fn date(input: &Value, args: &[Value]) -> FilterResult {
     if args.len() != 1 {

--- a/src/template.rs
+++ b/src/template.rs
@@ -13,28 +13,28 @@ pub struct Template {
 impl Renderable for Template {
     fn render(&self, context: &mut Context) -> Result<Option<String>> {
 
-        context.maybe_add_filter("size", Box::new(size));
-        context.maybe_add_filter("upcase", Box::new(upcase));
-        context.maybe_add_filter("downcase", Box::new(downcase));
-        context.maybe_add_filter("capitalize", Box::new(capitalize));
-        context.maybe_add_filter("minus", Box::new(minus));
-        context.maybe_add_filter("plus", Box::new(plus));
-        context.maybe_add_filter("times", Box::new(times));
-        context.maybe_add_filter("divided_by", Box::new(divided_by));
-        context.maybe_add_filter("ceil", Box::new(ceil));
-        context.maybe_add_filter("floor", Box::new(floor));
-        context.maybe_add_filter("round", Box::new(round));
-        context.maybe_add_filter("first", Box::new(first));
-        context.maybe_add_filter("last", Box::new(last));
-        context.maybe_add_filter("prepend", Box::new(prepend));
         context.maybe_add_filter("append", Box::new(append));
-        context.maybe_add_filter("replace", Box::new(replace));
-        context.maybe_add_filter("pluralize", Box::new(pluralize));
-        context.maybe_add_filter("split", Box::new(split));
+        context.maybe_add_filter("capitalize", Box::new(capitalize));
+        context.maybe_add_filter("ceil", Box::new(ceil));
+        context.maybe_add_filter("date", Box::new(date));
+        context.maybe_add_filter("divided_by", Box::new(divided_by));
+        context.maybe_add_filter("downcase", Box::new(downcase));
+        context.maybe_add_filter("first", Box::new(first));
+        context.maybe_add_filter("floor", Box::new(floor));
         context.maybe_add_filter("join", Box::new(join));
+        context.maybe_add_filter("last", Box::new(last));
+        context.maybe_add_filter("minus", Box::new(minus));
+        context.maybe_add_filter("pluralize", Box::new(pluralize));
+        context.maybe_add_filter("plus", Box::new(plus));
+        context.maybe_add_filter("prepend", Box::new(prepend));
+        context.maybe_add_filter("replace", Box::new(replace));
+        context.maybe_add_filter("round", Box::new(round));
+        context.maybe_add_filter("size", Box::new(size));
         context.maybe_add_filter("slice", Box::new(slice));
         context.maybe_add_filter("sort", Box::new(sort));
-        context.maybe_add_filter("date", Box::new(date));
+        context.maybe_add_filter("split", Box::new(split));
+        context.maybe_add_filter("times", Box::new(times));
+        context.maybe_add_filter("upcase", Box::new(upcase));
 
         let mut buf = String::new();
         for el in &self.elements {


### PR DESCRIPTION
- Template::render(): Sort filter names alphabetically.
- src/filters.rs: Leave a single blank line between function definitions.