### PR TITLE
Add `date_in_tz` filter.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,8 @@ difference = "0.4"
 skeptic = "0.6"
 
 [features]
-default=[]
+default = ["extra-filters"]
+
+extra-filters = []
+
 dev=[]

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -5,7 +5,10 @@ use std::cmp::Ordering;
 use value::Value;
 use value::Value::{Array, Bool, Num, Object, Str};
 
-use chrono::{DateTime, FixedOffset};
+use chrono::DateTime;
+
+#[cfg(feature = "extra-filters")]
+use chrono::FixedOffset;
 
 use self::FilterError::*;
 
@@ -187,6 +190,7 @@ pub fn date(input: &Value, args: &[Value]) -> FilterResult {
     Ok(Value::Str(date.format(format).to_string()))
 }
 
+#[cfg(feature = "extra-filters")]
 pub fn date_in_tz(input: &Value, args: &[Value]) -> FilterResult {
     try!(check_args_len(args, 2));
     let date = match *input {
@@ -853,6 +857,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "extra-filters")]
     fn unit_date_in_tz_same_day() {
         let input = &tos!("13 Jun 2016 12:00:00 +0000");
         let args = &[tos!("%Y-%m-%d %H:%M:%S %z"), Num(3f32)];
@@ -861,6 +866,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "extra-filters")]
     fn unit_date_in_tz_previous_day() {
         let input = &tos!("13 Jun 2016 12:00:00 +0000");
         let args = &[tos!("%Y-%m-%d %H:%M:%S %z"), Num(-13f32)];
@@ -869,6 +875,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "extra-filters")]
     fn unit_date_in_tz_next_day() {
         let input = &tos!("13 Jun 2016 12:00:00 +0000");
         let args = &[tos!("%Y-%m-%d %H:%M:%S %z"), Num(13f32)];
@@ -877,6 +884,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "extra-filters")]
     fn unit_date_in_tz_input_not_a_string() {
         let input = &Num(0f32);
         let args = &[tos!("%Y-%m-%d %H:%M:%S %z"), Num(0f32)];
@@ -885,6 +893,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "extra-filters")]
     fn unit_date_in_tz_input_not_a_date_string() {
         let input = &tos!("blah blah blah");
         let args = &[tos!("%Y-%m-%d %H:%M:%S %z"), Num(0f32)];
@@ -895,6 +904,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "extra-filters")]
     fn unit_date_in_tz_date_format_not_a_string() {
         let input = &tos!("13 Jun 2016 12:00:00 +0000");
         let args = &[Num(0f32), Num(1f32)];
@@ -903,6 +913,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "extra-filters")]
     fn unit_date_in_tz_offset_not_a_num() {
         let input = &tos!("13 Jun 2016 12:00:00 +0000");
         let args = &[tos!("%Y-%m-%d %H:%M:%S %z"), tos!("0")];
@@ -911,6 +922,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "extra-filters")]
     fn unit_date_in_tz_zero_arguments() {
         let input = &tos!("13 Jun 2016 12:00:00 +0000");
         let args = &[];
@@ -919,6 +931,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "extra-filters")]
     fn unit_date_in_tz_one_argument() {
         let input = &tos!("13 Jun 2016 12:00:00 +0000");
         let args = &[tos!("%Y-%m-%d %H:%M:%S %z")];
@@ -927,6 +940,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "extra-filters")]
     fn unit_date_in_tz_three_arguments() {
         let input = &tos!("13 Jun 2016 12:00:00 +0000");
         let args = &[tos!("%Y-%m-%d %H:%M:%S %z"), Num(0f32), Num(1f32)];

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -853,7 +853,7 @@ mod tests {
     }
 
     #[test]
-    fn unit_date_with_timezone() {
+    fn unit_date_in_tz() {
         // Shift timezone, same day.
         assert_eq!(unit!(date_in_tz,
                          tos!("13 Jun 2016 12:00:00 +0000"),

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -888,8 +888,9 @@ mod tests {
     fn unit_date_in_tz_input_not_a_date_string() {
         let input = &tos!("blah blah blah");
         let args = &[tos!("%Y-%m-%d %H:%M:%S %z"), Num(0f32)];
-        let desired_result = FilterError::InvalidType("Invalid date format: input contains invalid \
-                                                      characters".to_owned());
+        let desired_result = FilterError::InvalidType("Invalid date format: input contains \
+                                                       invalid characters"
+            .to_owned());
         assert_eq!(failed!(date_in_tz, input, args), desired_result);
     }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,7 +1,7 @@
 use Renderable;
 use context::Context;
-use filters::{abs, append, capitalize, ceil, date, default, divided_by, downcase, escape,
-              escape_once, first, floor, join, last, lstrip, minus, modulo, newline_to_br,
+use filters::{abs, append, capitalize, ceil, date, date_in_tz, default, divided_by, downcase,
+              escape, escape_once, first, floor, join, last, lstrip, minus, modulo, newline_to_br,
               pluralize, plus, prepend, remove, remove_first, replace, replace_first, reverse,
               round, rstrip, size, slice, sort, split, strip, strip_html, strip_newlines, times,
               truncate, truncatewords, uniq, upcase};
@@ -20,6 +20,7 @@ impl Renderable for Template {
         context.maybe_add_filter("ceil", Box::new(ceil));
         context.maybe_add_filter("date", Box::new(date));
         context.maybe_add_filter("default", Box::new(default));
+        context.maybe_add_filter("date_in_tz", Box::new(date_in_tz));
         context.maybe_add_filter("divided_by", Box::new(divided_by));
         context.maybe_add_filter("downcase", Box::new(downcase));
         context.maybe_add_filter("escape", Box::new(escape));

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,11 +1,14 @@
 use Renderable;
 use context::Context;
-use filters::{abs, append, capitalize, ceil, date, date_in_tz, default, divided_by, downcase,
-              escape, escape_once, first, floor, join, last, lstrip, minus, modulo, newline_to_br,
+use filters::{abs, append, capitalize, ceil, date, default, divided_by, downcase, escape,
+              escape_once, first, floor, join, last, lstrip, minus, modulo, newline_to_br,
               pluralize, plus, prepend, remove, remove_first, replace, replace_first, reverse,
               round, rstrip, size, slice, sort, split, strip, strip_html, strip_newlines, times,
               truncate, truncatewords, uniq, upcase};
 use error::Result;
+
+#[cfg(feature = "extra-filters")]
+use filters::date_in_tz;
 
 pub struct Template {
     pub elements: Vec<Box<Renderable>>,
@@ -20,7 +23,6 @@ impl Renderable for Template {
         context.maybe_add_filter("ceil", Box::new(ceil));
         context.maybe_add_filter("date", Box::new(date));
         context.maybe_add_filter("default", Box::new(default));
-        context.maybe_add_filter("date_in_tz", Box::new(date_in_tz));
         context.maybe_add_filter("divided_by", Box::new(divided_by));
         context.maybe_add_filter("downcase", Box::new(downcase));
         context.maybe_add_filter("escape", Box::new(escape));
@@ -55,6 +57,10 @@ impl Renderable for Template {
         context.maybe_add_filter("truncatewords", Box::new(truncatewords));
         context.maybe_add_filter("uniq", Box::new(uniq));
         context.maybe_add_filter("upcase", Box::new(upcase));
+
+
+        #[cfg(feature = "extra-filters")]
+        context.maybe_add_filter("date_in_tz", Box::new(date_in_tz));
 
         let mut buf = String::new();
         for el in &self.elements {


### PR DESCRIPTION
I wanted to add a date filter that would allow setting the timezone, so I created this filter based on the date filter.  There is a lot of duplication between this filter and the date filter, but I decided to keep things simple for now.

Example use is: `{{ "13 Jun 2016 12:00:00 +0000" | date_in_tz: "%Y-%m-%d",-13 }}`, which would result in `2016-06-12`.