### PR TITLE
feat(value): Add null value

### DIFF
--- a/src/filters.rs
+++ b/src/filters.rs
@@ -849,6 +849,7 @@ pub fn default(input: &Value, args: &[Value]) -> FilterResult {
         Array(ref a) => a.is_empty(),
         Bool(b) => !b,
         Num(_) => false,
+        Value::Nil => true,
     };
 
     if use_default {

--- a/src/value.rs
+++ b/src/value.rs
@@ -16,6 +16,7 @@ pub enum Value {
     Str(String),
     Array(Array),
     Object(Object),
+    Nil,
 }
 
 /// Type representing a Liquid array, payload of the `Value::Array` variant
@@ -132,6 +133,7 @@ impl PartialEq<Value> for Value {
             (&Value::Str(ref x), &Value::Str(ref y)) => x == y,
             (&Value::Array(ref x), &Value::Array(ref y)) => x == y,
             (&Value::Object(ref x), &Value::Object(ref y)) => x == y,
+            (&Value::Nil, &Value::Nil) => true,
 
             // encode Ruby truthiness; all values except false and nil
             // are true, and we don't have a notion of nil
@@ -164,6 +166,7 @@ impl ToString for Value {
             Value::Num(ref x) => x.to_string(),
             Value::Bool(ref x) => x.to_string(),
             Value::Str(ref x) => x.to_owned(),
+            Value::Nil => "".to_owned(),
             Value::Array(ref x) => {
                 let arr: Vec<String> = x.iter().map(|v| v.to_string()).collect();
                 arr.join(", ")
@@ -267,6 +270,11 @@ mod test {
     fn numbers_have_ruby_truthiness() {
         assert_eq!(TRUE, Value::Num(42f32));
         assert_eq!(TRUE, Value::Num(0f32));
+    }
+
+    #[test]
+    fn nil_equality() {
+        assert_eq!(Value::Nil, Value::Nil);
     }
 
     #[test]

--- a/tests/value.rs
+++ b/tests/value.rs
@@ -67,6 +67,22 @@ pub fn deserialize_bool() {
 }
 
 #[test]
+pub fn serialize_nil() {
+    let actual = liquid::Value::Nil;
+    let actual = serde_yaml::to_string(&actual).unwrap();
+    assert_diff!(&actual, "---\n~", "", 0);
+}
+
+#[test]
+pub fn deserialize_nil() {
+    let actual: liquid::Value = serde_yaml::from_str("---\n~").unwrap();
+    assert_eq!(actual, liquid::Value::Nil);
+
+    let actual: liquid::Value = serde_yaml::from_str("---\n- ").unwrap();
+    assert_eq!(actual, liquid::Value::Array(vec![liquid::Value::Nil]));
+}
+
+#[test]
 pub fn serialize_str() {
     let actual = liquid::Value::str("Hello");
     let actual = serde_yaml::to_string(&actual).unwrap();


### PR DESCRIPTION
This adds the missing null type to the values of liquid, thus allowing to
parse serde_json and others containing null-values in the data directly