### PR TITLE
perf: Reduce allocations

### DIFF
--- a/src/interpreter/context.rs
+++ b/src/interpreter/context.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync;
 
 use error::{Error, Result};
 use value::{Index, Object, Value};
@@ -39,7 +40,7 @@ pub struct Context {
     cycles: HashMap<String, usize>,
 
     // Public for backwards compatability
-    filters: HashMap<&'static str, BoxedValueFilter>,
+    filters: sync::Arc<HashMap<&'static str, BoxedValueFilter>>,
 }
 
 impl Context {
@@ -53,8 +54,8 @@ impl Context {
         self
     }
 
-    pub fn with_filters(mut self, filters: HashMap<&'static str, BoxedValueFilter>) -> Self {
-        self.filters = filters;
+    pub fn with_filters(mut self, filters: &sync::Arc<HashMap<&'static str, BoxedValueFilter>>) -> Self {
+        self.filters = sync::Arc::clone(filters);
         self
     }
 
@@ -74,10 +75,6 @@ impl Context {
 
         let val = values[index].evaluate(self)?;
         Ok(Some(val))
-    }
-
-    pub fn add_filter(&mut self, name: &'static str, filter: BoxedValueFilter) {
-        self.filters.insert(name, filter);
     }
 
     pub fn get_filter<'b>(&'b self, name: &str) -> Option<&'b FilterValue> {

--- a/src/tags/for_block.rs
+++ b/src/tags/for_block.rs
@@ -300,9 +300,13 @@ pub fn for_block(
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use std::collections::HashMap;
+    use std::sync;
+
     use compiler;
     use interpreter;
+
+    use super::*;
 
     fn options() -> LiquidOptions {
         let mut options = LiquidOptions::default();
@@ -634,13 +638,13 @@ mod test {
             &options(),
         ).unwrap();
 
-        let mut data: Context = Default::default();
-        data.add_filter(
-            "shout",
+        let mut filters: HashMap<&'static str, interpreter::BoxedValueFilter> = HashMap::new();
+        filters.insert("shout",
             ((|input, _args| Ok(Value::scalar(input.to_str().to_uppercase())))
                 as interpreter::FnFilterValue)
                 .into(),
-        );
+                    );
+        let mut data = Context::new().with_filters(&sync::Arc::new(filters));
 
         data.set_global_val(
             "array",

--- a/src/tags/include_tag.rs
+++ b/src/tags/include_tag.rs
@@ -53,14 +53,18 @@ pub fn include_tag(
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use std::iter::FromIterator;
+    use std::path;
+    use std::collections::HashMap;
+    use std::sync;
+
+    use tags;
+    use value;
     use compiler;
     use filters;
     use interpreter;
-    use std::iter::FromIterator;
-    use std::path;
-    use tags;
-    use value;
+
+    use super::*;
 
     fn options() -> LiquidOptions {
         let include_path = path::PathBuf::from_iter("tests/fixtures/input".split('/'));
@@ -88,10 +92,11 @@ mod test {
             .map(interpreter::Template::new)
             .unwrap();
 
-        let mut context = Context::new();
+        let mut filters: HashMap<&'static str, interpreter::BoxedValueFilter> = HashMap::new();
+        filters.insert("size",(filters::size as interpreter::FnFilterValue).into());
+        let mut context = Context::new().with_filters(&sync::Arc::new(filters));
         context.set_global_val("num", value::Value::scalar(5f64));
         context.set_global_val("numTwo", value::Value::scalar(10f64));
-        context.add_filter("size", (filters::size as interpreter::FnFilterValue).into());
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, Some("5 wat wot\n".to_owned()));
     }
@@ -104,10 +109,11 @@ mod test {
             .map(interpreter::Template::new)
             .unwrap();
 
-        let mut context = Context::new();
+        let mut filters: HashMap<&'static str, interpreter::BoxedValueFilter> = HashMap::new();
+        filters.insert("size",(filters::size as interpreter::FnFilterValue).into());
+        let mut context = Context::new().with_filters(&sync::Arc::new(filters));
         context.set_global_val("num", value::Value::scalar(5f64));
         context.set_global_val("numTwo", value::Value::scalar(10f64));
-        context.add_filter("size", (filters::size as interpreter::FnFilterValue).into());
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, Some("5 wat wot\n".to_owned()));
     }

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync;
 
 use super::Object;
 use error::Result;
@@ -8,14 +9,14 @@ use interpreter::Renderable;
 
 pub struct Template {
     pub(crate) template: interpreter::Template,
-    pub(crate) filters: HashMap<&'static str, interpreter::BoxedValueFilter>,
+    pub(crate) filters: sync::Arc<HashMap<&'static str, interpreter::BoxedValueFilter>>,
 }
 
 impl Template {
     /// Renders an instance of the Template, using the given globals.
     pub fn render(&self, globals: &Object) -> Result<String> {
         let mut data = interpreter::Context::new()
-            .with_filters(self.filters.clone())
+            .with_filters(&self.filters)
             .with_values(globals.clone());
         let output = self.template
             .render(&mut data)?


### PR DESCRIPTION
Before
test bench_parse_template  ... bench:      25,960 ns/iter (+/- 2,495)
test bench_parse_text      ... bench:         854 ns/iter (+/- 60)
test bench_parse_variable  ... bench:       2,802 ns/iter (+/- 241)
test bench_render_template ... bench:       8,106 ns/iter (+/- 578)
test bench_render_text     ... bench:         456 ns/iter (+/- 29)
test bench_render_variable ... bench:       1,617 ns/iter (+/- 117)

After:
test bench_parse_template  ... bench:      25,607 ns/iter (+/- 2,131)
test bench_parse_text      ... bench:         624 ns/iter (+/- 43)
test bench_parse_variable  ... bench:       2,600 ns/iter (+/- 221)
test bench_render_template ... bench:       7,817 ns/iter (+/- 554)
test bench_render_text     ... bench:         262 ns/iter (+/- 18)
test bench_render_variable ... bench:       1,392 ns/iter (+/- 106)

Looks like it took about 200ns off of both `parse` and `render`.

Fixes #188

BREAKING CHANGE: `Context` now takes in an `Arc` to the filters.

- [ ] Tests created for any new feature or regression tests for bugfixes.
