### PR TITLE
feature(Filter): Add named arguments

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -184,8 +184,9 @@ fn test_whitespace_control() {
 fn test_split_atom() {
     assert_eq!(split_atom("truc | arg:val"),
                vec!["truc", " ", "", "|", "", " ", "arg", ":", "val"]);
-    assert_eq!(split_atom("truc | filter:arg1,arg2"),
-               vec!["truc", " ", "", "|", "", " ", "filter", ":", "arg1", ",", "arg2"]);
+    assert_eq!(split_atom("truc | filter:arg1,arg2,a:arg3"),
+               vec!["truc", " ", "", "|", "", " ", "filter", ":", "arg1", ",", "arg2", ",", "a",
+                    ":", "arg3"]);
 }
 
 #[test]

--- a/src/output.rs
+++ b/src/output.rs
@@ -8,6 +8,7 @@ use error::{Error, Result};
 pub struct FilterPrototype {
     name: String,
     arguments: Vec<Argument>,
+    named_arguments: Vec<(String, Argument)>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -17,10 +18,14 @@ pub enum Argument {
 }
 
 impl FilterPrototype {
-    pub fn new(name: &str, arguments: Vec<Argument>) -> FilterPrototype {
+    pub fn new(name: &str,
+               arguments: Vec<Argument>,
+               named_arguments: Vec<(String, Argument)>)
+               -> FilterPrototype {
         FilterPrototype {
             name: name.to_owned(),
             arguments: arguments,
+            named_arguments: named_arguments,
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -120,7 +120,7 @@ fn parse_positional_args(iter: &mut Peekable<Iter<Token>>) -> Result<Vec<Argumen
                 let _ = iter.next().unwrap();
                 continue;
             }
-            Some(&&Pipe) | None => break,
+            None => break,
             _ => {
                 return Error::parser("a comma or a pipe", Some(iter.next().unwrap()));
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -356,6 +356,24 @@ mod test {
         }
 
         #[test]
+        fn named_args_require_a_value() {
+            let tokens = granularize("abc | def: a: | toto").unwrap();
+            let results = parse_output(&tokens);
+            assert_eq!(results.unwrap_err().to_string(),
+                       "Parsing error: Expected a string | number | boolean | identifier, found nothing");
+
+            let tokens = granularize("abc | def: a:,").unwrap();
+            let results = parse_output(&tokens);
+            assert_eq!(results.unwrap_err().to_string(),
+                       "Parsing error: Expected a string | number | boolean | identifier, found ,");
+
+            let tokens = granularize("abc | def: a: a:").unwrap();
+            let results = parse_output(&tokens);
+            assert_eq!(results.unwrap_err().to_string(),
+                       "Parsing error: Expected a comma or a pipe, found :");
+        }
+
+        #[test]
         fn fails_on_missing_colons() {
             let tokens = granularize("abc | def '1',2,'3' | blabla").unwrap();
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -15,7 +15,7 @@ use lexer::Element::{self, Expression, Tag, Raw};
 use error::{Error, Result};
 use std::slice::Iter;
 use std::collections::HashSet;
-use std::iter::FromIterator;
+use std::iter::{FromIterator, Peekable};
 
 /// Parses the provided elements into a number of Renderable items
 /// This is the internal version of parse that accepts Elements tokenized
@@ -95,9 +95,14 @@ fn parse_filter(tokens: &[Token]) -> Result<FilterPrototype> {
 
     try!(expect(&mut iter, &Colon));
 
+    let args = parse_positional_args(&mut iter)?;
+
+    Ok(FilterPrototype::new(name, args))
+}
+
+fn parse_positional_args(iter: &mut Peekable<Iter<Token>>) -> Result<Vec<Argument>> {
     let mut args = vec![];
 
-    // loops through the argument list after the filter name
     while iter.peek() != None {
         match iter.next().unwrap() {
             x @ &StringLiteral(_) |
@@ -122,7 +127,7 @@ fn parse_filter(tokens: &[Token]) -> Result<FilterPrototype> {
         }
     }
 
-    Ok(FilterPrototype::new(name, args))
+    Ok(args)
 }
 
 // a tag can be either a single-element tag or a block, which can contain other

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -55,14 +55,16 @@ fn parse_expression(tokens: &[Token], options: &LiquidOptions) -> Result<Box<Ren
 /// used internally, from a list of Tokens. This is mostly useful
 /// for correctly parsing complex expressions with filters.
 pub fn parse_output(tokens: &[Token]) -> Result<Output> {
-    let entry = match tokens[0] {
-        Identifier(ref x) => Argument::Var(Variable::new(x)),
-        ref x => Argument::Val(try!(Value::from_token(x))),
+    let mut iter = tokens.iter().peekable();
+    let token = iter.next();
+
+    let entry = match token {
+        Some(&Identifier(ref x)) => Argument::Var(Variable::new(x)),
+        Some(ref x) => Argument::Val(Value::from_token(x)?),
+        _ => return Error::parser("a token", None),
     };
 
     let mut filters = vec![];
-    let mut iter = tokens.iter().peekable();
-    iter.next();
 
     while iter.peek() != None {
         try!(expect(&mut iter, &Pipe));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -15,7 +15,7 @@ use lexer::Element::{self, Expression, Tag, Raw};
 use error::{Error, Result};
 use std::slice::Iter;
 use std::collections::HashSet;
-use std::iter::{FromIterator, Peekable};
+use std::iter::FromIterator;
 
 /// Parses the provided elements into a number of Renderable items
 /// This is the internal version of parse that accepts Elements tokenized
@@ -55,103 +55,89 @@ fn parse_expression(tokens: &[Token], options: &LiquidOptions) -> Result<Box<Ren
 /// used internally, from a list of Tokens. This is mostly useful
 /// for correctly parsing complex expressions with filters.
 pub fn parse_output(tokens: &[Token]) -> Result<Output> {
-    let mut iter = tokens.iter().peekable();
-    let token = iter.next();
-
-    let entry = match token {
-        Some(&Identifier(ref x)) => Argument::Var(Variable::new(x)),
-        Some(ref x) => Argument::Val(Value::from_token(x)?),
-        _ => return Error::parser("a token", None),
+    let entry = match tokens[0] {
+        Identifier(ref x) => Argument::Var(Variable::new(x)),
+        ref x => Argument::Val(try!(Value::from_token(x))),
     };
 
-    if let None = iter.peek() {
-        return Ok(Output::new(entry, vec![]));
-    }
-
-    expect(&mut iter, &Pipe)?;
-
     let mut filters = vec![];
+    let mut iter = tokens.iter().peekable();
+    iter.next();
 
-    for filter_tokens in tokens.split(|token| token == &Pipe).skip(1) {
-        filters.push(try!(parse_filter(filter_tokens)));
+    while iter.peek() != None {
+        try!(expect(&mut iter, &Pipe));
+
+        let name = match iter.next() {
+            Some(&Identifier(ref name)) => name,
+            x => {
+                return Error::parser("an identifier", x);
+            }
+        };
+        let mut args = vec![];
+        let mut named_args = vec![];
+
+        match iter.peek() {
+            Some(&&Pipe) | None => {
+                filters.push(FilterPrototype::new(name, args, named_args));
+                continue;
+            }
+            _ => (),
+        }
+
+        try!(expect(&mut iter, &Colon));
+
+        // loops through the argument list after the filter name
+        while iter.peek() != None && iter.peek().unwrap() != &&Pipe {
+            match iter.next().unwrap() {
+                x @ &StringLiteral(_) |
+                x @ &NumberLiteral(_) |
+                x @ &BooleanLiteral(_) => args.push(Argument::Val(try!(Value::from_token(x)))),
+                &Identifier(ref v) => {
+                    match iter.peek() {
+                        Some(&&Colon) => {
+                            iter.next();
+                            if iter.peek() == None {
+                                return Error::parser("a string | number | boolean | identifier",
+                                                     None);
+                            }
+
+                            let value = match iter.next().unwrap() {
+                                x @ &StringLiteral(_) |
+                                x @ &NumberLiteral(_) |
+                                x @ &BooleanLiteral(_) => Argument::Val(try!(Value::from_token(x))),
+                                &Identifier(ref v) => Argument::Var(Variable::new(v)),
+                                x => {
+                                    return Error::parser("a string | number | boolean | identifier",
+                                                         Some(x));
+                                }
+                            };
+                            named_args.push((v.to_string(), value));
+                        }
+                        _ => args.push(Argument::Var(Variable::new(v))),
+                    }
+                }
+                x => {
+                    return Error::parser("a comma or a pipe", Some(x));
+                }
+            }
+
+            // ensure that the next token is either a Comma or a Pipe
+            match iter.peek() {
+                Some(&&Comma) => {
+                    let _ = iter.next().unwrap();
+                    continue;
+                }
+                Some(&&Pipe) | None => break,
+                _ => {
+                    return Error::parser("a comma or a pipe", Some(iter.next().unwrap()));
+                }
+            }
+        }
+
+        filters.push(FilterPrototype::new(name, args, named_args));
     }
 
     Ok(Output::new(entry, filters))
-}
-
-fn parse_filter(tokens: &[Token]) -> Result<FilterPrototype> {
-    let mut iter = tokens.iter().peekable();
-
-    let name = match iter.next() {
-        Some(&Identifier(ref name)) => name,
-        x => {
-            return Error::parser("an identifier", x);
-        }
-    };
-
-    if let None = iter.peek() {
-        return Ok(FilterPrototype::new(name, vec![], vec![]));
-    }
-
-    try!(expect(&mut iter, &Colon));
-
-    let (args, named_args) = parse_args(&mut iter.clone())?;
-
-    Ok(FilterPrototype::new(name, args, named_args))
-}
-
-fn parse_args(iter: &mut Peekable<Iter<Token>>)
-              -> Result<(Vec<Argument>, Vec<(String, Argument)>)> {
-    let mut args = vec![];
-    let mut named_args = vec![];
-
-    while iter.peek() != None {
-        match iter.next().unwrap() {
-            x @ &StringLiteral(_) |
-            x @ &NumberLiteral(_) |
-            x @ &BooleanLiteral(_) => args.push(Argument::Val(try!(Value::from_token(x)))),
-            &Identifier(ref v) => {
-                match iter.peek() {
-                    Some(&&Colon) => {
-                        iter.next();
-                        if None == iter.peek() {
-                            return Error::parser("a string | number | boolean | identifier", None);
-                        }
-
-                        let value = match iter.next().unwrap() {
-                            x @ &StringLiteral(_) |
-                            x @ &NumberLiteral(_) |
-                            x @ &BooleanLiteral(_) => Argument::Val(try!(Value::from_token(x))),
-                            &Identifier(ref v) => Argument::Var(Variable::new(v)),
-                            x => {
-                                return Error::parser("a string | number | boolean | identifier",
-                                                     Some(x))
-                            }
-                        };
-                        named_args.push((v.to_string(), value));
-                    }
-                    _ => args.push(Argument::Var(Variable::new(v))),
-                }
-            }
-            x => {
-                return Error::parser("a comma or a pipe", Some(x));
-            }
-        }
-
-        // ensure that the next token is either a Comma or a Pipe
-        match iter.peek() {
-            Some(&&Comma) => {
-                let _ = iter.next().unwrap();
-                continue;
-            }
-            None => break,
-            _ => {
-                return Error::parser("a comma or a pipe", Some(iter.next().unwrap()));
-            }
-        }
-    }
-
-    Ok((args, named_args))
 }
 
 // a tag can be either a single-element tag or a block, which can contain other
@@ -360,7 +346,7 @@ mod test {
             let tokens = granularize("abc | def: a: | toto").unwrap();
             let results = parse_output(&tokens);
             assert_eq!(results.unwrap_err().to_string(),
-                       "Parsing error: Expected a string | number | boolean | identifier, found nothing");
+                       "Parsing error: Expected a string | number | boolean | identifier, found |");
 
             let tokens = granularize("abc | def: a:,").unwrap();
             let results = parse_output(&tokens);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -90,14 +90,14 @@ fn parse_filter(tokens: &[Token]) -> Result<FilterPrototype> {
     };
 
     if let None = iter.peek() {
-        return Ok(FilterPrototype::new(name, vec![]))
+        return Ok(FilterPrototype::new(name, vec![], vec![]))
     }
 
     try!(expect(&mut iter, &Colon));
 
     let args = parse_positional_args(&mut iter)?;
 
-    Ok(FilterPrototype::new(name, args))
+    Ok(FilterPrototype::new(name, args, vec![]))
 }
 
 fn parse_positional_args(iter: &mut Peekable<Iter<Token>>) -> Result<Vec<Argument>> {
@@ -315,7 +315,7 @@ mod test {
 
             let result = parse_output(&tokens);
             assert_eq!(result.unwrap_err().to_string(),
-            "Parsing error: Expected a comma, a pipe, or a colon, found blabla");
+                       "Parsing error: Expected a colon, found ','");
         }
 
         #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -226,7 +226,7 @@ pub struct BlockSplit<'a> {
 /// when it finds a delimter at the top level of the token stream,
 /// ignoring any it finds in nested blocks.
 ///
-/// Returns a slice contaiing all elements before the delimiter, and
+/// Returns a slice containing all elements before the delimiter, and
 /// an optional `BlockSplit` struct describing the delimiter and
 /// trailing elements.
 pub fn split_block<'a>(tokens: &'a [Element],
@@ -277,18 +277,18 @@ mod test {
 
         #[test]
         fn parses_filters() {
-            let tokens = granularize("abc | def:'1',2,'3' | blabla").unwrap();
+            let tokens = granularize("abc | def:'1',2,'3',a:'b', b:'c' | blabla").unwrap();
 
             let result = parse_output(&tokens);
             assert_eq!(result.unwrap(),
                        Output::new(Argument::Var(Variable::new("abc")),
                                    vec![FilterPrototype::new("def",
                                                              vec![
-                                                                 Argument::Val(Value::str("1")),
-                                                                 Argument::Val(Value::Num(2.0)),
-                                                                 Argument::Val(Value::str("3")),
-                    ]),
-                                        FilterPrototype::new("blabla", vec![])]));
+                                         Argument::Val(Value::str("1")),
+                                         Argument::Val(Value::Num(2.0)),
+                                         Argument::Val(Value::str("3")),
+                    ], vec![("a".to_string(), Argument::Val(Value::str("b"))), ("b".to_string(), Argument::Val(Value::str("c")))]),
+                                        FilterPrototype::new("blabla", vec![], vec![])]));
         }
 
         #[test]
@@ -307,6 +307,15 @@ mod test {
             let result = parse_output(&tokens);
             assert_eq!(result.unwrap_err().to_string(),
                        "Parsing error: Expected a comma or a pipe, found blabla");
+        }
+
+        #[test]
+        fn fails_on_positional_args_following_named_args() {
+            let tokens = granularize("abc | def:'1',a: blabla, 'a'").unwrap();
+
+            let result = parse_output(&tokens);
+            assert_eq!(result.unwrap_err().to_string(),
+            "Parsing error: Expected a comma, a pipe, or a colon, found blabla");
         }
 
         #[test]


### PR DESCRIPTION
Fixed #92

This PR adds named arguments to filters, much like Shopify/liquid does; using a 3rd argument to `FilterPrototype`.