### PR TITLE
fix(CI): Switch to `cargo-travis`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ script:
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then (! which cargo-clippy || cargo clippy -- --version) fi
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then (! which cargo-clippy || cargo clippy --features "cli serde serde_yaml serde_json") fi
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then (cargo bench --features "cli serde serde_yaml serde_json") fi
+  - if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then (cargo doc --no-deps --all-features) fi
   - cargo fmt -- --version
   - cargo fmt -- --write-mode=diff
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rust:
   - nightly
 
 install:
-  - travis_wait cargo install rustfmt --force --vers 0.8.3
+  - if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then (travis_wait cargo install rustfmt --force --vers 0.8.3) fi
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then (cargo install clippy --force || true) fi
   - export PATH=$HOME/.cargo/bin:$PATH
 
@@ -21,8 +21,8 @@ script:
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then (! which cargo-clippy || cargo clippy --features "cli serde serde_yaml serde_json") fi
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then (cargo bench --features "cli serde serde_yaml serde_json") fi
   - if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then (cargo doc --no-deps --all-features) fi
-  - cargo fmt -- --version
-  - cargo fmt -- --write-mode=diff
+  - if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then (cargo fmt -- --version) fi
+  - if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then (cargo fmt -- --write-mode=diff) fi
 
 # Note: this will kill the build of we call `set -e` like trust
 after_success: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rust:
   - nightly
 
 install:
+  - which cargo-coveralls || cargo install cargo-travis
   - if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then (travis_wait cargo install rustfmt --force --vers 0.8.3) fi
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then (cargo install clippy --force || true) fi
   - export PATH=$HOME/.cargo/bin:$PATH
@@ -24,26 +25,20 @@ script:
   - if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then (cargo fmt -- --version) fi
   - if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then (cargo fmt -- --write-mode=diff) fi
 
-# Note: this will kill the build of we call `set -e` like trust
-after_success: |
-  [ $TRAVIS_RUST_VERSION = stable ] &&
-  wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
-  tar xzf master.tar.gz && mkdir kcov-master/build && cd kcov-master/build && cmake .. && make && make install DESTDIR=../tmp && cd ../.. &&
-  ls target/debug &&
-  ./kcov-master/tmp/usr/local/bin/kcov --exclude-pattern=/.cargo target/kcov target/debug/fixtures-* &&
-  ./kcov-master/tmp/usr/local/bin/kcov --exclude-pattern=/.cargo target/kcov target/debug/filters-* &&
-  ./kcov-master/tmp/usr/local/bin/kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/liquid-*
+after_success:
+  - cargo --only stable coveralls
 
 addons:
   apt:
     packages:
-      # Needed for kcov
+      # necessary for `cargo coveralls`
       - libcurl4-openssl-dev
       - libelf-dev
       - libdw-dev
-      - cmake
-      - gcc
       - binutils-dev
+      - cmake
+    sources:
+      - kalakris-cmake
 
 cache:
   apt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script:
   - cargo test  --verbose --features "cli serde serde_yaml serde_json"
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then (! which cargo-clippy || cargo clippy -- --version) fi
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then (! which cargo-clippy || cargo clippy --features "cli serde serde_yaml serde_json") fi
+  - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then (cargo bench --features "cli serde serde_yaml serde_json") fi
   - cargo fmt -- --version
   - cargo fmt -- --write-mode=diff
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,16 @@ script:
   - cargo fmt -- --version
   - cargo fmt -- --write-mode=diff
 
+# Note: this will kill the build of we call `set -e` like trust
+after_success: |
+  [ $TRAVIS_RUST_VERSION = stable ] &&
+  wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
+  tar xzf master.tar.gz && mkdir kcov-master/build && cd kcov-master/build && cmake .. && make && make install DESTDIR=../tmp && cd ../.. &&
+  ls target/debug &&
+  ./kcov-master/tmp/usr/local/bin/kcov --exclude-pattern=/.cargo target/kcov target/debug/fixtures-* &&
+  ./kcov-master/tmp/usr/local/bin/kcov --exclude-pattern=/.cargo target/kcov target/debug/filters-* &&
+  ./kcov-master/tmp/usr/local/bin/kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/liquid-*
+
 addons:
   apt:
     packages:
@@ -38,20 +48,9 @@ addons:
 cache:
   apt: true
   cargo: true
-
 before_cache:
     # Travis can't cache files that are not readable by "others"
     - chmod -R a+r $HOME/.cargo
-
-# Note: this will kill the build of we call `set -e` like trust
-after_success: |
-  [ $TRAVIS_RUST_VERSION = stable ] &&
-  wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
-  tar xzf master.tar.gz && mkdir kcov-master/build && cd kcov-master/build && cmake .. && make && make install DESTDIR=../tmp && cd ../.. &&
-  ls target/debug &&
-  ./kcov-master/tmp/usr/local/bin/kcov --exclude-pattern=/.cargo target/kcov target/debug/fixtures-* &&
-  ./kcov-master/tmp/usr/local/bin/kcov --exclude-pattern=/.cargo target/kcov target/debug/filters-* &&
-  ./kcov-master/tmp/usr/local/bin/kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/liquid-*
 
 notifications:
   email:


### PR DESCRIPTION
- Hopefully `cargo coveralls` from `cargo-travis` will fix #107
- rustfmt is now stable-only to reduce overall build time
- Do test build of docs.  Eventually we'll also want to setup upload
- Enable `bench`