### PR TITLE
refactor(Parse): Rename VarOrVal to Argument

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -7,17 +7,17 @@ use error::{Error, Result};
 #[derive(Debug, PartialEq)]
 pub struct FilterPrototype {
     name: String,
-    arguments: Vec<VarOrVal>,
+    arguments: Vec<Argument>,
 }
 
 #[derive(Debug, PartialEq)]
-pub enum VarOrVal {
+pub enum Argument {
     Var(Variable),
     Val(Value),
 }
 
 impl FilterPrototype {
-    pub fn new(name: &str, arguments: Vec<VarOrVal>) -> FilterPrototype {
+    pub fn new(name: &str, arguments: Vec<Argument>) -> FilterPrototype {
         FilterPrototype {
             name: name.to_owned(),
             arguments: arguments,
@@ -27,7 +27,7 @@ impl FilterPrototype {
 
 #[derive(Debug, PartialEq)]
 pub struct Output {
-    entry: VarOrVal,
+    entry: Argument,
     filters: Vec<FilterPrototype>,
 }
 
@@ -39,7 +39,7 @@ impl Renderable for Output {
 }
 
 impl Output {
-    pub fn new(entry: VarOrVal, filters: Vec<FilterPrototype>) -> Output {
+    pub fn new(entry: Argument, filters: Vec<FilterPrototype>) -> Output {
         Output {
             entry: entry,
             filters: filters,
@@ -49,8 +49,8 @@ impl Output {
     pub fn apply_filters(&self, context: &Context) -> Result<Value> {
         // take either the provided value or the value from the provided variable
         let mut entry = match self.entry {
-            VarOrVal::Val(ref x) => x.clone(),
-            VarOrVal::Var(ref x) => {
+            Argument::Val(ref x) => x.clone(),
+            Argument::Var(ref x) => {
                 context
                     .get_val(&*x.name())
                     .cloned()
@@ -70,7 +70,7 @@ impl Output {
             let mut arguments = Vec::new();
             for arg in &filter.arguments {
                 match *arg {
-                    VarOrVal::Var(ref x) => {
+                    Argument::Var(ref x) => {
                         let val = try!(context.get_val(&*x.name())
                             .cloned()
                             .ok_or_else(|| {
@@ -78,7 +78,7 @@ impl Output {
                             }));
                         arguments.push(val);
                     }
-                    VarOrVal::Val(ref x) => arguments.push(x.clone()),
+                    Argument::Val(ref x) => arguments.push(x.clone()),
                 }
             }
             entry = try!(f(&entry, &*arguments));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,7 +8,7 @@ use LiquidOptions;
 use value::Value;
 use variable::Variable;
 use text::Text;
-use output::{Output, FilterPrototype, VarOrVal};
+use output::{Output, FilterPrototype, Argument};
 use token::Token;
 use token::Token::*;
 use lexer::Element::{self, Expression, Tag, Raw};
@@ -56,8 +56,8 @@ fn parse_expression(tokens: &[Token], options: &LiquidOptions) -> Result<Box<Ren
 /// for correctly parsing complex expressions with filters.
 pub fn parse_output(tokens: &[Token]) -> Result<Output> {
     let entry = match tokens[0] {
-        Identifier(ref x) => VarOrVal::Var(Variable::new(x)),
-        ref x => VarOrVal::Val(try!(Value::from_token(x))),
+        Identifier(ref x) => Argument::Var(Variable::new(x)),
+        ref x => Argument::Val(try!(Value::from_token(x))),
     };
 
     let mut filters = vec![];
@@ -90,8 +90,8 @@ pub fn parse_output(tokens: &[Token]) -> Result<Output> {
             match iter.next().unwrap() {
                 x @ &StringLiteral(_) |
                 x @ &NumberLiteral(_) |
-                x @ &BooleanLiteral(_) => args.push(VarOrVal::Val(try!(Value::from_token(x)))),
-                &Identifier(ref v) => args.push(VarOrVal::Var(Variable::new(v))),
+                x @ &BooleanLiteral(_) => args.push(Argument::Val(try!(Value::from_token(x)))),
+                &Identifier(ref v) => args.push(Argument::Var(Variable::new(v))),
                 x => {
                     return Error::parser("a comma or a pipe", Some(x));
                 }
@@ -257,7 +257,7 @@ mod test {
     mod test_parse_output {
         use super::super::parse_output;
         use lexer::granularize;
-        use output::{Output, VarOrVal, FilterPrototype};
+        use output::{Output, Argument, FilterPrototype};
         use variable::Variable;
         use value::Value;
 
@@ -267,12 +267,12 @@ mod test {
 
             let result = parse_output(&tokens);
             assert_eq!(result.unwrap(),
-                       Output::new(VarOrVal::Var(Variable::new("abc")),
+                       Output::new(Argument::Var(Variable::new("abc")),
                                    vec![FilterPrototype::new("def",
                                                              vec![
-                                         VarOrVal::Val(Value::str("1")),
-                                         VarOrVal::Val(Value::Num(2.0)),
-                                         VarOrVal::Val(Value::str("3")),
+                                                                 Argument::Val(Value::str("1")),
+                                                                 Argument::Val(Value::Num(2.0)),
+                                                                 Argument::Val(Value::str("3")),
                     ]),
                                         FilterPrototype::new("blabla", vec![])]));
         }


### PR DESCRIPTION
I was trying to implement named arguments for filters, and I had trouble understanding what `VarOrVal` meant. I understood that it could contain either a variable or a value, but understanding the union of those types was hard.

It occurred to me that holding these values is just a coincidence; what `VarOrVal` really represents, is the arguments passed into filters [as used in FilterPrototype](https://github.com/cobalt-org/liquid-rust/compare/master...gmalette:rename-varorval-to-argument?expand=1#diff-ac5cd937cc00cb0544b06a1b6ce1ce5eR10). It's the "unknown" value of an argument between the time the code gets parsed until it gets evaluated.

Thoughts about renaming it `FilterArgument` ?

Had the grammar been structured different, I would've suggested something more along the lines of

```rust
enum FilterArgument {
  Literal(Value)
  Identifier(Variable)
}
```

Speaking of grammar, I'm curious: do you know why the tokenizer and parser were written by hand, rather than using a generator?