### PR TITLE
File system trait and template locations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,9 +126,8 @@ pub trait Renderable: Send + Sync {
     fn render(&self, context: &mut Context) -> Result<Option<String>>;
 }
 
-pub type TemplateName = String;
 pub trait TemplateRepository {
-    fn read_template(&self, path: &TemplateName) -> Result<String>;
+    fn read_template(&self, path: &str) -> Result<String>;
 }
 
 /// `TemplateRepository` to load files relative to the root
@@ -143,7 +142,7 @@ impl LocalTemplateRepository {
 }
 
 impl TemplateRepository for LocalTemplateRepository {
-    fn read_template(&self, relative_path: &TemplateName) -> Result<String> {
+    fn read_template(&self, relative_path: &str) -> Result<String> {
         let path = self.root.clone().join(relative_path);
 
         if !path.exists() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,15 +126,48 @@ pub trait Renderable: Send + Sync {
     fn render(&self, context: &mut Context) -> Result<Option<String>>;
 }
 
+pub trait FileSystem {
+    fn read_template_file(&self, path: &Path) -> Result<String>;
+}
+
+/// FileSystem to load files relative to the root
+pub struct LocalFileSystem {
+    root: PathBuf,
+}
+
+impl FileSystem for LocalFileSystem {
+    fn read_template_file(&self, relative_path: &Path) -> Result<String> {
+        let path = self.root.clone().join(relative_path);
+
+        if !path.exists() {
+            return Err(Error::from(&*format!("{:?} does not exist", path)));
+        }
+        let mut file = try!(File::open(path));
+
+        let mut content = String::new();
+        file.read_to_string(&mut content)?;
+        Ok(content)
+    }
+}
+
 /// Options that `liquid::parse` takes
-#[derive(Default)]
 pub struct LiquidOptions {
     /// Holds all custom block-size tags
     pub blocks: HashMap<String, Box<Block>>,
     /// Holds all custom tags
     pub tags: HashMap<String, Box<Tag>>,
     /// The path to which paths in include tags should be relative to
-    pub file_system: Option<PathBuf>,
+    pub file_system: Box<FileSystem>,
+}
+
+impl Default for LiquidOptions {
+    fn default() -> LiquidOptions {
+        LiquidOptions {
+            blocks: Default::default(),
+            tags: Default::default(),
+            file_system: Box::new(LocalFileSystem { root: PathBuf::new() }),
+        }
+    }
 }
 
 impl LiquidOptions {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,8 +126,9 @@ pub trait Renderable: Send + Sync {
     fn render(&self, context: &mut Context) -> Result<Option<String>>;
 }
 
+pub type TemplateLocation = Path;
 pub trait FileSystem {
-    fn read_template_file(&self, path: &Path) -> Result<String>;
+    fn read_template_file(&self, path: &TemplateLocation) -> Result<String>;
 }
 
 /// FileSystem to load files relative to the root
@@ -136,7 +137,7 @@ pub struct LocalFileSystem {
 }
 
 impl FileSystem for LocalFileSystem {
-    fn read_template_file(&self, relative_path: &Path) -> Result<String> {
+    fn read_template_file(&self, relative_path: &TemplateLocation) -> Result<String> {
         let path = self.root.clone().join(relative_path);
 
         if !path.exists() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,16 +127,16 @@ pub trait Renderable: Send + Sync {
 }
 
 pub type TemplateLocation = Path;
-pub trait FileSystem {
+pub trait FileRepository {
     fn read_template_file(&self, path: &TemplateLocation) -> Result<String>;
 }
 
 /// FileSystem to load files relative to the root
-pub struct LocalFileSystem {
+pub struct LocalFileRepository {
     root: PathBuf,
 }
 
-impl FileSystem for LocalFileSystem {
+impl FileRepository for LocalFileRepository {
     fn read_template_file(&self, relative_path: &TemplateLocation) -> Result<String> {
         let path = self.root.clone().join(relative_path);
 
@@ -158,7 +158,7 @@ pub struct LiquidOptions {
     /// Holds all custom tags
     pub tags: HashMap<String, Box<Tag>>,
     /// The path to which paths in include tags should be relative to
-    pub file_system: Box<FileSystem>,
+    pub file_repository: Box<FileRepository>,
 }
 
 impl Default for LiquidOptions {
@@ -166,7 +166,7 @@ impl Default for LiquidOptions {
         LiquidOptions {
             blocks: Default::default(),
             tags: Default::default(),
-            file_system: Box::new(LocalFileSystem { root: PathBuf::new() }),
+            file_repository: Box::new(LocalFileRepository { root: PathBuf::new() }),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,18 +126,24 @@ pub trait Renderable: Send + Sync {
     fn render(&self, context: &mut Context) -> Result<Option<String>>;
 }
 
-pub type TemplateLocation = Path;
-pub trait FileRepository {
-    fn read_template_file(&self, path: &TemplateLocation) -> Result<String>;
+pub type TemplateName = String;
+pub trait TemplateRepository {
+    fn read_template(&self, path: &TemplateName) -> Result<String>;
 }
 
-/// FileSystem to load files relative to the root
-pub struct LocalFileRepository {
+/// `TemplateRepository` to load files relative to the root
+pub struct LocalTemplateRepository {
     root: PathBuf,
 }
 
-impl FileRepository for LocalFileRepository {
-    fn read_template_file(&self, relative_path: &TemplateLocation) -> Result<String> {
+impl LocalTemplateRepository {
+    pub fn new(root: PathBuf) -> LocalTemplateRepository {
+        LocalTemplateRepository { root: root }
+    }
+}
+
+impl TemplateRepository for LocalTemplateRepository {
+    fn read_template(&self, relative_path: &TemplateName) -> Result<String> {
         let path = self.root.clone().join(relative_path);
 
         if !path.exists() {
@@ -158,7 +164,7 @@ pub struct LiquidOptions {
     /// Holds all custom tags
     pub tags: HashMap<String, Box<Tag>>,
     /// The path to which paths in include tags should be relative to
-    pub file_repository: Box<FileRepository>,
+    pub template_repository: Box<TemplateRepository>,
 }
 
 impl Default for LiquidOptions {
@@ -166,7 +172,7 @@ impl Default for LiquidOptions {
         LiquidOptions {
             blocks: Default::default(),
             tags: Default::default(),
-            file_repository: Box::new(LocalFileRepository { root: PathBuf::new() }),
+            template_repository: Box::new(LocalTemplateRepository { root: PathBuf::new() }),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,11 @@ fn run() -> Result<()> {
         .get_matches_safe()?;
 
     let mut options = liquid::LiquidOptions::default();
-    options.file_system = matches.value_of("include-root").map(path::PathBuf::from);
+    let root = matches
+        .value_of("include-root")
+        .map(path::PathBuf::from)
+        .unwrap_or(Default::default());
+    options.template_repository = Box::new(liquid::LocalTemplateRepository::new(root));
 
     let mut data = matches
         .value_of("context")

--- a/src/tags/include_tag.rs
+++ b/src/tags/include_tag.rs
@@ -3,7 +3,6 @@ use Renderable;
 use context::Context;
 use token::Token;
 use LiquidOptions;
-use TemplateName;
 use template::Template;
 use parser;
 use lexer;
@@ -19,7 +18,7 @@ impl Renderable for Include {
     }
 }
 
-fn parse_partial(name: &TemplateName, options: &LiquidOptions) -> Result<Template> {
+fn parse_partial(name: &str, options: &LiquidOptions) -> Result<Template> {
     let content = options.template_repository.read_template(name)?;
 
     let tokens = try!(lexer::tokenize(&content));

--- a/src/tags/include_tag.rs
+++ b/src/tags/include_tag.rs
@@ -3,12 +3,11 @@ use Renderable;
 use context::Context;
 use token::Token;
 use LiquidOptions;
+use TemplateLocation;
 use template::Template;
 use parser;
 use lexer;
 use error::{Result, Error};
-
-use std::path::Path;
 
 struct Include {
     partial: Template,
@@ -20,7 +19,7 @@ impl Renderable for Include {
     }
 }
 
-fn parse_partial<P: AsRef<Path>>(path: P, options: &LiquidOptions) -> Result<Template> {
+fn parse_partial<P: AsRef<TemplateLocation>>(path: P, options: &LiquidOptions) -> Result<Template> {
     let content = options.file_system.read_template_file(path.as_ref())?;
 
     let tokens = try!(lexer::tokenize(&content));

--- a/src/tags/include_tag.rs
+++ b/src/tags/include_tag.rs
@@ -55,8 +55,8 @@ mod test {
     fn options() -> LiquidOptions {
         LiquidOptions {
             template_repository: Box::new(LocalTemplateRepository {
-                root: PathBuf::from("tests/fixtures/input"),
-            }),
+                                              root: PathBuf::from("tests/fixtures/input"),
+                                          }),
             ..Default::default()
         }
     }

--- a/src/tags/include_tag.rs
+++ b/src/tags/include_tag.rs
@@ -20,7 +20,7 @@ impl Renderable for Include {
 }
 
 fn parse_partial<P: AsRef<TemplateLocation>>(path: P, options: &LiquidOptions) -> Result<Template> {
-    let content = options.file_system.read_template_file(path.as_ref())?;
+    let content = options.file_repository.read_template_file(path.as_ref())?;
 
     let tokens = try!(lexer::tokenize(&content));
     parser::parse(&tokens, options).map(Template::new)
@@ -49,12 +49,14 @@ mod test {
     use parse;
     use error::Error;
     use LiquidOptions;
-    use LocalFileSystem;
+    use LocalFileRepository;
     use std::path::PathBuf;
 
     fn options() -> LiquidOptions {
         LiquidOptions {
-            file_system: Box::new(LocalFileSystem { root: PathBuf::from("tests/fixtures/input") }),
+            file_repository: Box::new(LocalFileRepository {
+                root: PathBuf::from("tests/fixtures/input"),
+            }),
             ..Default::default()
         }
     }

--- a/tests/custom_blocks.rs
+++ b/tests/custom_blocks.rs
@@ -37,11 +37,7 @@ fn run() {
         Ok(Box::new(Multiply { numbers: numbers }))
     }
 
-    let mut options = LiquidOptions {
-        blocks: Default::default(),
-        tags: Default::default(),
-        file_system: Default::default(),
-    };
+    let mut options: LiquidOptions = Default::default();
     options.register_tag("multiply", Box::new(multiply_tag));
 
     let template = parse("wat\n{{hello}}\n{{multiply 5 3}}{%raw%}{{multiply 5 3}}{%endraw%} test",


### PR DESCRIPTION
Hello! 

This is my first Rust contribution, so I expect it to be less-than-perfect, please let me know how I can improve it!

---

Currently `LiquidOptions.file_system` is implemented as a `PathBuf`, reading directly for the disk. This leaves little options for where to store the files. I'd like to have my files in abstract repositories, either in the database, S3, etc. As a result, I changed `file_system` to be a trait, boxed in `LiquidOptions`. 

Then I realized my custom blocks needed a way to specify to the file system where the templates were stored. This required little change, but I still thought it would be a good time to introduce a `TemplateName` type. I wondered if I should change `include_tag` to send `include://#{path}` as the `TemplateName`, like I would do in custom blocks, but I ended up not doing it. Thoughts on this?

Finally, I wondered if `file_system` was really a `file_system` given the previous changes. I renamed it to `template_repository`. I realize that this is diverging from Shopify/liquid, so I don't have a particularly strong opinion on this one. 