### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,15 @@ build = "build.rs"
 [dependencies]
 regex = "0.2"
 lazy_static = "0.2"
-chrono = "0.2"
-unicode-segmentation = "0.1.0"
+chrono = "0.3"
+unicode-segmentation = "1.1"
 
 [build-dependencies]
-skeptic = "0.6"
+skeptic = "0.9"
 
 [dev-dependencies]
-difference = "0.4"
-skeptic = "0.6"
+difference = "1.0"
+skeptic = "0.9"
 
 [features]
 default = ["extra-filters"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,6 @@ install:
 
 test_script:
   - cargo build --verbose
-  - cargo test
 
 cache:
   - C:\Users\appveyor\.cargo\registry

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,8 @@ impl Error {
     pub fn parser<T>(expected: &str, actual: Option<&Token>) -> Result<T> {
         Err(Error::Parser(format!("Expected {}, found {}",
                                   expected,
-                                  actual.map(|x| x.to_string()).unwrap_or("nothing".to_owned()))))
+                                  actual.map(|x| x.to_string())
+                                      .unwrap_or_else(|| "nothing".to_owned()))))
     }
 
     pub fn renderer<T>(msg: &str) -> Result<T> {

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -178,7 +178,7 @@ pub fn date(input: &Value, args: &[Value]) -> FilterResult {
     try!(check_args_len(args, 1));
     let date = match *input {
         Value::Str(ref s) => {
-            try!(DateTime::parse_from_str(&s, "%d %B %Y %H:%M:%S %z")
+            try!(DateTime::parse_from_str(s, "%d %B %Y %H:%M:%S %z")
                 .map_err(|e| FilterError::InvalidType(format!("Invalid date format: {}", e))))
         }
         _ => return Err(FilterError::InvalidType("String expected".to_owned())),
@@ -195,7 +195,7 @@ pub fn date_in_tz(input: &Value, args: &[Value]) -> FilterResult {
     try!(check_args_len(args, 2));
     let date = match *input {
         Value::Str(ref s) => {
-            try!(DateTime::parse_from_str(&s, "%d %B %Y %H:%M:%S %z")
+            try!(DateTime::parse_from_str(s, "%d %B %Y %H:%M:%S %z")
                 .map_err(|e| FilterError::InvalidType(format!("Invalid date format: {}", e))))
         }
         _ => return Err(FilterError::InvalidType("String expected".to_owned())),

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -1538,7 +1538,7 @@ mod tests {
     fn unit_truncate_unicode_codepoints_examples() {
         // The examples below came from the unicode_segmentation documentation.
         //
-        // https://kbknapp.github.io/clap-rs/unicode_segmentation/ ...
+        // https://unicode-rs.github.io/unicode-segmentation/unicode_segmentation/ ...
         //               ...  trait.UnicodeSegmentation.html#tymethod.graphemes
         //
         // Note that the accents applied to each letter are treated as part of the single grapheme
@@ -1551,7 +1551,7 @@ mod tests {
         // Note that the 🇷🇺🇸🇹 is treated as a single grapheme cluster.
         let input = &tos!("Here is a RUST: 🇷🇺🇸🇹.");
         let args = &[Num(20f32)];
-        let desired_result = tos!("Here is a RUST: 🇷🇺🇸🇹...");
+        let desired_result = tos!("Here is a RUST: 🇷🇺...");
         assert_eq!(unit!(truncate, input, args), desired_result);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,7 @@ pub fn parse(text: &str, options: LiquidOptions) -> Result<Template> {
     let mut options = options;
     options.register_known_blocks();
 
-    let tokens = try!(lexer::tokenize(&text));
+    let tokens = try!(lexer::tokenize(text));
     parser::parse(&tokens, &options).map(Template::new)
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -58,7 +58,7 @@ impl Output {
         // apply all specified filters
         for filter in &self.filters {
             let f = try!(context.get_filter(&filter.name)
-                .ok_or(Error::Render(format!("Filter {} not implemented", &filter.name))));
+                .ok_or_else(|| Error::Render(format!("Filter {} not implemented", &filter.name))));
 
             let mut arguments = Vec::new();
             for arg in &filter.arguments {
@@ -66,7 +66,9 @@ impl Output {
                     VarOrVal::Var(ref x) => {
                         let val = try!(context.get_val(&*x.name())
                             .cloned()
-                            .ok_or(Error::Render(format!("undefined variable {}", x.name()))));
+                            .ok_or_else(|| {
+                                Error::Render(format!("undefined variable {}", x.name()))
+                            }));
                         arguments.push(val);
                     }
                     VarOrVal::Val(ref x) => arguments.push(x.clone()),

--- a/src/tags/capture_block.rs
+++ b/src/tags/capture_block.rs
@@ -42,7 +42,7 @@ pub fn capture_block(_tag_name: &str,
         return Error::parser("%}", t);
     };
 
-    let t = Template::new(try!(parse(&tokens, options)));
+    let t = Template::new(try!(parse(tokens, options)));
 
     Ok(Box::new(Capture {
         id: id,

--- a/src/tags/case_block.rs
+++ b/src/tags/case_block.rs
@@ -24,7 +24,7 @@ impl CaseOption {
 
     fn evaluate(&self, value: &Value, context: &Context) -> Result<bool> {
         for t in &self.tokens {
-            match try!(context.evaluate(&t)) {
+            match try!(context.evaluate(t)) {
                 Some(ref v) if *v == *value => return Ok(true),
                 _ => {}
             }

--- a/src/tags/include_tag.rs
+++ b/src/tags/include_tag.rs
@@ -53,7 +53,7 @@ pub fn include_tag(_tag_name: &str,
     };
 
 
-    Ok(Box::new(Include { partial: try!(parse_partial(&path, &options)) }))
+    Ok(Box::new(Include { partial: try!(parse_partial(&path, options)) }))
 }
 
 #[cfg(test)]

--- a/tests/custom_blocks.rs
+++ b/tests/custom_blocks.rs
@@ -28,8 +28,8 @@ fn run() {
                     -> Result<Box<Renderable>, Error> {
 
         let numbers = arguments.iter()
-            .filter_map(|x| match x {
-                &Token::NumberLiteral(ref num) => Some(*num),
+            .filter_map(|x| match *x {
+                Token::NumberLiteral(ref num) => Some(*num),
                 _ => None,
             })
             .collect();

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -1,3 +1,4 @@
+#[macro_use]
 extern crate difference;
 extern crate liquid;
 
@@ -20,7 +21,7 @@ fn compare(name: &str, context: &mut Context) {
     let mut comp = String::new();
     File::open(output_file).unwrap().read_to_string(&mut comp).unwrap();
 
-    difference::assert_diff(&comp, &output.unwrap(), " ", 0);
+    assert_diff!(&comp, &output.unwrap(), " ", 0);
 }
 
 #[test]

--- a/tests/multithreading.rs
+++ b/tests/multithreading.rs
@@ -1,3 +1,4 @@
+#[macro_use]
 extern crate difference;
 extern crate liquid;
 
@@ -35,7 +36,7 @@ pub fn pass_between_threads() {
             let mut comp = String::new();
             File::open(output_file).unwrap().read_to_string(&mut comp).unwrap();
 
-            difference::assert_diff(&comp, &output.unwrap(), " ", 0);
+            assert_diff!(&comp, &output.unwrap(), " ", 0);
         }));
     }
 

--- a/tests/parse_file.rs
+++ b/tests/parse_file.rs
@@ -1,3 +1,4 @@
+#[macro_use]
 extern crate difference;
 extern crate liquid;
 
@@ -21,7 +22,7 @@ fn compare_by_file(name: &str, context: &mut Context) {
     let mut comp = String::new();
     File::open(output_file).unwrap().read_to_string(&mut comp).unwrap();
 
-    difference::assert_diff(&comp, &output.unwrap(), " ", 0);
+    assert_diff!(&comp, &output.unwrap(), " ", 0);
 }
 
 #[test]


### PR DESCRIPTION
This fixes the test failures.

Note: `truncate` has changed behavior based on an updated version of
unicode-segmentation.

- [x] Ran clippy
- [x] Ran fmt
- [x] Ran tests