### PR TITLE
feat(filters): Add missing filters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ lazy_static = "0.2"
 chrono = "0.3"
 unicode-segmentation = "1.1"
 itertools = "0.6.0"
+url = "1.4"
 serde = "1.0"
 serde_derive = "1.0"
 

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -530,10 +530,16 @@ pub fn map(input: &Value, args: &[Value]) -> FilterResult {
     Ok(Value::Array(result))
 }
 
-// TODO compact removes nulls from an iterable.  For hashes, you can specify which property you
-// want to filter out if it maps to Null.
-// liquid-rust doesn't have the concept of Null.  Are there some behavior gaps we have that should
-// force us to support Null? Should we make this function a no-op?
+/// Remove nulls from an iterable.  For hashes, you can specify which property you
+/// want to filter out if it maps to Null.
+pub fn compact(input: &Value, args: &[Value]) -> FilterResult {
+    try!(check_args_len(args, 0, 1));
+
+    // No-op.  liquid-rust doesn't have Null but this is left in for compatibility with existing
+    // shopofy/liquid code.  Should it be a no-op, error, or not exist?
+
+    Ok(input.clone())
+}
 
 pub fn replace(input: &Value, args: &[Value]) -> FilterResult {
     try!(check_args_len(args, 1, 1));

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -466,7 +466,26 @@ pub fn reverse(input: &Value, args: &[Value]) -> FilterResult {
     Ok(Value::Array(reversed))
 }
 
-// TODO map
+/// Extract `property` from the `Value::Object` elements of an array
+pub fn map(input: &Value, args: &[Value]) -> FilterResult {
+    try!(check_args_len(args, 1));
+
+    let array = input
+        .as_array()
+        .ok_or_else(|| InvalidType("Array expected".to_owned()))?;
+
+    let property = args[0].to_string();
+
+    let result = array
+        .iter()
+        .filter_map(|v| {
+                        v.as_object()
+                            .map(|o| o.get(&property).cloned())
+                            .map_or(None, |o| o)
+                    })
+        .collect();
+    Ok(Value::Array(result))
+}
 
 // TODO compact removes nulls from an iterable.  For hashes, you can specify which property you
 // want to filter out if it maps to Null.

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -468,7 +468,10 @@ pub fn reverse(input: &Value, args: &[Value]) -> FilterResult {
 
 // TODO map
 
-// TODO compact
+// TODO compact removes nulls from an iterable.  For hashes, you can specify which property you
+// want to filter out if it maps to Null.
+// liquid-rust doesn't have the concept of Null.  Are there some behavior gaps we have that should
+// force us to support Null? Should we make this function a no-op?
 
 pub fn replace(input: &Value, args: &[Value]) -> FilterResult {
     if args.len() < 1 || 2 < args.len() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ extern crate regex;
 extern crate chrono;
 extern crate unicode_segmentation;
 extern crate itertools;
+extern crate url;
 
 #[macro_use]
 extern crate lazy_static;

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,6 +1,6 @@
 use Renderable;
 use context::Context;
-use filters::{abs, append, capitalize, ceil, date, default, divided_by, downcase, escape,
+use filters::{abs, append, capitalize, concat, ceil, date, default, divided_by, downcase, escape,
               escape_once, first, floor, join, last, lstrip, minus, modulo, newline_to_br, plus,
               prepend, remove, remove_first, replace, replace_first, reverse, round, rstrip, size,
               slice, sort, split, strip, strip_html, strip_newlines, times, truncate,
@@ -23,6 +23,7 @@ impl Renderable for Template {
         context.maybe_add_filter("append", Box::new(append));
         context.maybe_add_filter("capitalize", Box::new(capitalize));
         context.maybe_add_filter("ceil", Box::new(ceil));
+        context.maybe_add_filter("concat", Box::new(concat));
         context.maybe_add_filter("date", Box::new(date));
         context.maybe_add_filter("default", Box::new(default));
         context.maybe_add_filter("divided_by", Box::new(divided_by));

--- a/src/template.rs
+++ b/src/template.rs
@@ -51,6 +51,8 @@ impl Renderable for Template {
         context.maybe_add_filter("truncatewords", Box::new(filters::truncatewords));
         context.maybe_add_filter("uniq", Box::new(filters::uniq));
         context.maybe_add_filter("upcase", Box::new(filters::upcase));
+        context.maybe_add_filter("url_decode", Box::new(filters::url_decode));
+        context.maybe_add_filter("url_encode", Box::new(filters::url_encode));
 
         #[cfg(feature = "extra-filters")]
         context.maybe_add_filter("pluralize", Box::new(filters::pluralize));

--- a/src/template.rs
+++ b/src/template.rs
@@ -14,6 +14,7 @@ impl Renderable for Template {
         context.maybe_add_filter("append", Box::new(filters::append));
         context.maybe_add_filter("capitalize", Box::new(filters::capitalize));
         context.maybe_add_filter("ceil", Box::new(filters::ceil));
+        context.maybe_add_filter("compact", Box::new(filters::compact));
         context.maybe_add_filter("concat", Box::new(filters::concat));
         context.maybe_add_filter("date", Box::new(filters::date));
         context.maybe_add_filter("default", Box::new(filters::default));

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,16 +1,7 @@
 use Renderable;
 use context::Context;
-use filters::{abs, append, capitalize, concat, ceil, date, default, divided_by, downcase, escape,
-              escape_once, first, floor, join, last, lstrip, minus, modulo, newline_to_br, plus,
-              prepend, remove, remove_first, replace, replace_first, reverse, round, rstrip, size,
-              slice, sort, split, strip, strip_html, strip_newlines, times, truncate,
-              truncatewords, uniq, upcase};
+use filters;
 use error::Result;
-
-#[cfg(feature = "extra-filters")]
-use filters::pluralize;
-#[cfg(feature = "extra-filters")]
-use filters::date_in_tz;
 
 pub struct Template {
     pub elements: Vec<Box<Renderable>>,
@@ -19,51 +10,52 @@ pub struct Template {
 impl Renderable for Template {
     fn render(&self, context: &mut Context) -> Result<Option<String>> {
 
-        context.maybe_add_filter("abs", Box::new(abs));
-        context.maybe_add_filter("append", Box::new(append));
-        context.maybe_add_filter("capitalize", Box::new(capitalize));
-        context.maybe_add_filter("ceil", Box::new(ceil));
-        context.maybe_add_filter("concat", Box::new(concat));
-        context.maybe_add_filter("date", Box::new(date));
-        context.maybe_add_filter("default", Box::new(default));
-        context.maybe_add_filter("divided_by", Box::new(divided_by));
-        context.maybe_add_filter("downcase", Box::new(downcase));
-        context.maybe_add_filter("escape", Box::new(escape));
-        context.maybe_add_filter("escape_once", Box::new(escape_once));
-        context.maybe_add_filter("first", Box::new(first));
-        context.maybe_add_filter("floor", Box::new(floor));
-        context.maybe_add_filter("join", Box::new(join));
-        context.maybe_add_filter("last", Box::new(last));
-        context.maybe_add_filter("lstrip", Box::new(lstrip));
-        context.maybe_add_filter("minus", Box::new(minus));
-        context.maybe_add_filter("modulo", Box::new(modulo));
-        context.maybe_add_filter("newline_to_br", Box::new(newline_to_br));
-        context.maybe_add_filter("plus", Box::new(plus));
-        context.maybe_add_filter("prepend", Box::new(prepend));
-        context.maybe_add_filter("remove", Box::new(remove));
-        context.maybe_add_filter("remove_first", Box::new(remove_first));
-        context.maybe_add_filter("replace", Box::new(replace));
-        context.maybe_add_filter("replace_first", Box::new(replace_first));
-        context.maybe_add_filter("reverse", Box::new(reverse));
-        context.maybe_add_filter("round", Box::new(round));
-        context.maybe_add_filter("rstrip", Box::new(rstrip));
-        context.maybe_add_filter("size", Box::new(size));
-        context.maybe_add_filter("slice", Box::new(slice));
-        context.maybe_add_filter("sort", Box::new(sort));
-        context.maybe_add_filter("split", Box::new(split));
-        context.maybe_add_filter("strip", Box::new(strip));
-        context.maybe_add_filter("strip_html", Box::new(strip_html));
-        context.maybe_add_filter("strip_newlines", Box::new(strip_newlines));
-        context.maybe_add_filter("times", Box::new(times));
-        context.maybe_add_filter("truncate", Box::new(truncate));
-        context.maybe_add_filter("truncatewords", Box::new(truncatewords));
-        context.maybe_add_filter("uniq", Box::new(uniq));
-        context.maybe_add_filter("upcase", Box::new(upcase));
+        context.maybe_add_filter("abs", Box::new(filters::abs));
+        context.maybe_add_filter("append", Box::new(filters::append));
+        context.maybe_add_filter("capitalize", Box::new(filters::capitalize));
+        context.maybe_add_filter("ceil", Box::new(filters::ceil));
+        context.maybe_add_filter("concat", Box::new(filters::concat));
+        context.maybe_add_filter("date", Box::new(filters::date));
+        context.maybe_add_filter("default", Box::new(filters::default));
+        context.maybe_add_filter("divided_by", Box::new(filters::divided_by));
+        context.maybe_add_filter("downcase", Box::new(filters::downcase));
+        context.maybe_add_filter("escape", Box::new(filters::escape));
+        context.maybe_add_filter("escape_once", Box::new(filters::escape_once));
+        context.maybe_add_filter("first", Box::new(filters::first));
+        context.maybe_add_filter("floor", Box::new(filters::floor));
+        context.maybe_add_filter("join", Box::new(filters::join));
+        context.maybe_add_filter("last", Box::new(filters::last));
+        context.maybe_add_filter("lstrip", Box::new(filters::lstrip));
+        context.maybe_add_filter("map", Box::new(filters::map));
+        context.maybe_add_filter("minus", Box::new(filters::minus));
+        context.maybe_add_filter("modulo", Box::new(filters::modulo));
+        context.maybe_add_filter("newline_to_br", Box::new(filters::newline_to_br));
+        context.maybe_add_filter("plus", Box::new(filters::plus));
+        context.maybe_add_filter("prepend", Box::new(filters::prepend));
+        context.maybe_add_filter("remove", Box::new(filters::remove));
+        context.maybe_add_filter("remove_first", Box::new(filters::remove_first));
+        context.maybe_add_filter("replace", Box::new(filters::replace));
+        context.maybe_add_filter("replace_first", Box::new(filters::replace_first));
+        context.maybe_add_filter("reverse", Box::new(filters::reverse));
+        context.maybe_add_filter("round", Box::new(filters::round));
+        context.maybe_add_filter("rstrip", Box::new(filters::rstrip));
+        context.maybe_add_filter("size", Box::new(filters::size));
+        context.maybe_add_filter("slice", Box::new(filters::slice));
+        context.maybe_add_filter("sort", Box::new(filters::sort));
+        context.maybe_add_filter("split", Box::new(filters::split));
+        context.maybe_add_filter("strip", Box::new(filters::strip));
+        context.maybe_add_filter("strip_html", Box::new(filters::strip_html));
+        context.maybe_add_filter("strip_newlines", Box::new(filters::strip_newlines));
+        context.maybe_add_filter("times", Box::new(filters::times));
+        context.maybe_add_filter("truncate", Box::new(filters::truncate));
+        context.maybe_add_filter("truncatewords", Box::new(filters::truncatewords));
+        context.maybe_add_filter("uniq", Box::new(filters::uniq));
+        context.maybe_add_filter("upcase", Box::new(filters::upcase));
 
         #[cfg(feature = "extra-filters")]
-        context.maybe_add_filter("pluralize", Box::new(pluralize));
+        context.maybe_add_filter("pluralize", Box::new(filters::pluralize));
         #[cfg(feature = "extra-filters")]
-        context.maybe_add_filter("date_in_tz", Box::new(date_in_tz));
+        context.maybe_add_filter("date_in_tz", Box::new(filters::date_in_tz));
 
         let mut buf = String::new();
         for el in &self.elements {


### PR DESCRIPTION
Filters include
- `map`
- `url_encode` and `url_decode`
- `concat`
- `compact` though more of a dummy implementation due to our lack of Nulls

Partially fixes #11.  sort_natural is the only filter remaining.