### PR TITLE
 fix(nil): Equality logic missed a case 

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -10,7 +10,7 @@ use compiler;
 use interpreter;
 use super::Template;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ParserBuilder {
     blocks: HashMap<String, compiler::BoxedBlockParser>,
     tags: HashMap<String, compiler::BoxedTagParser>,
@@ -113,11 +113,13 @@ impl ParserBuilder {
                     filters::url_encode as interpreter::FnFilterValue)
     }
 
+    /// Register non-standard filters
     #[cfg(not(feature = "extra-filters"))]
     pub fn extra_filters(self) -> Self {
         self
     }
 
+    /// Register non-standard filters
     #[cfg(feature = "extra-filters")]
     pub fn extra_filters(self) -> Self {
         self.filter("pluralize",
@@ -150,6 +152,7 @@ impl ParserBuilder {
         self
     }
 
+    /// Create a parser
     pub fn build(self) -> Parser {
         let Self {
             blocks,
@@ -169,7 +172,7 @@ impl ParserBuilder {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Parser {
     options: compiler::LiquidOptions,
     filters: HashMap<String, interpreter::BoxedValueFilter>,

--- a/src/tags/if_block.rs
+++ b/src/tags/if_block.rs
@@ -87,7 +87,7 @@ pub fn unless_block(_tag_name: &str,
                     tokens: &[Element],
                     options: &LiquidOptions)
                     -> Result<Box<Renderable>> {
-    let cond = try!(condition(arguments));
+    let cond = condition(arguments)?;
     Ok(Box::new(Conditional {
                     condition: cond,
                     mode: false,
@@ -101,7 +101,7 @@ pub fn if_block(_tag_name: &str,
                 tokens: &[Element],
                 options: &LiquidOptions)
                 -> Result<Box<Renderable>> {
-    let cond = try!(condition(arguments));
+    let cond = condition(arguments)?;
 
     let (leading_tokens, trailing_tokens) = split_block(&tokens[..], &["else", "elsif"], options);
     let if_false = match trailing_tokens {
@@ -201,6 +201,16 @@ mod test {
                            "{% else %}",
                            "nope",
                            "{% endif %}");
+
+        let tokens = compiler::tokenize(&text).unwrap();
+        let template = compiler::parse(&tokens, &options())
+            .map(interpreter::Template::new)
+            .unwrap();
+
+        let mut context = Context::new();
+        context.set_global_val("truthy", Value::Nil);
+        let output = template.render(&mut context).unwrap();
+        assert_eq!(output, Some("nope".to_owned()));
 
         let tokens = compiler::tokenize(&text).unwrap();
         let template = compiler::parse(&tokens, &options())

--- a/src/template.rs
+++ b/src/template.rs
@@ -12,6 +12,7 @@ pub struct Template {
 }
 
 impl Template {
+    /// Renders an instance of the Template, using the given globals.
     pub fn render(&self, globals: &Object) -> Result<String> {
         let mut data = interpreter::Context::new()
             .with_filters(self.filters.clone())

--- a/src/value/values.rs
+++ b/src/value/values.rs
@@ -147,8 +147,9 @@ impl PartialEq<Value> for Value {
             (&Value::Object(ref x), &Value::Object(ref y)) => x == y,
             (&Value::Nil, &Value::Nil) => true,
 
-            // encode Ruby truthiness; all values except false and nil
-            // are true, and we don't have a notion of nil
+            // encode Ruby truthiness: all values except false and nil are true
+            (&Value::Nil, &Value::Bool(b)) |
+            (&Value::Bool(b), &Value::Nil) => !b,
             (_, &Value::Bool(b)) |
             (&Value::Bool(b), _) => b,
 


### PR DESCRIPTION
In cobalt, this presented itself as `{if null_var}` evaluating as true.
Its sad we missed this case considering we added code for `Nil` right
before a comment about us not supporting `Nil`.