### PR TITLE
feat(if): Base if is an existence check

### DIFF
--- a/src/value/values.rs
+++ b/src/value/values.rs
@@ -187,6 +187,12 @@ impl Value {
     }
 }
 
+impl Default for Value {
+    fn default() -> Self {
+        Self::nil()
+    }
+}
+
 impl PartialEq<Value> for Value {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {


### PR DESCRIPTION
A couple releases ago, I made liquid consistently treat non-existent
variables as a hard error.

To help with checking for variable existence, `contains` operator was
finally implemented.  That doesn't help with globals though.

So to support globals, I'm relaxing the non-existence restrictions
within a unary-if.

ie you can now do
```
{% if title %}
{{ title }}
{% endif %}
```

Fixes cobalt-org/cobalt.rs#363