### PR TITLE
Add indexed access to context values

### DIFF
--- a/src/filters.rs
+++ b/src/filters.rs
@@ -535,7 +535,7 @@ pub fn map(input: &Value, args: &[Value]) -> FilterResult {
         .filter_map(|v| {
                         v.as_object()
                             .map(|o| o.get(&property).cloned())
-                            .map_or(None, |o| o)
+                            .and_then(|o| o)
                     })
         .collect();
     Ok(Value::Array(result))

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -138,9 +138,8 @@ pub fn granularize(block: &str) -> Result<Vec<Token>> {
                         "contains" => Comparison(Contains),
                         ".." => DotDot,
 
-                        x
-                            if SINGLE_STRING_LITERAL.is_match(x) ||
-                               DOUBLE_STRING_LITERAL.is_match(x) => {
+                        x if SINGLE_STRING_LITERAL.is_match(x) ||
+                             DOUBLE_STRING_LITERAL.is_match(x) => {
                             StringLiteral(x[1..x.len() - 1].to_owned())
                         }
                         x if NUMBER_LITERAL.is_match(x) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ mod filters;
 mod value;
 mod variable;
 mod context;
+mod path;
 
 /// A trait for creating custom tags. This is a simple type alias for a function.
 ///

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -9,6 +9,7 @@ use value::Value;
 use variable::Variable;
 use text::Text;
 use output::{Output, FilterPrototype, Argument};
+use path::IdentifierPath;
 use token::Token;
 use token::Token::*;
 use lexer::Element::{self, Expression, Tag, Raw};
@@ -41,6 +42,11 @@ pub fn parse(elements: &[Element], options: &LiquidOptions) -> Result<Vec<Box<Re
 // creates an expression, which wraps everything that gets rendered
 fn parse_expression(tokens: &[Token], options: &LiquidOptions) -> Result<Box<Renderable>> {
     match tokens[0] {
+        Identifier(ref x) if tokens.len() > 1 && (tokens[1] == Dot || tokens[1] == OpenSquare) => {
+            let mut result = IdentifierPath::new(x.clone());
+            try!(result.append_indexes(&tokens[1..]));
+            return Ok(Box::new(result));
+        }
         Identifier(ref x) if options.tags.contains_key(x) => {
             options.tags[x](x, &tokens[1..], options)
         }
@@ -89,12 +95,12 @@ pub fn parse_output(tokens: &[Token]) -> Result<Output> {
         while iter.peek() != None && iter.peek().unwrap() != &&Pipe {
             match iter.next().unwrap() {
                 x @ &StringLiteral(_) |
-                x @ &NumberLiteral(_) |
-                x @ &BooleanLiteral(_) => args.push(Argument::Val(try!(Value::from_token(x)))),
-                &Identifier(ref v) => args.push(Argument::Var(Variable::new(v))),
-                x => {
-                    return Error::parser("a comma or a pipe", Some(x));
-                }
+                    x @ &NumberLiteral(_) |
+                    x @ &BooleanLiteral(_) => args.push(Argument::Val(try!(Value::from_token(x)))),
+                    &Identifier(ref v) => args.push(Argument::Var(Variable::new(v))),
+                    x => {
+                        return Error::parser("a comma or a pipe", Some(x));
+                    }
             }
 
             // ensure that the next token is either a Comma or a Pipe
@@ -123,55 +129,55 @@ pub fn parse_output(tokens: &[Token]) -> Result<Output> {
 fn parse_tag(iter: &mut Iter<Element>,
              tokens: &[Token],
              options: &LiquidOptions)
-             -> Result<Box<Renderable>> {
-    let tag = &tokens[0];
-    match *tag {
-        // is a tag
-        Identifier(ref x) if options.tags.contains_key(x) => {
-            options.tags[x](x, &tokens[1..], options)
-        }
-
-        // is a block
-        Identifier(ref x) if options.blocks.contains_key(x) => {
-            // Collect all the inner elements of this block until we find a
-            // matching "end<blockname>" tag. Note that there may be nested blocks
-            // of the same type (and hence have the same closing delimiter) *inside*
-            // the body of the block, which would premauturely stop the element
-            // collection early if we did a nesting-unaware search for the
-            // closing tag.
-            //
-            // The whole nesting count machinery below is to ensure we only stop
-            // collecting elements when we have an un-nested closing tag.
-
-            let end_tag = Identifier("end".to_owned() + x);
-            let mut children = vec![];
-            let mut nesting_depth = 0;
-            for t in iter {
-                if let Tag(ref tokens, _) = *t {
-                    match tokens[0] {
-                        ref n if n == tag => {
-                            nesting_depth += 1;
-                        }
-                        ref n if n == &end_tag && nesting_depth > 0 => {
-                            nesting_depth -= 1;
-                        }
-                        ref n if n == &end_tag && nesting_depth == 0 => break,
-                        _ => {}
-                    }
-                };
-                children.push(t.clone())
+    -> Result<Box<Renderable>> {
+        let tag = &tokens[0];
+        match *tag {
+            // is a tag
+            Identifier(ref x) if options.tags.contains_key(x) => {
+                options.tags[x](x, &tokens[1..], options)
             }
-            options.blocks[x](x, &tokens[1..], &children, options)
-        }
 
-        ref x => Err(Error::Parser(format!("parse_tag: {:?} not implemented", x))),
+            // is a block
+            Identifier(ref x) if options.blocks.contains_key(x) => {
+                // Collect all the inner elements of this block until we find a
+                // matching "end<blockname>" tag. Note that there may be nested blocks
+                // of the same type (and hence have the same closing delimiter) *inside*
+                // the body of the block, which would premauturely stop the element
+                // collection early if we did a nesting-unaware search for the
+                // closing tag.
+                //
+                // The whole nesting count machinery below is to ensure we only stop
+                // collecting elements when we have an un-nested closing tag.
+
+                let end_tag = Identifier("end".to_owned() + x);
+                let mut children = vec![];
+                let mut nesting_depth = 0;
+                for t in iter {
+                    if let Tag(ref tokens, _) = *t {
+                        match tokens[0] {
+                            ref n if n == tag => {
+                                nesting_depth += 1;
+                            }
+                            ref n if n == &end_tag && nesting_depth > 0 => {
+                                nesting_depth -= 1;
+                            }
+                            ref n if n == &end_tag && nesting_depth == 0 => break,
+                            _ => {}
+                        }
+                    };
+                    children.push(t.clone())
+                }
+                options.blocks[x](x, &tokens[1..], &children, options)
+            }
+
+            ref x => Err(Error::Parser(format!("parse_tag: {:?} not implemented", x))),
+        }
     }
-}
 
 /// Confirm that the next token in a token stream is what you want it
 /// to be. The token iterator is moved to the next token in the stream.
 pub fn expect<'a, T>(tokens: &mut T, expected: &Token) -> Result<&'a Token>
-    where T: Iterator<Item = &'a Token>
+where T: Iterator<Item = &'a Token>
 {
     match tokens.next() {
         Some(x) if x == expected => Ok(x),
@@ -194,9 +200,9 @@ pub fn consume_value_token(tokens: &mut Iter<Token>) -> Result<Token> {
 pub fn value_token(t: Token) -> Result<Token> {
     match t {
         v @ StringLiteral(_) |
-        v @ NumberLiteral(_) |
-        v @ BooleanLiteral(_) |
-        v @ Identifier(_) => Ok(v),
+            v @ NumberLiteral(_) |
+            v @ BooleanLiteral(_) |
+            v @ Identifier(_) => Ok(v),
         x => Error::parser("string | number | boolean | identifier", Some(&x)),
     }
 }
@@ -218,7 +224,7 @@ pub struct BlockSplit<'a> {
 pub fn split_block<'a>(tokens: &'a [Element],
                        delimiters: &[&str],
                        options: &LiquidOptions)
-                       -> (&'a [Element], Option<BlockSplit<'a>>) {
+-> (&'a [Element], Option<BlockSplit<'a>>) {
     // construct a fast-lookup cache of the delimiters, as we're going to be
     // consulting the delimiter list a *lot*.
     let delims: HashSet<&str> = HashSet::from_iter(delimiters.iter().map(|x| *x));
@@ -273,12 +279,12 @@ mod test {
                     vec![FilterPrototype::new(
                         "def",
                         vec![Argument::Val(Value::str("1")),
-                             Argument::Val(Value::Num(2.0)),
-                             Argument::Val(Value::str("3"))]
-                    ),
-                         FilterPrototype::new("blabla", vec![])],
-                )
-            );
+                        Argument::Val(Value::Num(2.0)),
+                        Argument::Val(Value::str("3"))]
+                        ),
+                        FilterPrototype::new("blabla", vec![])],
+                        )
+                );
         }
 
         #[test]
@@ -287,7 +293,7 @@ mod test {
 
             let result = parse_output(&tokens);
             assert_eq!(result.unwrap_err().to_string(),
-                       "Parsing error: Expected an identifier, found 1");
+            "Parsing error: Expected an identifier, found 1");
         }
 
         #[test]
@@ -296,7 +302,7 @@ mod test {
 
             let result = parse_output(&tokens);
             assert_eq!(result.unwrap_err().to_string(),
-                       "Parsing error: Expected a comma or a pipe, found blabla");
+            "Parsing error: Expected a comma or a pipe, found blabla");
         }
 
         #[test]
@@ -305,7 +311,7 @@ mod test {
 
             let result = parse_output(&tokens);
             assert_eq!(result.unwrap_err().to_string(),
-                       "Parsing error: Expected :, found 1");
+            "Parsing error: Expected :, found 1");
         }
     }
 
@@ -335,7 +341,7 @@ mod test {
             // top level, which is where it should split.
             let tokens = tokenize("{% comment %}A{%endcomment%} bunch of {{text}} with {{no}} \
                                    else tag")
-                .unwrap();
+                         .unwrap();
 
             // note that we need an options block that has been initilaised with
             // the supported block list; otherwise the split_tag function won't know
@@ -354,16 +360,16 @@ mod test {
             // A stream of tokens with lots of `else`s in it, but only one at the
             // top level, which is where it should split.
             let tokens = tokenize(concat!("{% for x in (1..10) %}",
-                                          "{% if x == 2 %}",
-                                          "{% for y (2..10) %}{{y}}{% else %} zz {% endfor %}",
-                                          "{% else %}",
-                                          "c",
-                                          "{% endif %}",
-                                          "{% else %}",
-                                          "something",
-                                          "{% endfor %}",
-                                          "{% else %}",
-                                          "trailing tags"))
+            "{% if x == 2 %}",
+            "{% for y (2..10) %}{{y}}{% else %} zz {% endfor %}",
+            "{% else %}",
+            "c",
+            "{% endif %}",
+            "{% else %}",
+            "something",
+            "{% endfor %}",
+            "{% else %}",
+            "trailing tags"))
                 .unwrap();
 
             // note that we need an options block that has been initilaised with
@@ -377,8 +383,8 @@ mod test {
                     assert_eq!(split.args, &[Identifier("else".to_owned())]);
                     assert_eq!(split.trailing,
                                &[Tag(vec![Identifier("else".to_owned())],
-                                     "{% else %}".to_owned()),
-                                 Raw("trailing tags".to_owned())]);
+                               "{% else %}".to_owned()),
+                               Raw("trailing tags".to_owned())]);
                 }
                 None => panic!("split failed"),
             }

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,0 +1,149 @@
+use Renderable;
+use value::Value;
+use context::Context;
+use token::Token;
+use token::Token::*;
+use error::{Error, Result};
+
+#[derive(Debug)]
+pub struct IdentifierPath {
+    value: String,
+    indexes: Vec<Value>,
+}
+
+impl Renderable for IdentifierPath {
+    fn render(&self, context: &mut Context) -> Result<Option<String>> {
+        println!("{:?}", self);
+        let value = context
+            .get_val(&self.value)
+            .ok_or(Error::Render(
+                format!("{} not found in context", self.value),
+            ))?
+            .clone();
+
+        let mut counter = self.indexes.len();
+        let result = self.indexes
+            .iter()
+            .fold(Ok(&value), |value, index| {
+                // go through error
+                let value = if let Ok(ref value) = value {
+                    value
+                } else {
+                    return value
+                };
+                counter-=1;
+       match (value, index) {
+            (&&Value::Array(ref value), &Value::Num(ref x)) => {
+                if (*x != 0f32 && !x.is_normal()) // only is_normal is not enough, because zero is not counted normal
+                    || *x < 0f32 ||
+                    x.round() > (::std::usize::MAX as f32)
+                {
+                    return Error::renderer("bad array index");
+                }
+                let idx = x.round() as usize;
+                let value = value.get(idx).ok_or(Error::Render(
+                    "index out of range".to_string(),
+                ))?;
+                Ok(&value)
+            }
+            (&&Value::Array(_), _) => Error::renderer("bad array index type"),
+            (&&Value::Object(ref value), &Value::Str(ref x)) => {
+                let value = value.get(x).ok_or(Error::Render(
+                    "object element not found".to_string(),
+                ))?;
+                Ok(&value)
+            }
+            (&&Value::Object(_), _) => Error::renderer("bad object index"),
+            (&value, _) if counter == 0  => Ok(value),
+            _ => Error::renderer("non-indexable element found while indexable expected")
+        }
+        });
+
+        match result {
+            Ok(result) => result.render(context),
+            Err(e) => Error::renderer(&format!("rendering error: {}", e)),
+        }
+    }
+}
+
+impl IdentifierPath {
+    pub fn new(value: String) -> Self {
+        Self {
+            value: value,
+            indexes: Vec::new(),
+        }
+    }
+    pub fn append_indexes(&mut self, tokens: &[Token]) -> Result<()> {
+        let rest = match tokens[0] {
+            Dot if tokens.len() > 1 => {
+                match tokens[1] {
+                    Identifier(ref x) => self.indexes.push(Value::Str(x.clone())),
+                    _ => {
+                        return Error::parser("identifier", Some(&tokens[0]));
+                    }
+                };
+                2
+            }
+            OpenSquare if tokens.len() > 2 => {
+                let index = match tokens[1] {
+                    StringLiteral(ref x) => Value::Str(x.clone()),
+                    NumberLiteral(ref x) => Value::Num(*x),
+                    _ => {
+                        return Error::parser("number | string", Some(&tokens[0]));
+                    }
+                };
+                self.indexes.push(index);
+
+                if tokens[2] != CloseSquare {
+                    return Error::parser("]", Some(&tokens[1]));
+                }
+                3
+            }
+            _ => return Ok(()),
+        };
+
+        if tokens.len() > rest {
+            self.append_indexes(&tokens[rest..])
+        } else {
+            Ok(())
+        }
+    }
+}
+#[cfg(test)]
+mod test {
+    use value::Value;
+    use parse;
+    use Renderable;
+    use Context;
+    use LiquidOptions;
+    use std::collections::HashMap;
+
+    #[test]
+    fn identifier_path() {
+        let options = LiquidOptions::with_known_blocks();
+        let template = concat!(
+            "array: {{ test_a[0] }}\n",
+            "complex_dot: {{ test_a[0].test_h }}\n",
+            "complex_string: {{ test_a[0][\"test_h\"] }}\n"
+        );
+
+        let mut context = Context::new();
+        let mut internal = HashMap::new();
+        internal.insert("test_h".to_string(), Value::Num(5f32));
+
+        let test = Value::Array(vec![Value::Object(internal)]);
+        context.set_val("test_a", test);
+
+        let template = parse(template, options).unwrap();
+        assert_eq!(
+            template.render(&mut context).unwrap(),
+            Some(
+                concat!(
+                    "array: test_h: 5\n",
+                    "complex_dot: 5\n",
+                    "complex_string: 5\n"
+                ).to_owned(),
+            )
+        );
+    }
+}


### PR DESCRIPTION
This fixes #127 adding feature to access identifiers via index
- array indexes `arr[0]` are supported
- object indexes `obj["child"]` are supported and interchangeable with `obj.child`
- index expressions are not yet supported.

Checklist
- [x] Tests created for any new feature or regression tests for bugfixes.
- [x] `cargo test` succeeds
- [x] `rustup run nightly cargo clippy` succeeds
- [x] `cargo fmt -- --write-mode=diff` succeeds