### PR TITLE
Add `modulo' filter

### DIFF
--- a/src/filters.rs
+++ b/src/filters.rs
@@ -332,7 +332,7 @@ pub fn slice(input: &Value, args: &[Value]) -> FilterResult {
 }
 
 pub fn sort(input: &Value, args: &[Value]) -> FilterResult {
-    if args.len() > 0 {
+    if !args.is_empty() {
         return Err(InvalidArgumentCount(format!("expected no arguments, {} given", args.len())));
     }
     match input {
@@ -365,6 +365,17 @@ pub fn date(input: &Value, args: &[Value]) -> FilterResult {
     };
 
     Ok(Value::Str(date.format(format).to_string()))
+}
+
+pub fn modulo(input: &Value, args: &[Value]) -> FilterResult {
+    let num = match *input {
+        Num(n) => n,
+        _ => return Err(InvalidType("Num expected".to_owned())),
+    };
+    match args.first() {
+        Some(&Num(x)) => Ok(Num(num % x)),
+        _ => Err(InvalidArgument(0, "Num expected".to_owned())),
+    }
 }
 
 #[cfg(test)]
@@ -632,5 +643,13 @@ mod tests {
                            tos!("13 Jun 2016 02:30:00 +0300"),
                            &[Num(0f32), Num(1f32)]),
                    FilterError::InvalidArgumentCount("expected 1, 2 given".to_owned()));
+    }
+
+    #[test]
+    fn unit_modulo() {
+        assert_eq!(unit!(modulo, Num(3_f32), &[Num(2_f32)]), Num(1_f32));
+        assert_eq!(unit!(modulo, Num(3_f32), &[Num(3.0)]), Num(0_f32));
+        assert_eq!(unit!(modulo, Num(24_f32), &[Num(7_f32)]), Num(3_f32));
+        assert_eq!(unit!(modulo, Num(183.357), &[Num(12_f32)]), Num(3.3569946));
     }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,7 +1,7 @@
 use Renderable;
 use context::Context;
 use filters::{size, upcase, downcase, capitalize, minus, plus, times, divided_by, ceil, floor,
-              round, prepend, append, first, last, pluralize, replace, date, sort, slice};
+              round, prepend, append, first, last, pluralize, replace, date, sort, slice, modulo};
 use filters::split;
 use filters::join;
 use error::Result;
@@ -24,6 +24,7 @@ impl Renderable for Template {
         context.maybe_add_filter("join", Box::new(join));
         context.maybe_add_filter("last", Box::new(last));
         context.maybe_add_filter("minus", Box::new(minus));
+        context.maybe_add_filter("modulo", Box::new(modulo));
         context.maybe_add_filter("pluralize", Box::new(pluralize));
         context.maybe_add_filter("plus", Box::new(plus));
         context.maybe_add_filter("prepend", Box::new(prepend));

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -20,7 +20,6 @@ pub fn upcase() {
     assert_eq!(output.unwrap(), Some("HELLO".to_string()));
 }
 
-
 #[test]
 pub fn downcase() {
     let text = "{{ text | downcase}}";
@@ -34,7 +33,6 @@ pub fn downcase() {
     assert_eq!(output.unwrap(), Some("hello there".to_string()));
 }
 
-
 #[test]
 pub fn capitalize() {
     let text = "{{ text | capitalize}}";
@@ -47,7 +45,6 @@ pub fn capitalize() {
     let output = template.render(&mut data);
     assert_eq!(output.unwrap(), Some("Hello World".to_string()));
 }
-
 
 #[test]
 pub fn pluralize() {
@@ -87,7 +84,6 @@ pub fn minus() {
     let output = template.render(&mut data);
     assert_eq!(output.unwrap(), Some("2".to_string()));
 }
-
 
 #[test]
 pub fn plus() {
@@ -143,7 +139,6 @@ pub fn first() {
     assert_eq!(output.unwrap(), Some("f".to_string()));
 }
 
-
 #[test]
 pub fn last() {
     let text = "{{ list | last }}";
@@ -187,7 +182,6 @@ pub fn replace() {
     assert_eq!(output.unwrap(), Some("foo2foo".to_string()));
 }
 
-
 #[test]
 pub fn prepend() {
     let text = "{{ text | prepend: 'fifo' }}";
@@ -211,7 +205,6 @@ pub fn prepend() {
     let output = template.render(&mut data);
     assert_eq!(output.unwrap(), Some("fifobar2bar".to_string()));
 }
-
 
 #[test]
 pub fn append() {
@@ -296,6 +289,7 @@ pub fn slice_negative() {
     let output = template.render(&mut data);
     assert_eq!(output.unwrap(), Some("321".to_string()));
 }
+
 #[test]
 // Slicing with overflow should fit to string size
 pub fn slice_overflow() {
@@ -334,4 +328,18 @@ pub fn split_sort_join() {
     let output = template.render(&mut data);
     assert_eq!(output.unwrap(),
                Some("Sally Snake, giraffe, octopus, zebra".to_string()));
+}
+
+#[test]
+pub fn modulo() {
+    let text = "{{ num | modulo: 2 }}";
+    let options: LiquidOptions = Default::default();
+    let template = parse(&text, options).unwrap();
+    let mut data = Context::new();
+
+    let samples = [(4_f32, "0"), (3_f32, "1"), (5.1, "1.0999999")];
+    for t in &samples {
+        data.set_val("num", Value::Num(t.0));
+        assert_eq!(template.render(&mut data).unwrap(), Some(t.1.to_string()));
+    }
 }


### PR DESCRIPTION
+ src/filters.rs (sort): Use is_empty() instead of comparing len() with 0.
+ tests/filters.rs: Separate function definitions with a single blank line.