### PR TITLE
Only capitalize the first character

### DIFF
--- a/src/filters.rs
+++ b/src/filters.rs
@@ -75,20 +75,13 @@ pub fn downcase(input: &Value, _args: &[Value]) -> FilterResult {
 pub fn capitalize(input: &Value, _args: &[Value]) -> FilterResult {
     match *input {
         Str(ref s) => {
-            Ok(Str(s.char_indices().fold(String::new(), |word, (_, chr)| {
-                let next_char = match word.chars().last() {
-                        Some(last) => {
-                            if last.is_whitespace() {
-                                chr.to_uppercase().next().unwrap()
-                            } else {
-                                chr
-                            }
-                        }
-                        _ => chr.to_uppercase().next().unwrap(),
-                    }
-                    .to_string();
-                word + &next_char
-            })))
+            let mut chars = s.chars();
+            let capitalized = match chars.next() {
+                Some(first_char) => first_char.to_uppercase().chain(chars).collect(),
+                None => String::new(),
+            };
+
+            Ok(Str(capitalized))
         }
         _ => Err(InvalidType("String expected".to_owned())),
     }
@@ -582,16 +575,18 @@ mod tests {
     fn unit_capitalize() {
         assert_eq!(unit!(capitalize, tos!("abc")), tos!("Abc"));
         assert_eq!(unit!(capitalize, tos!("hello world 21")),
-                   tos!("Hello World 21"));
+                   tos!("Hello world 21"));
 
         // sure that Umlauts work
         assert_eq!(unit!(capitalize, tos!("über ètat, y̆es?")),
-                   tos!("Über Ètat, Y\u{306}es?"));
+                   tos!("Über ètat, y̆es?"));
 
         // Weird UTF-8 White space is kept – this is a no-break whitespace!
         assert_eq!(unit!(capitalize, tos!("hello world​")),
-                   tos!("Hello World​"));
+                   tos!("Hello world​"));
 
+        // The uppercase version of some character are more than one character long
+        assert_eq!(unit!(capitalize, tos!("ßß")), tos!("SSß"));
     }
 
     #[test]

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -43,7 +43,7 @@ pub fn capitalize() {
     data.set_val("text", Value::Str("hello world".to_string()));
 
     let output = template.render(&mut data);
-    assert_eq!(output.unwrap(), Some("Hello World".to_string()));
+    assert_eq!(output.unwrap(), Some("Hello world".to_string()));
 }
 
 #[test]


### PR DESCRIPTION
According to https://shopify.github.io/liquid/filters/capitalize/, the `capitalize` filter should only capitalize the first character.