### PR TITLE
feat: Make LiquidOptions cloneable

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ designated name. You will have to specify a function or closure that will
 then return a `Renderable` object to do the rendering.
 
 ```rust
-use liquid::{LiquidOptions, Renderable, Context, Error};
+use liquid::{LiquidOptions, Renderable, Context, Error, FnTagParser};
 
 // our renderable object
 struct Shout {
@@ -90,9 +90,9 @@ impl Renderable for Shout {
 let mut options : LiquidOptions = Default::default();
 
 // initialize the tag and pass a closure that will return a new Shout renderable
-options.register_tag("shout", Box::new(|_tag_name, arguments, _options| {
+options.register_tag("shout", Box::new(FnTagParser::new(|_tag_name, arguments, _options| {
     Ok(Box::new(Shout{text: arguments[0].to_string()}))
-}));
+})));
 
 // use our new tag
 let template = liquid::parse("{{shout 'hello'}}", options).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,11 +226,30 @@ pub trait Renderable: Send + Sync {
     fn render(&self, context: &mut Context) -> Result<Option<String>>;
 }
 
-pub trait TemplateRepository {
+pub trait TemplateRepository: Send + Sync + TemplateRepositoryClone {
     fn read_template(&self, path: &str) -> Result<String>;
 }
 
+pub trait TemplateRepositoryClone {
+    fn clone_box(&self) -> Box<TemplateRepository>;
+}
+
+impl<T> TemplateRepositoryClone for T
+    where T: 'static + TemplateRepository + Clone
+{
+    fn clone_box(&self) -> Box<TemplateRepository> {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for Box<TemplateRepository> {
+    fn clone(&self) -> Box<TemplateRepository> {
+        self.clone_box()
+    }
+}
+
 /// `TemplateRepository` to load files relative to the root
+#[derive(Clone)]
 pub struct LocalTemplateRepository {
     root: PathBuf,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,6 +276,7 @@ impl TemplateRepository for LocalTemplateRepository {
 }
 
 /// Options that `liquid::parse` takes
+#[derive(Clone)]
 pub struct LiquidOptions {
     /// Holds all custom block-size tags
     pub blocks: HashMap<String, Box<ParseBlock>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,13 +166,31 @@ impl ParseTag for FnTagParser {
 /// of the block, the argument [Tokens](lexer/enum.Token.html) passed to
 /// the block, a Vec of all [Elements](lexer/enum.Element.html) inside the block and
 /// the global [`LiquidOptions`](struct.LiquidOptions.html).
-pub trait ParseBlock: Send + Sync {
+pub trait ParseBlock: Send + Sync + ParseBlockClone {
     fn parse(&self,
              tag_name: &str,
              arguments: &[Token],
              tokens: &[Element],
              options: &LiquidOptions)
              -> Result<Box<Renderable>>;
+}
+
+pub trait ParseBlockClone {
+    fn clone_box(&self) -> Box<ParseBlock>;
+}
+
+impl<T> ParseBlockClone for T
+    where T: 'static + ParseBlock + Clone
+{
+    fn clone_box(&self) -> Box<ParseBlock> {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for Box<ParseBlock> {
+    fn clone(&self) -> Box<ParseBlock> {
+        self.clone_box()
+    }
 }
 
 pub type FnParseBlock = fn(&str, &[Token], &[Element], &LiquidOptions) -> Result<Box<Renderable>>;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -48,7 +48,7 @@ fn parse_expression(tokens: &[Token], options: &LiquidOptions) -> Result<Box<Ren
             Ok(Box::new(result))
         }
         Identifier(ref x) if options.tags.contains_key(x) => {
-            options.tags[x](x, &tokens[1..], options)
+            options.tags[x].parse(x, &tokens[1..], options)
         }
         _ => {
             let output = try!(parse_output(tokens));
@@ -134,7 +134,7 @@ fn parse_tag(iter: &mut Iter<Element>,
     match *tag {
         // is a tag
         Identifier(ref x) if options.tags.contains_key(x) => {
-            options.tags[x](x, &tokens[1..], options)
+            options.tags[x].parse(x, &tokens[1..], options)
         }
 
         // is a block

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -167,7 +167,7 @@ fn parse_tag(iter: &mut Iter<Element>,
                 };
                 children.push(t.clone())
             }
-            options.blocks[x](x, &tokens[1..], &children, options)
+            options.blocks[x].parse(x, &tokens[1..], &children, options)
         }
 
         ref x => Err(Error::Parser(format!("parse_tag: {:?} not implemented", x))),

--- a/tests/custom_blocks.rs
+++ b/tests/custom_blocks.rs
@@ -38,7 +38,7 @@ fn run() {
     }
 
     let mut options: LiquidOptions = Default::default();
-    options.register_tag("multiply", Box::new(multiply_tag));
+    options.register_tag("multiply", Box::new(liquid::FnTagParser::new(multiply_tag)));
 
     let template = parse("wat\n{{hello}}\n{{multiply 5 3}}{%raw%}{{multiply 5 3}}{%endraw%} test",
                          options)


### PR DESCRIPTION
This required making `ParseBlock` (formerly `Block) and `ParseTag` (formerly `Tag`) cloneable.

Obviously, this breaks compatibility in multiple ways.  This is needed for a cobalt feature which will consolidate the creation of `LiquidOptions` but it still needs to be cloneable because `liquid::parse` takes ownership.

This is a tiny steps towards #95