### PR TITLE
Upgrade to f64 floats

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ let template = liquid::ParserBuilder::with_liquid()
     .parse("Liquid! {{num | minus: 2}}").unwrap();
 
 let mut globals = liquid::Object::new();
-globals.insert("num".to_owned(), liquid::Value::scalar(4f32));
+globals.insert("num".to_owned(), liquid::Value::scalar(4f64));
 
 let output = template.render(&globals).unwrap();
 assert_eq!(output, "Liquid! 2".to_string());

--- a/src/compiler/lexer.rs
+++ b/src/compiler/lexer.rs
@@ -156,7 +156,7 @@ pub fn granularize(block: &str) -> Result<Vec<Token>> {
             x if NUMBER_LITERAL.is_match(x) => x.parse::<i32>()
                 .map(Token::IntegerLiteral)
                 .unwrap_or_else(|_e| {
-                    let x = x.parse::<f32>()
+                    let x = x.parse::<f64>()
                         .expect("matches to NUMBER_LITERAL are parseable as floats");
                     Token::FloatLiteral(x)
                 }),
@@ -517,8 +517,8 @@ mod test {
             granularize("multiply 5.5 3.2434").unwrap(),
             vec![
                 Token::Identifier("multiply".to_owned()),
-                Token::FloatLiteral(5.5f32),
-                Token::FloatLiteral(3.2434f32),
+                Token::FloatLiteral(5.5f64),
+                Token::FloatLiteral(3.2434f64),
             ]
         );
         assert_eq!(

--- a/src/compiler/token.rs
+++ b/src/compiler/token.rs
@@ -47,7 +47,7 @@ pub enum Token {
     Identifier(String),
     StringLiteral(String),
     IntegerLiteral(i32),
-    FloatLiteral(f32),
+    FloatLiteral(f64),
     BooleanLiteral(bool),
     DotDot,
     Comparison(ComparisonOperator),
@@ -135,12 +135,12 @@ mod test {
     fn evaluate_handles_number_literals() {
         let ctx = Context::new();
         assert_eq!(
-            Token::FloatLiteral(42f32)
+            Token::FloatLiteral(42f64)
                 .to_arg()
                 .unwrap()
                 .evaluate(&ctx)
                 .unwrap(),
-            Value::scalar(42f32)
+            Value::scalar(42f64)
         );
 
         let ctx = Context::new();
@@ -179,14 +179,14 @@ mod test {
     #[test]
     fn evaluate_handles_identifiers() {
         let mut ctx = Context::new();
-        ctx.set_global_val("var0", Value::scalar(42f32));
+        ctx.set_global_val("var0", Value::scalar(42f64));
         assert_eq!(
             Token::Identifier("var0".to_owned())
                 .to_arg()
                 .unwrap()
                 .evaluate(&ctx)
                 .unwrap(),
-            Value::scalar(42f32)
+            Value::scalar(42f64)
         );
         assert!(
             Token::Identifier("nope".to_owned())

--- a/src/filters/date.rs
+++ b/src/filters/date.rs
@@ -106,8 +106,8 @@ mod tests {
     #[test]
     fn unit_date_bad_input_type() {
         assert_eq!(
-            unit!(date, Value::scalar(0f32), &[tos!("%Y-%m-%d")]),
-            Value::scalar(0f32)
+            unit!(date, Value::scalar(0f64), &[tos!("%Y-%m-%d")]),
+            Value::scalar(0f64)
         );
     }
 
@@ -137,7 +137,7 @@ mod tests {
             unit!(
                 date,
                 tos!("13 Jun 2016 02:30:00 +0300"),
-                &[Value::scalar(0f32)]
+                &[Value::scalar(0f64)]
             ),
             tos!("0")
         );
@@ -157,7 +157,7 @@ mod tests {
             failed!(
                 date,
                 tos!("13 Jun 2016 02:30:00 +0300"),
-                &[Value::scalar(0f32), Value::scalar(1f32)]
+                &[Value::scalar(0f64), Value::scalar(1f64)]
             ),
             FilterError::InvalidArgumentCount("expected at most 1, 2 given".to_owned())
         );
@@ -193,7 +193,7 @@ mod tests {
     #[test]
     #[cfg(feature = "extra-filters")]
     fn unit_date_in_tz_input_not_a_string() {
-        let input = &Value::scalar(0f32);
+        let input = &Value::scalar(0f64);
         let args = &[tos!("%Y-%m-%d %H:%M:%S %z"), Value::scalar(0i32)];
         let desired_result = FilterError::InvalidType("Invalid date format".to_owned());
         assert_eq!(failed!(date_in_tz, input, args), desired_result);
@@ -243,8 +243,8 @@ mod tests {
         let input = &tos!("13 Jun 2016 12:00:00 +0000");
         let args = &[
             tos!("%Y-%m-%d %H:%M:%S %z"),
-            Value::scalar(0f32),
-            Value::scalar(1f32),
+            Value::scalar(0f64),
+            Value::scalar(1f64),
         ];
         let desired_result =
             FilterError::InvalidArgumentCount("expected at most 2, 3 given".to_owned());

--- a/src/filters/html.rs
+++ b/src/filters/html.rs
@@ -217,7 +217,7 @@ mod tests {
     #[test]
     fn unit_newline_to_br_one_argument() {
         let input = &tos!("a\nb");
-        let args = &[Value::scalar(0f32)];
+        let args = &[Value::scalar(0f64)];
         let desired_result =
             FilterError::InvalidArgumentCount("expected at most 0, 1 given".to_owned());
         assert_eq!(failed!(newline_to_br, input, args), desired_result);

--- a/src/filters/math.rs
+++ b/src/filters/math.rs
@@ -167,9 +167,9 @@ mod tests {
 
     #[test]
     fn unit_abs() {
-        let input = Value::scalar(-1f32);
+        let input = Value::scalar(-1f64);
         let args = &[];
-        let desired_result = Value::scalar(1f32);
+        let desired_result = Value::scalar(1f64);
         assert_eq!(unit!(abs, input, args), desired_result);
     }
 
@@ -177,7 +177,7 @@ mod tests {
     fn unit_abs_positive_in_string() {
         let input = &tos!("42");
         let args = &[];
-        let desired_result = Value::scalar(42f32);
+        let desired_result = Value::scalar(42f64);
         assert_eq!(unit!(abs, input, args), desired_result);
     }
 
@@ -191,8 +191,8 @@ mod tests {
 
     #[test]
     fn unit_abs_one_argument() {
-        let input = &Value::scalar(-1f32);
-        let args = &[Value::scalar(0f32)];
+        let input = &Value::scalar(-1f64);
+        let args = &[Value::scalar(0f64)];
         let desired_result =
             FilterError::InvalidArgumentCount("expected at most 0, 1 given".to_owned());
         assert_eq!(failed!(abs, input, args), desired_result);
@@ -201,15 +201,15 @@ mod tests {
     #[test]
     fn unit_abs_shopify_liquid() {
         // Three tests from https://shopify.github.io/liquid/filters/abs/
-        assert_eq!(unit!(abs, Value::scalar(-17f32), &[]), Value::scalar(17f32));
-        assert_eq!(unit!(abs, Value::scalar(4f32), &[]), Value::scalar(4f32));
-        assert_eq!(unit!(abs, tos!("-19.86"), &[]), Value::scalar(19.86f32));
+        assert_eq!(unit!(abs, Value::scalar(-17f64), &[]), Value::scalar(17f64));
+        assert_eq!(unit!(abs, Value::scalar(4f64), &[]), Value::scalar(4f64));
+        assert_eq!(unit!(abs, tos!("-19.86"), &[]), Value::scalar(19.86f64));
     }
     #[test]
     fn unit_plus() {
         assert_eq!(
-            unit!(plus, Value::scalar(2f32), &[Value::scalar(1f32)]),
-            Value::scalar(3f32)
+            unit!(plus, Value::scalar(2f64), &[Value::scalar(1f64)]),
+            Value::scalar(3f64)
         );
         assert_eq!(
             unit!(plus, Value::scalar(21.5), &[Value::scalar(2.25)]),
@@ -220,8 +220,8 @@ mod tests {
     #[test]
     fn unit_minus() {
         assert_eq!(
-            unit!(minus, Value::scalar(2f32), &[Value::scalar(1f32)]),
-            Value::scalar(1f32)
+            unit!(minus, Value::scalar(2f64), &[Value::scalar(1f64)]),
+            Value::scalar(1f64)
         );
         assert_eq!(
             unit!(minus, Value::scalar(21.5), &[Value::scalar(1.25)]),
@@ -232,8 +232,8 @@ mod tests {
     #[test]
     fn unit_times() {
         assert_eq!(
-            unit!(times, Value::scalar(2f32), &[Value::scalar(3f32)]),
-            Value::scalar(6f32)
+            unit!(times, Value::scalar(2f64), &[Value::scalar(3f64)]),
+            Value::scalar(6f64)
         );
         assert_eq!(
             unit!(times, Value::scalar(8.5), &[Value::scalar(0.5)]),
@@ -247,32 +247,32 @@ mod tests {
     #[test]
     fn unit_modulo() {
         assert_eq!(
-            unit!(modulo, Value::scalar(3_f32), &[Value::scalar(2_f32)]),
-            Value::scalar(1_f32)
+            unit!(modulo, Value::scalar(3_f64), &[Value::scalar(2_f64)]),
+            Value::scalar(1_f64)
         );
         assert_eq!(
-            unit!(modulo, Value::scalar(3_f32), &[Value::scalar(3.0)]),
-            Value::scalar(0_f32)
+            unit!(modulo, Value::scalar(3_f64), &[Value::scalar(3.0)]),
+            Value::scalar(0_f64)
         );
         assert_eq!(
-            unit!(modulo, Value::scalar(24_f32), &[Value::scalar(7_f32)]),
-            Value::scalar(3_f32)
+            unit!(modulo, Value::scalar(24_f64), &[Value::scalar(7_f64)]),
+            Value::scalar(3_f64)
         );
         assert_eq!(
-            unit!(modulo, Value::scalar(183.357), &[Value::scalar(12_f32)]),
-            Value::scalar(3.3569946)
+            unit!(modulo, Value::scalar(183.357), &[Value::scalar(12_f64)]),
+            Value::scalar(3.3569999999999993)
         );
     }
 
     #[test]
     fn unit_divided_by() {
         assert_eq!(
-            unit!(divided_by, Value::scalar(4f32), &[Value::scalar(2f32)]),
-            Value::scalar(2f32)
+            unit!(divided_by, Value::scalar(4f64), &[Value::scalar(2f64)]),
+            Value::scalar(2f64)
         );
         assert_eq!(
-            unit!(divided_by, Value::scalar(5f32), &[Value::scalar(2f32)]),
-            Value::scalar(2.5f32)
+            unit!(divided_by, Value::scalar(5f64), &[Value::scalar(2f64)]),
+            Value::scalar(2.5f64)
         );
         assert!(divided_by(&Value::scalar(true), &[Value::scalar(8.5)]).is_err());
         assert!(divided_by(&Value::scalar(2.5), &[Value::scalar(true)]).is_err());

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -564,7 +564,7 @@ pub fn round(input: &Value, args: &[Value]) -> FilterResult {
             "Positive number expected".to_owned(),
         ))
     } else {
-        let multiplier = 10.0_f32.powi(n);
+        let multiplier = 10.0_f64.powi(n);
         Ok(Value::scalar((input * multiplier).round() / multiplier))
     }
 }
@@ -653,33 +653,33 @@ mod tests {
 
     #[test]
     fn unit_concat_nothing() {
-        let input = Value::Array(vec![Value::scalar(1f32), Value::scalar(2f32)]);
+        let input = Value::Array(vec![Value::scalar(1f64), Value::scalar(2f64)]);
         let args = &[Value::Array(vec![])];
-        let result = Value::Array(vec![Value::scalar(1f32), Value::scalar(2f32)]);
+        let result = Value::Array(vec![Value::scalar(1f64), Value::scalar(2f64)]);
         assert_eq!(unit!(concat, input, args), result);
     }
 
     #[test]
     fn unit_concat_something() {
-        let input = Value::Array(vec![Value::scalar(1f32), Value::scalar(2f32)]);
-        let args = &[Value::Array(vec![Value::scalar(3f32), Value::scalar(4f32)])];
+        let input = Value::Array(vec![Value::scalar(1f64), Value::scalar(2f64)]);
+        let args = &[Value::Array(vec![Value::scalar(3f64), Value::scalar(4f64)])];
         let result = Value::Array(vec![
-            Value::scalar(1f32),
-            Value::scalar(2f32),
-            Value::scalar(3f32),
-            Value::scalar(4f32),
+            Value::scalar(1f64),
+            Value::scalar(2f64),
+            Value::scalar(3f64),
+            Value::scalar(4f64),
         ]);
         assert_eq!(unit!(concat, input, args), result);
     }
 
     #[test]
     fn unit_concat_mixed() {
-        let input = Value::Array(vec![Value::scalar(1f32), Value::scalar(2f32)]);
-        let args = &[Value::Array(vec![Value::scalar(3f32), Value::scalar("a")])];
+        let input = Value::Array(vec![Value::scalar(1f64), Value::scalar(2f64)]);
+        let args = &[Value::Array(vec![Value::scalar(3f64), Value::scalar("a")])];
         let result = Value::Array(vec![
-            Value::scalar(1f32),
-            Value::scalar(2f32),
-            Value::scalar(3f32),
+            Value::scalar(1f64),
+            Value::scalar(2f64),
+            Value::scalar(3f64),
             Value::scalar("a"),
         ]);
         assert_eq!(unit!(concat, input, args), result);
@@ -687,15 +687,15 @@ mod tests {
 
     #[test]
     fn unit_concat_wrong_type() {
-        let input = Value::Array(vec![Value::scalar(1f32), Value::scalar(2f32)]);
-        let args = &[Value::scalar(1f32)];
+        let input = Value::Array(vec![Value::scalar(1f64), Value::scalar(2f64)]);
+        let args = &[Value::scalar(1f64)];
         let result = FilterError::InvalidArgument(0, "Array expected".to_owned());
         assert_eq!(failed!(concat, input, args), result);
     }
 
     #[test]
     fn unit_concat_no_args() {
-        let input = Value::Array(vec![Value::scalar(1f32), Value::scalar(2f32)]);
+        let input = Value::Array(vec![Value::scalar(1f64), Value::scalar(2f64)]);
         let args = &[];
         let result = FilterError::InvalidArgumentCount("expected at least 1, 0 given".to_owned());
         assert_eq!(failed!(concat, input, args), result);
@@ -703,10 +703,10 @@ mod tests {
 
     #[test]
     fn unit_concat_extra_args() {
-        let input = Value::Array(vec![Value::scalar(1f32), Value::scalar(2f32)]);
+        let input = Value::Array(vec![Value::scalar(1f64), Value::scalar(2f64)]);
         let args = &[
-            Value::Array(vec![Value::scalar(3f32), Value::scalar("a")]),
-            Value::scalar(2f32),
+            Value::Array(vec![Value::scalar(3f64), Value::scalar("a")]),
+            Value::scalar(2f64),
         ];
         let result = FilterError::InvalidArgumentCount("expected at most 1, 2 given".to_owned());
         assert_eq!(failed!(concat, input, args), result);
@@ -738,8 +738,8 @@ mod tests {
 
     #[test]
     fn unit_ceil() {
-        assert_eq!(unit!(ceil, Value::scalar(1.1f32), &[]), Value::scalar(2f32));
-        assert_eq!(unit!(ceil, Value::scalar(1f32), &[]), Value::scalar(1f32));
+        assert_eq!(unit!(ceil, Value::scalar(1.1f64), &[]), Value::scalar(2f64));
+        assert_eq!(unit!(ceil, Value::scalar(1f64), &[]), Value::scalar(1f64));
         assert!(ceil(&Value::scalar(true), &[]).is_err());
     }
 
@@ -758,14 +758,14 @@ mod tests {
             unit!(
                 first,
                 Value::Array(vec![
-                    Value::scalar(0f32),
-                    Value::scalar(1f32),
-                    Value::scalar(2f32),
-                    Value::scalar(3f32),
-                    Value::scalar(4f32),
+                    Value::scalar(0f64),
+                    Value::scalar(1f64),
+                    Value::scalar(2f64),
+                    Value::scalar(3f64),
+                    Value::scalar(4f64),
                 ])
             ),
-            Value::scalar(0f32)
+            Value::scalar(0f64)
         );
         assert_eq!(
             unit!(first, Value::Array(vec![tos!("test"), tos!("two")])),
@@ -777,10 +777,10 @@ mod tests {
     #[test]
     fn unit_floor() {
         assert_eq!(
-            unit!(floor, Value::scalar(1.1f32), &[]),
-            Value::scalar(1f32)
+            unit!(floor, Value::scalar(1.1f64), &[]),
+            Value::scalar(1f64)
         );
-        assert_eq!(unit!(floor, Value::scalar(1f32), &[]), Value::scalar(1f32));
+        assert_eq!(unit!(floor, Value::scalar(1f64), &[]), Value::scalar(1f64));
         assert!(floor(&Value::scalar(true), &[]).is_err());
     }
 
@@ -803,7 +803,7 @@ mod tests {
     #[test]
     fn unit_join_bad_join_string() {
         let input = Value::Array(vec![tos!("a"), tos!("b"), tos!("c")]);
-        let args = &[Value::scalar(1f32)];
+        let args = &[Value::scalar(1f64)];
         let result = join(&input, args);
         assert_eq!(result.unwrap(), tos!("a1b1c"));
     }
@@ -818,7 +818,7 @@ mod tests {
 
     #[test]
     fn unit_join_non_string_element() {
-        let input = Value::Array(vec![tos!("a"), Value::scalar(1f32), tos!("c")]);
+        let input = Value::Array(vec![tos!("a"), Value::scalar(1f64), tos!("c")]);
         let args = &[tos!(",")];
         let result = join(&input, args);
         assert_eq!(result.unwrap(), tos!("a,1,c"));
@@ -846,14 +846,14 @@ mod tests {
             unit!(
                 last,
                 Value::Array(vec![
-                    Value::scalar(0f32),
-                    Value::scalar(1f32),
-                    Value::scalar(2f32),
-                    Value::scalar(3f32),
-                    Value::scalar(4f32),
+                    Value::scalar(0f64),
+                    Value::scalar(1f64),
+                    Value::scalar(2f64),
+                    Value::scalar(3f64),
+                    Value::scalar(4f64),
                 ])
             ),
-            Value::scalar(4f32)
+            Value::scalar(4f64)
         );
         assert_eq!(
             unit!(last, Value::Array(vec![tos!("test"), tos!("last")])),
@@ -872,7 +872,7 @@ mod tests {
 
     #[test]
     fn unit_lstrip_non_string() {
-        let input = &Value::scalar(0f32);
+        let input = &Value::scalar(0f64);
         let args = &[];
         let desired_result = tos!("0");
         assert_eq!(unit!(lstrip, input, args), desired_result);
@@ -881,7 +881,7 @@ mod tests {
     #[test]
     fn unit_lstrip_one_argument() {
         let input = &tos!(" 	 \n \r test");
-        let args = &[Value::scalar(0f32)];
+        let args = &[Value::scalar(0f64)];
         let desired_result =
             FilterError::InvalidArgumentCount("expected at most 0, 1 given".to_owned());
         assert_eq!(failed!(lstrip, input, args), desired_result);
@@ -1008,15 +1008,15 @@ mod tests {
     #[test]
     fn unit_reverse_array() {
         let input = &Value::Array(vec![
-            Value::scalar(3f32),
-            Value::scalar(1f32),
-            Value::scalar(2f32),
+            Value::scalar(3f64),
+            Value::scalar(1f64),
+            Value::scalar(2f64),
         ]);
         let args = &[];
         let desired_result = Value::Array(vec![
-            Value::scalar(2f32),
-            Value::scalar(1f32),
-            Value::scalar(3f32),
+            Value::scalar(2f64),
+            Value::scalar(1f64),
+            Value::scalar(3f64),
         ]);
         assert_eq!(unit!(reverse, input, args), desired_result);
     }
@@ -1024,11 +1024,11 @@ mod tests {
     #[test]
     fn unit_reverse_array_extra_args() {
         let input = &Value::Array(vec![
-            Value::scalar(3f32),
-            Value::scalar(1f32),
-            Value::scalar(2f32),
+            Value::scalar(3f64),
+            Value::scalar(1f64),
+            Value::scalar(2f64),
         ]);
-        let args = &[Value::scalar(0f32)];
+        let args = &[Value::scalar(0f64)];
         let desired_result =
             FilterError::InvalidArgumentCount("expected at most 0, 1 given".to_owned());
         assert_eq!(failed!(reverse, input, args), desired_result);
@@ -1135,7 +1135,7 @@ mod tests {
 
     #[test]
     fn unit_rstrip_non_string() {
-        let input = &Value::scalar(0f32);
+        let input = &Value::scalar(0f64);
         let args = &[];
         let desired_result = tos!("0");
         assert_eq!(unit!(rstrip, input, args), desired_result);
@@ -1144,7 +1144,7 @@ mod tests {
     #[test]
     fn unit_rstrip_one_argument() {
         let input = &tos!(" 	 \n \r test");
-        let args = &[Value::scalar(0f32)];
+        let args = &[Value::scalar(0f64)];
         let desired_result =
             FilterError::InvalidArgumentCount("expected at most 0, 1 given".to_owned());
         assert_eq!(failed!(rstrip, input, args), desired_result);
@@ -1162,52 +1162,52 @@ mod tests {
     #[test]
     fn unit_round() {
         assert_eq!(
-            unit!(round, Value::scalar(1.1f32), &[]),
+            unit!(round, Value::scalar(1.1f64), &[]),
             Value::scalar(1i32)
         );
         assert_eq!(
-            unit!(round, Value::scalar(1.5f32), &[]),
+            unit!(round, Value::scalar(1.5f64), &[]),
             Value::scalar(2i32)
         );
-        assert_eq!(unit!(round, Value::scalar(2f32), &[]), Value::scalar(2i32));
+        assert_eq!(unit!(round, Value::scalar(2f64), &[]), Value::scalar(2i32));
         assert!(round(&Value::scalar(true), &[]).is_err());
     }
 
     #[test]
     fn unit_round_precision() {
         assert_eq!(
-            unit!(round, Value::scalar(1.1f32), &[Value::scalar(0i32)]),
-            Value::scalar(1f32)
+            unit!(round, Value::scalar(1.1f64), &[Value::scalar(0i32)]),
+            Value::scalar(1f64)
         );
         assert_eq!(
-            unit!(round, Value::scalar(1.5f32), &[Value::scalar(1i32)]),
-            Value::scalar(1.5f32)
+            unit!(round, Value::scalar(1.5f64), &[Value::scalar(1i32)]),
+            Value::scalar(1.5f64)
         );
         assert_eq!(
-            unit!(round, Value::scalar(3.14159f32), &[Value::scalar(3i32)]),
-            Value::scalar(3.142f32)
+            unit!(round, Value::scalar(3.14159f64), &[Value::scalar(3i32)]),
+            Value::scalar(3.142f64)
         );
     }
 
     #[test]
     fn unit_size() {
-        assert_eq!(unit!(size, tos!("abc")), Value::scalar(3f32));
+        assert_eq!(unit!(size, tos!("abc")), Value::scalar(3f64));
         assert_eq!(
             unit!(size, tos!("this has 22 characters")),
-            Value::scalar(22f32)
+            Value::scalar(22f64)
         );
         assert_eq!(
             unit!(
                 size,
                 Value::Array(vec![
-                    Value::scalar(0f32),
-                    Value::scalar(1f32),
-                    Value::scalar(2f32),
-                    Value::scalar(3f32),
-                    Value::scalar(4f32),
+                    Value::scalar(0f64),
+                    Value::scalar(1f64),
+                    Value::scalar(2f64),
+                    Value::scalar(3f64),
+                    Value::scalar(4f64),
                 ])
             ),
-            Value::scalar(5f32)
+            Value::scalar(5f64)
         );
     }
 
@@ -1226,7 +1226,7 @@ mod tests {
     #[test]
     fn unit_split_bad_split_string() {
         let input = tos!("a,b,c");
-        let args = &[Value::scalar(1f32)];
+        let args = &[Value::scalar(1f64)];
         let desired_result = Value::Array(vec![tos!("a,b,c")]);
         assert_eq!(unit!(split, input, args), desired_result);
     }
@@ -1257,7 +1257,7 @@ mod tests {
 
     #[test]
     fn unit_strip_non_string() {
-        let input = &Value::scalar(0f32);
+        let input = &Value::scalar(0f64);
         let args = &[];
         let desired_result = tos!("0");
         assert_eq!(unit!(strip, input, args), desired_result);
@@ -1266,7 +1266,7 @@ mod tests {
     #[test]
     fn unit_strip_one_argument() {
         let input = &tos!(" 	 \n \r test 	 \n \r ");
-        let args = &[Value::scalar(0f32)];
+        let args = &[Value::scalar(0f64)];
         let desired_result =
             FilterError::InvalidArgumentCount("expected at most 0, 1 given".to_owned());
         assert_eq!(failed!(strip, input, args), desired_result);
@@ -1315,7 +1315,7 @@ mod tests {
 
     #[test]
     fn unit_strip_newlines_non_string() {
-        let input = &Value::scalar(0f32);
+        let input = &Value::scalar(0f64);
         let args = &[];
         let desired_result = tos!("0");
         assert_eq!(unit!(strip_newlines, input, args), desired_result);
@@ -1324,7 +1324,7 @@ mod tests {
     #[test]
     fn unit_strip_newlines_one_argument() {
         let input = &tos!("ab\n");
-        let args = &[Value::scalar(0f32)];
+        let args = &[Value::scalar(0f64)];
         let desired_result =
             FilterError::InvalidArgumentCount("expected at most 0, 1 given".to_owned());
         assert_eq!(failed!(strip_newlines, input, args), desired_result);
@@ -1365,7 +1365,7 @@ mod tests {
 
     #[test]
     fn unit_truncate_non_string() {
-        let input = &Value::scalar(10000000f32);
+        let input = &Value::scalar(10000000f64);
         let args = &[Value::scalar(5i32)];
         let desired_result = tos!("10...");
         assert_eq!(unit!(truncate, input, args), desired_result);
@@ -1500,7 +1500,7 @@ mod tests {
 
     #[test]
     fn unit_uniq_non_array() {
-        let input = &Value::scalar(0f32);
+        let input = &Value::scalar(0f64);
         let args = &[];
         let desired_result = FilterError::InvalidType("Array expected".to_string());
         assert_eq!(failed!(uniq, input, args), desired_result);
@@ -1509,7 +1509,7 @@ mod tests {
     #[test]
     fn unit_uniq_one_argument() {
         let input = &Value::Array(vec![tos!("a"), tos!("b"), tos!("a")]);
-        let args = &[Value::scalar(0f32)];
+        let args = &[Value::scalar(0f64)];
         let desired_result =
             FilterError::InvalidArgumentCount("expected at most 0, 1 given".to_string());
         assert_eq!(failed!(uniq, input, args), desired_result);
@@ -1544,18 +1544,18 @@ mod tests {
         assert_eq!(unit!(default, tos!(""), &[tos!("bar")]), tos!("bar"));
         assert_eq!(unit!(default, tos!("foo"), &[tos!("bar")]), tos!("foo"));
         assert_eq!(
-            unit!(default, Value::scalar(0_f32), &[tos!("bar")]),
-            Value::scalar(0_f32)
+            unit!(default, Value::scalar(0_f64), &[tos!("bar")]),
+            Value::scalar(0_f64)
         );
         assert_eq!(
-            unit!(default, Value::Array(vec![]), &[Value::scalar(1_f32)]),
-            Value::scalar(1_f32)
+            unit!(default, Value::Array(vec![]), &[Value::scalar(1_f64)]),
+            Value::scalar(1_f64)
         );
         assert_eq!(
             unit!(
                 default,
                 Value::Array(vec![tos!("")]),
-                &[Value::scalar(1_f32)]
+                &[Value::scalar(1_f64)]
             ),
             Value::Array(vec![tos!("")])
         );
@@ -1563,16 +1563,16 @@ mod tests {
             unit!(
                 default,
                 Value::Object(Object::new()),
-                &[Value::scalar(1_f32)]
+                &[Value::scalar(1_f64)]
             ),
-            Value::scalar(1_f32)
+            Value::scalar(1_f64)
         );
         assert_eq!(
-            unit!(default, Value::scalar(false), &[Value::scalar(1_f32)]),
-            Value::scalar(1_f32)
+            unit!(default, Value::scalar(false), &[Value::scalar(1_f64)]),
+            Value::scalar(1_f64)
         );
         assert_eq!(
-            unit!(default, Value::scalar(true), &[Value::scalar(1_f32)]),
+            unit!(default, Value::scalar(true), &[Value::scalar(1_f64)]),
             Value::scalar(true)
         );
     }

--- a/src/interpreter/context.rs
+++ b/src/interpreter/context.rs
@@ -194,15 +194,15 @@ mod test {
     #[test]
     fn get_val() {
         let mut ctx = Context::new();
-        ctx.set_global_val("number", Value::scalar(42f32));
-        assert_eq!(ctx.get_val("number").unwrap(), &Value::scalar(42f32));
+        ctx.set_global_val("number", Value::scalar(42f64));
+        assert_eq!(ctx.get_val("number").unwrap(), &Value::scalar(42f64));
     }
 
     #[test]
     fn get_val_failure() {
         let mut ctx = Context::new();
         let mut post = Object::new();
-        post.insert("number".to_owned(), Value::scalar(42f32));
+        post.insert("number".to_owned(), Value::scalar(42f64));
         ctx.set_global_val("post", Value::Object(post));
         assert!(ctx.get_val("post.number").is_none());
     }
@@ -211,35 +211,35 @@ mod test {
     fn get_val_by_index() {
         let mut ctx = Context::new();
         let mut post = Object::new();
-        post.insert("number".to_owned(), Value::scalar(42f32));
+        post.insert("number".to_owned(), Value::scalar(42f64));
         ctx.set_global_val("post", Value::Object(post));
         let indexes = vec![Index::with_key("post"), Index::with_key("number")];
         assert_eq!(
             ctx.get_val_by_index(indexes.iter()).unwrap(),
-            &Value::scalar(42f32)
+            &Value::scalar(42f64)
         );
     }
 
     #[test]
     fn scoped_variables() {
         let mut ctx = Context::new();
-        ctx.set_global_val("test", Value::scalar(42f32));
-        assert_eq!(ctx.get_val("test").unwrap(), &Value::scalar(42f32));
+        ctx.set_global_val("test", Value::scalar(42f64));
+        assert_eq!(ctx.get_val("test").unwrap(), &Value::scalar(42f64));
 
         ctx.run_in_scope(|new_scope| {
             // assert that values are chained to the parent scope
-            assert_eq!(new_scope.get_val("test").unwrap(), &Value::scalar(42f32));
+            assert_eq!(new_scope.get_val("test").unwrap(), &Value::scalar(42f64));
 
             // set a new local value, and assert that it overrides the previous value
-            new_scope.set_val("test", Value::scalar(3.14f32));
-            assert_eq!(new_scope.get_val("test").unwrap(), &Value::scalar(3.14f32));
+            new_scope.set_val("test", Value::scalar(3.14f64));
+            assert_eq!(new_scope.get_val("test").unwrap(), &Value::scalar(3.14f64));
 
             // sat a new val that we will pick up outside the scope
             new_scope.set_global_val("global", Value::scalar("some value"));
         });
 
         // assert that the value has reverted to the old one
-        assert_eq!(ctx.get_val("test").unwrap(), &Value::scalar(42f32));
+        assert_eq!(ctx.get_val("test").unwrap(), &Value::scalar(42f64));
         assert_eq!(ctx.get_val("global").unwrap(), &Value::scalar("some value"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!     .parse("Liquid! {{num | minus: 2}}").unwrap();
 //!
 //! let mut globals = liquid::Object::new();
-//! globals.insert("num".to_owned(), liquid::Value::scalar(4f32));
+//! globals.insert("num".to_owned(), liquid::Value::scalar(4f64));
 //!
 //! let output = template.render(&globals).unwrap();
 //! assert_eq!(output, "Liquid! 2".to_string());

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -259,7 +259,7 @@ impl Parser {
     ///     .parse_file("path/to/template.txt").unwrap();
     ///
     /// let mut globals = liquid::Object::new();
-    /// globals.insert("data".to_owned(), liquid::Value::scalar(4f32));
+    /// globals.insert("data".to_owned(), liquid::Value::scalar(4f64));
     /// let output = template.render(&globals).unwrap();
     /// assert_eq!(output, "Liquid! 4\n".to_string());
     /// ```

--- a/src/tags/capture_block.rs
+++ b/src/tags/capture_block.rs
@@ -86,7 +86,7 @@ mod test {
 
         let mut ctx = Context::new();
         ctx.set_global_val("item", Value::scalar("potato"));
-        ctx.set_global_val("i", Value::scalar(42f32));
+        ctx.set_global_val("i", Value::scalar(42f64));
 
         let output = template.render(&mut ctx).unwrap();
         assert_eq!(

--- a/src/tags/case_block.rs
+++ b/src/tags/case_block.rs
@@ -208,19 +208,19 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.set_global_val("x", Value::scalar(2f32));
+        context.set_global_val("x", Value::scalar(2f64));
         assert_eq!(
             template.render(&mut context).unwrap(),
             Some("two".to_owned())
         );
 
-        context.set_global_val("x", Value::scalar(3f32));
+        context.set_global_val("x", Value::scalar(3f64));
         assert_eq!(
             template.render(&mut context).unwrap(),
             Some("three and a half".to_owned())
         );
 
-        context.set_global_val("x", Value::scalar(4f32));
+        context.set_global_val("x", Value::scalar(4f64));
         assert_eq!(
             template.render(&mut context).unwrap(),
             Some("three and a half".to_owned())

--- a/src/tags/cycle_tag.rs
+++ b/src/tags/cycle_tag.rs
@@ -173,9 +173,9 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.set_global_val("alpha", Value::scalar(1f32));
-        context.set_global_val("beta", Value::scalar(2f32));
-        context.set_global_val("gamma", Value::scalar(3f32));
+        context.set_global_val("alpha", Value::scalar(1f64));
+        context.set_global_val("beta", Value::scalar(2f64));
+        context.set_global_val("gamma", Value::scalar(3f64));
 
         let output = template.render(&mut context);
 

--- a/src/tags/for_block.rs
+++ b/src/tags/for_block.rs
@@ -330,9 +330,9 @@ mod test {
         data.set_global_val(
             "array",
             Value::Array(vec![
-                Value::scalar(22f32),
-                Value::scalar(23f32),
-                Value::scalar(24f32),
+                Value::scalar(22f64),
+                Value::scalar(23f64),
+                Value::scalar(24f64),
                 Value::scalar("wat".to_owned()),
             ]),
         );

--- a/src/tags/if_block.rs
+++ b/src/tags/if_block.rs
@@ -348,7 +348,7 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.set_global_val("some_value", Value::scalar(1f32));
+        context.set_global_val("some_value", Value::scalar(1f64));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, Some("".to_owned()));
 
@@ -358,7 +358,7 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.set_global_val("some_value", Value::scalar(42f32));
+        context.set_global_val("some_value", Value::scalar(42f64));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, Some("unless body".to_owned()));
     }
@@ -409,7 +409,7 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.set_global_val("a", Value::scalar(1f32));
+        context.set_global_val("a", Value::scalar(1f64));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, Some("first".to_owned()));
 
@@ -419,7 +419,7 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.set_global_val("a", Value::scalar(2f32));
+        context.set_global_val("a", Value::scalar(2f64));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, Some("second".to_owned()));
 
@@ -429,7 +429,7 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.set_global_val("a", Value::scalar(3f32));
+        context.set_global_val("a", Value::scalar(3f64));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, Some("third".to_owned()));
 

--- a/src/tags/include_tag.rs
+++ b/src/tags/include_tag.rs
@@ -89,8 +89,8 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.set_global_val("num", value::Value::scalar(5f32));
-        context.set_global_val("numTwo", value::Value::scalar(10f32));
+        context.set_global_val("num", value::Value::scalar(5f64));
+        context.set_global_val("numTwo", value::Value::scalar(10f64));
         context.add_filter("size", (filters::size as interpreter::FnFilterValue).into());
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, Some("5 wat wot\n".to_owned()));
@@ -105,8 +105,8 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.set_global_val("num", value::Value::scalar(5f32));
-        context.set_global_val("numTwo", value::Value::scalar(10f32));
+        context.set_global_val("num", value::Value::scalar(5f64));
+        context.set_global_val("numTwo", value::Value::scalar(10f64));
         context.add_filter("size", (filters::size as interpreter::FnFilterValue).into());
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, Some("5 wat wot\n".to_owned()));

--- a/src/value/scalar.rs
+++ b/src/value/scalar.rs
@@ -17,7 +17,7 @@ pub struct Scalar(ScalarEnum);
 #[cfg_attr(feature = "serde", serde(untagged))]
 enum ScalarEnum {
     Integer(i32),
-    Float(f32),
+    Float(f64),
     Bool(bool),
     #[cfg_attr(feature = "serde", serde(with = "friendly_date"))]
     Date(Date),
@@ -59,11 +59,11 @@ impl Scalar {
     }
 
     /// Interpret as an float, if possible
-    pub fn to_float(&self) -> Option<f32> {
+    pub fn to_float(&self) -> Option<f64> {
         match self.0 {
-            ScalarEnum::Integer(ref x) => Some(*x as f32),
+            ScalarEnum::Integer(ref x) => Some(f64::from(*x)),
             ScalarEnum::Float(ref x) => Some(*x),
-            ScalarEnum::Str(ref x) => x.parse::<f32>().ok(),
+            ScalarEnum::Str(ref x) => x.parse::<f64>().ok(),
             _ => None,
         }
     }
@@ -123,8 +123,8 @@ impl From<i32> for Scalar {
     }
 }
 
-impl From<f32> for Scalar {
-    fn from(s: f32) -> Self {
+impl From<f64> for Scalar {
+    fn from(s: f64) -> Self {
         Scalar {
             0: ScalarEnum::Float(s),
         }
@@ -175,8 +175,8 @@ impl PartialEq<Scalar> for Scalar {
     fn eq(&self, other: &Self) -> bool {
         match (&self.0, &other.0) {
             (&ScalarEnum::Integer(x), &ScalarEnum::Integer(y)) => x == y,
-            (&ScalarEnum::Integer(x), &ScalarEnum::Float(y)) => (x as f32) == y,
-            (&ScalarEnum::Float(x), &ScalarEnum::Integer(y)) => x == (y as f32),
+            (&ScalarEnum::Integer(x), &ScalarEnum::Float(y)) => (f64::from(x)) == y,
+            (&ScalarEnum::Float(x), &ScalarEnum::Integer(y)) => x == (f64::from(y)),
             (&ScalarEnum::Float(x), &ScalarEnum::Float(y)) => x == y,
             (&ScalarEnum::Bool(x), &ScalarEnum::Bool(y)) => x == y,
             (&ScalarEnum::Date(x), &ScalarEnum::Date(y)) => x == y,
@@ -194,8 +194,8 @@ impl PartialOrd<Scalar> for Scalar {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         match (&self.0, &other.0) {
             (&ScalarEnum::Integer(x), &ScalarEnum::Integer(y)) => x.partial_cmp(&y),
-            (&ScalarEnum::Integer(x), &ScalarEnum::Float(y)) => (x as f32).partial_cmp(&y),
-            (&ScalarEnum::Float(x), &ScalarEnum::Integer(y)) => x.partial_cmp(&(y as f32)),
+            (&ScalarEnum::Integer(x), &ScalarEnum::Float(y)) => (f64::from(x)).partial_cmp(&y),
+            (&ScalarEnum::Float(x), &ScalarEnum::Integer(y)) => x.partial_cmp(&(f64::from(y))),
             (&ScalarEnum::Float(x), &ScalarEnum::Float(y)) => x.partial_cmp(&y),
             (&ScalarEnum::Bool(x), &ScalarEnum::Bool(y)) => x.partial_cmp(&y),
             (&ScalarEnum::Date(x), &ScalarEnum::Date(y)) => x.partial_cmp(&y),
@@ -264,7 +264,7 @@ mod test {
 
     #[test]
     fn test_to_str_float() {
-        let val: Scalar = 42f32.into();
+        let val: Scalar = 42f64.into();
         assert_eq!(val.to_str(), "42");
 
         let val: Scalar = 42.34.into();
@@ -290,7 +290,7 @@ mod test {
 
     #[test]
     fn test_to_integer_float() {
-        let val: Scalar = 42f32.into();
+        let val: Scalar = 42f64.into();
         assert_eq!(val.to_integer(), None);
 
         let val: Scalar = 42.34.into();
@@ -317,13 +317,13 @@ mod test {
     #[test]
     fn test_to_float_integer() {
         let val: Scalar = 42i32.into();
-        assert_eq!(val.to_float(), Some(42f32));
+        assert_eq!(val.to_float(), Some(42f64));
     }
 
     #[test]
     fn test_to_float_float() {
-        let val: Scalar = 42f32.into();
-        assert_eq!(val.to_float(), Some(42f32));
+        let val: Scalar = 42f64.into();
+        assert_eq!(val.to_float(), Some(42f64));
 
         let val: Scalar = 42.34.into();
         assert_eq!(val.to_float(), Some(42.34));
@@ -338,7 +338,7 @@ mod test {
         assert_eq!(val.to_float(), Some(42.34));
 
         let val: Scalar = "42".into();
-        assert_eq!(val.to_float(), Some(42f32));
+        assert_eq!(val.to_float(), Some(42f64));
     }
 
     #[test]
@@ -354,7 +354,7 @@ mod test {
 
     #[test]
     fn test_to_bool_float() {
-        let val: Scalar = 42f32.into();
+        let val: Scalar = 42f64.into();
         assert_eq!(val.to_bool(), None);
 
         let val: Scalar = 42.34.into();
@@ -398,8 +398,8 @@ mod test {
 
     #[test]
     fn float_equality() {
-        let val: Scalar = 42f32.into();
-        let zero: Scalar = 0f32.into();
+        let val: Scalar = 42f64.into();
+        let zero: Scalar = 0f64.into();
         assert_eq!(val, val);
         assert_eq!(zero, zero);
         assert!(val != zero);
@@ -408,8 +408,8 @@ mod test {
 
     #[test]
     fn floats_have_ruby_truthiness() {
-        let val: Scalar = 42f32.into();
-        let zero: Scalar = 0f32.into();
+        let val: Scalar = 42f64.into();
+        let zero: Scalar = 0f64.into();
         assert_eq!(TRUE, val);
         assert_eq!(val, TRUE);
         assert!(val.is_truthy());

--- a/src/value/values.rs
+++ b/src/value/values.rs
@@ -238,14 +238,14 @@ mod test {
 
     #[test]
     fn test_to_string_scalar() {
-        let val = Value::scalar(42f32);
+        let val = Value::scalar(42f64);
         assert_eq!(&val.to_string(), "42");
     }
 
     #[test]
     fn test_to_string_array() {
         let val = Value::Array(vec![
-            Value::scalar(3f32),
+            Value::scalar(3f64),
             Value::scalar("test"),
             Value::scalar(5.3),
         ]);
@@ -298,7 +298,7 @@ mod test {
     fn object_equality() {
         let a: Object = [
             ("alpha".to_owned(), Value::scalar("1")),
-            ("beta".to_owned(), Value::scalar(2f32)),
+            ("beta".to_owned(), Value::scalar(2f64)),
         ].into_iter()
             .cloned()
             .collect();
@@ -306,7 +306,7 @@ mod test {
 
         let b: Object = [
             ("alpha".to_owned(), Value::scalar("1")),
-            ("beta".to_owned(), Value::scalar(2f32)),
+            ("beta".to_owned(), Value::scalar(2f64)),
             ("gamma".to_owned(), Value::Array(vec![])),
         ].into_iter()
             .cloned()

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -439,7 +439,7 @@ pub fn split_sort_join() {
 #[test]
 pub fn modulo() {
     let text = "{{ num | modulo: 2 }}";
-    let samples = [(4_f32, "0"), (3_f32, "1"), (5.1, "1.0999999")];
+    let samples = [(4_f64, "0"), (3_f64, "1"), (5.1, "1.0999999999999996")];
     for t in &samples {
         let globals: liquid::Object = serde_yaml::from_str(&format!("num: {}", t.0)).unwrap();
         let template = liquid::ParserBuilder::with_liquid()

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -53,8 +53,8 @@ numTwo: 6
 #[test]
 pub fn include() {
     let mut globals: liquid::Object = Default::default();
-    globals.insert("num".to_owned(), Value::scalar(5f32));
-    globals.insert("numTwo".to_owned(), Value::scalar(10f32));
+    globals.insert("num".to_owned(), Value::scalar(5f64));
+    globals.insert("numTwo".to_owned(), Value::scalar(10f64));
     compare_by_file("include", &globals);
 }
 

--- a/tests/multithreading.rs
+++ b/tests/multithreading.rs
@@ -20,7 +20,7 @@ pub fn pass_between_threads() {
 
     // Start threads
     let mut handles = Vec::new();
-    let v = vec![(5f32, 6f32), (20f32, 10f32)];
+    let v = vec![(5f64, 6f64), (20f64, 10f64)];
     for (counter, (num1, num2)) in v.into_iter().enumerate() {
         let template = Arc::clone(&template);
         let output_file = format!("tests/fixtures/output/example_mt{}.txt", counter + 1);

--- a/tests/parse_file.rs
+++ b/tests/parse_file.rs
@@ -66,8 +66,8 @@ numTwo: 6
 #[test]
 pub fn include_by_file() {
     let mut globals: Object = Default::default();
-    globals.insert("num".to_owned(), Value::scalar(5f32));
-    globals.insert("numTwo".to_owned(), Value::scalar(10f32));
+    globals.insert("num".to_owned(), Value::scalar(5f64));
+    globals.insert("numTwo".to_owned(), Value::scalar(10f64));
     compare_by_file("include", &globals);
 }
 

--- a/tests/value.rs
+++ b/tests/value.rs
@@ -4,27 +4,27 @@ extern crate serde_yaml;
 #[macro_use]
 extern crate difference;
 
-use std::f32;
+use std::f64;
 
 #[test]
 pub fn serialize_num() {
-    let actual = liquid::Value::scalar(1f32);
+    let actual = liquid::Value::scalar(1f64);
     let actual = serde_yaml::to_string(&actual).unwrap();
     assert_diff!(&actual, "---\n1.0", "", 0);
 
-    let actual = liquid::Value::scalar(-100f32);
+    let actual = liquid::Value::scalar(-100f64);
     let actual = serde_yaml::to_string(&actual).unwrap();
     assert_diff!(&actual, "---\n-100.0", "", 0);
 
-    let actual = liquid::Value::scalar(3.14e_10f32);
+    let actual = liquid::Value::scalar(3.14e_10f64);
     let actual = serde_yaml::to_string(&actual).unwrap();
-    assert_diff!(&actual, "---\n31399999488.0", "", 0);
+    assert_diff!(&actual, "---\n31400000000.0", "", 0);
 
-    let actual = liquid::Value::scalar(f32::NAN);
+    let actual = liquid::Value::scalar(f64::NAN);
     let actual = serde_yaml::to_string(&actual).unwrap();
     assert_diff!(&actual, "---\n.nan", "", 0);
 
-    let actual = liquid::Value::scalar(f32::INFINITY);
+    let actual = liquid::Value::scalar(f64::INFINITY);
     let actual = serde_yaml::to_string(&actual).unwrap();
     assert_diff!(&actual, "---\n.inf", "", 0);
 }
@@ -32,18 +32,18 @@ pub fn serialize_num() {
 #[test]
 pub fn deserialize_num() {
     let actual: liquid::Value = serde_yaml::from_str("---\n1").unwrap();
-    assert_eq!(actual, liquid::Value::scalar(1f32));
+    assert_eq!(actual, liquid::Value::scalar(1f64));
 
     let actual: liquid::Value = serde_yaml::from_str("---\n-100").unwrap();
-    assert_eq!(actual, liquid::Value::scalar(-100f32));
+    assert_eq!(actual, liquid::Value::scalar(-100f64));
 
     let actual: liquid::Value = serde_yaml::from_str("---\n31399999488").unwrap();
-    assert_eq!(actual, liquid::Value::scalar(3.14e_10f32));
+    assert_eq!(actual, liquid::Value::scalar(31399999488.0f64));
 
     // Skipping NaN since equality fails
 
     let actual: liquid::Value = serde_yaml::from_str("---\ninf").unwrap();
-    assert_eq!(actual, liquid::Value::scalar(f32::INFINITY));
+    assert_eq!(actual, liquid::Value::scalar(f64::INFINITY));
 }
 
 #[test]
@@ -112,7 +112,7 @@ pub fn deserialize_str() {
 #[test]
 pub fn serialize_array() {
     let actual = vec![
-        liquid::Value::scalar(1f32),
+        liquid::Value::scalar(1f64),
         liquid::Value::scalar(true),
         liquid::Value::scalar("true"),
     ];
@@ -125,7 +125,7 @@ pub fn serialize_array() {
 pub fn deserialize_array() {
     let actual: liquid::Value = serde_yaml::from_str("---\n- 1\n- true\n- \"true\"").unwrap();
     let expected = vec![
-        liquid::Value::scalar(1f32),
+        liquid::Value::scalar(1f64),
         liquid::Value::scalar(true),
         liquid::Value::scalar("true"),
     ];
@@ -143,7 +143,7 @@ pub fn deserialize_object() {
     let actual: liquid::Value =
         serde_yaml::from_str("---\nNum: 1\nBool: true\nStr: \"true\"").unwrap();
     let expected: liquid::Object = [
-        ("Num".to_owned(), liquid::Value::scalar(1f32)),
+        ("Num".to_owned(), liquid::Value::scalar(1f64)),
         ("Bool".to_owned(), liquid::Value::scalar(true)),
         ("Str".to_owned(), liquid::Value::scalar("true")),
     ].iter()


### PR DESCRIPTION
BREAKING CHANGE: Liquid's "Value" API now works with f64's instead of f32's
- [ ] Tests created for any new feature or regression tests for bugfixes.
- [ ] `cargo test` succeeds
- [ ] `rustup run nightly cargo clippy` succeeds
- [ ] `cargo fmt -- --write-mode=diff` succeeds


