### PR TITLE
perf(render): Use a Write

### DIFF
--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -404,6 +404,9 @@ mod test_expect {
 
 #[cfg(test)]
 mod test_split_block {
+    use std::collections::HashMap;
+    use std::io::Write;
+
     use super::super::split_block;
     use super::super::tokenize;
     use super::super::BoxedBlockParser;
@@ -412,14 +415,13 @@ mod test_split_block {
     use interpreter;
     use interpreter::Context;
     use interpreter::Renderable;
-    use std::collections::HashMap;
 
     #[derive(Debug)]
     struct NullBlock;
 
     impl Renderable for NullBlock {
-        fn render(&self, _context: &mut Context) -> Result<Option<String>> {
-            Ok(None)
+        fn render_to(&self, _writer: &mut Write, _context: &mut Context) -> Result<()> {
+            Ok(())
         }
     }
 

--- a/src/interpreter/output.rs
+++ b/src/interpreter/output.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::io::Write;
 
 use itertools;
 
@@ -53,9 +54,10 @@ impl fmt::Display for Output {
 }
 
 impl Renderable for Output {
-    fn render(&self, context: &mut Context) -> Result<Option<String>> {
+    fn render_to(&self, writer: &mut Write, context: &mut Context) -> Result<()> {
         let entry = self.apply_filters(context)?;
-        Ok(Some(entry.to_string()))
+        write!(writer, "{}", entry).chain("Failed to render")?;
+        Ok(())
     }
 }
 

--- a/src/interpreter/renderable.rs
+++ b/src/interpreter/renderable.rs
@@ -1,14 +1,18 @@
 use std::fmt::Debug;
+use std::io::Write;
 
 use error::Result;
-
 use super::Context;
 
 /// Any object (tag/block) that can be rendered by liquid must implement this trait.
 pub trait Renderable: Send + Sync + Debug {
     /// Renders the Renderable instance given a Liquid context.
-    /// The Result that is returned signals if there was an error rendering,
-    /// the Option<String> that is wrapped by the Result will be None if
-    /// the render has run successfully but there is no content to render.
-    fn render(&self, context: &mut Context) -> Result<Option<String>>;
+    fn render(&self, context: &mut Context) -> Result<String> {
+        let mut data = Vec::new();
+        self.render_to(&mut data, context)?;
+        Ok(String::from_utf8(data).expect("render only writes UTF-8"))
+    }
+
+    /// Renders the Renderable instance given a Liquid context.
+    fn render_to(&self, writer: &mut Write, context: &mut Context) -> Result<()>;
 }

--- a/src/interpreter/template.rs
+++ b/src/interpreter/template.rs
@@ -1,5 +1,6 @@
-use error::Result;
+use std::io::Write;
 
+use error::Result;
 use super::Context;
 use super::Renderable;
 
@@ -9,12 +10,9 @@ pub struct Template {
 }
 
 impl Renderable for Template {
-    fn render(&self, context: &mut Context) -> Result<Option<String>> {
-        let mut buf = String::new();
+    fn render_to(&self, writer: &mut Write, context: &mut Context) -> Result<()> {
         for el in &self.elements {
-            if let Some(ref x) = el.render(context)? {
-                buf = buf + x;
-            }
+            el.render_to(writer, context)?;
 
             // Did the last element we processed set an interrupt? If so, we
             // need to abandon the rest of our child elements and just
@@ -24,7 +22,7 @@ impl Renderable for Template {
                 break;
             }
         }
-        Ok(Some(buf))
+        Ok(())
     }
 }
 

--- a/src/interpreter/text.rs
+++ b/src/interpreter/text.rs
@@ -1,5 +1,6 @@
-use error::Result;
+use std::io::Write;
 
+use error::{Result, ResultLiquidChainExt};
 use super::Context;
 use super::Renderable;
 
@@ -9,8 +10,9 @@ pub struct Text {
 }
 
 impl Renderable for Text {
-    fn render(&self, _context: &mut Context) -> Result<Option<String>> {
-        Ok(Some(self.text.to_owned()))
+    fn render_to(&self, writer: &mut Write, _context: &mut Context) -> Result<()> {
+        write!(writer, "{}", &self.text).chain("Failed to render")?;
+        Ok(())
     }
 }
 

--- a/src/interpreter/variable.rs
+++ b/src/interpreter/variable.rs
@@ -1,8 +1,9 @@
 use std::fmt;
+use std::io::Write;
 
 use itertools;
 
-use error::Result;
+use error::{Result, ResultLiquidChainExt};
 use value::Index;
 
 use super::Context;
@@ -38,9 +39,10 @@ impl fmt::Display for Variable {
 }
 
 impl Renderable for Variable {
-    fn render(&self, context: &mut Context) -> Result<Option<String>> {
+    fn render_to(&self, writer: &mut Write, context: &mut Context) -> Result<()> {
         let value = context.get_val_by_index(self.indexes.iter())?;
-        Ok(Some(value.to_string()))
+        write!(writer, "{}", value).chain("Failed to render")?;
+        Ok(())
     }
 }
 

--- a/src/tags/assign_tag.rs
+++ b/src/tags/assign_tag.rs
@@ -1,5 +1,6 @@
-use error::Result;
+use std::io::Write;
 
+use error::Result;
 use compiler::LiquidOptions;
 use compiler::ResultLiquidExt;
 use compiler::Token;
@@ -21,12 +22,12 @@ impl Assign {
 }
 
 impl Renderable for Assign {
-    fn render(&self, context: &mut Context) -> Result<Option<String>> {
+    fn render_to(&self, _writer: &mut Write, context: &mut Context) -> Result<()> {
         let value = self.src
             .apply_filters(context)
             .trace_with(|| self.trace().into())?;
         context.set_global_val(self.dst.to_owned(), value);
-        Ok(None)
+        Ok(())
     }
 }
 
@@ -101,7 +102,7 @@ mod test {
 
             let output = template.render(&mut context).unwrap();
             assert_eq!(context.get_val("freestyle"), Some(&Value::scalar(false)));
-            assert_eq!(output, Some("".to_string()));
+            assert_eq!(output, "");
         }
 
         // test two: matching value in `tags`
@@ -119,7 +120,7 @@ mod test {
 
             let output = template.render(&mut context).unwrap();
             assert_eq!(context.get_val("freestyle"), Some(&Value::scalar(true)));
-            assert_eq!(output, Some("<p>Freestyle!</p>".to_string()));
+            assert_eq!(output, "<p>Freestyle!</p>");
         }
     }
 }

--- a/src/tags/comment_block.rs
+++ b/src/tags/comment_block.rs
@@ -1,5 +1,6 @@
-use error::Result;
+use std::io::Write;
 
+use error::Result;
 use compiler::Element;
 use compiler::LiquidOptions;
 use compiler::Token;
@@ -10,8 +11,8 @@ use interpreter::Renderable;
 struct Comment;
 
 impl Renderable for Comment {
-    fn render(&self, _context: &mut Context) -> Result<Option<String>> {
-        Ok(None)
+    fn render_to(&self, _writer: &mut Write, _context: &mut Context) -> Result<()> {
+        Ok(())
     }
 }
 
@@ -48,7 +49,7 @@ mod test {
         );
         assert_eq!(
             comment.unwrap().render(&mut Default::default()).unwrap(),
-            None
+            ""
         );
     }
 }

--- a/src/tags/include_tag.rs
+++ b/src/tags/include_tag.rs
@@ -1,5 +1,6 @@
-use error::{Result, ResultLiquidExt};
+use std::io::Write;
 
+use error::{Result, ResultLiquidExt};
 use compiler::tokenize;
 use compiler::LiquidOptions;
 use compiler::Token;
@@ -15,10 +16,12 @@ struct Include {
 }
 
 impl Renderable for Include {
-    fn render(&self, mut context: &mut Context) -> Result<Option<String>> {
+    fn render_to(&self, writer: &mut Write, mut context: &mut Context) -> Result<()> {
         self.partial
-            .render(&mut context)
-            .trace_with(|| format!("{{% include {} %}}", self.name).into())
+            .render_to(writer, &mut context)
+            .trace_with(|| format!("{{% include {} %}}", self.name).into())?;
+
+        Ok(())
     }
 }
 
@@ -98,7 +101,7 @@ mod test {
         context.set_global_val("num", value::Value::scalar(5f64));
         context.set_global_val("numTwo", value::Value::scalar(10f64));
         let output = template.render(&mut context).unwrap();
-        assert_eq!(output, Some("5 wat wot\n".to_owned()));
+        assert_eq!(output, "5 wat wot\n");
     }
 
     #[test]
@@ -115,7 +118,7 @@ mod test {
         context.set_global_val("num", value::Value::scalar(5f64));
         context.set_global_val("numTwo", value::Value::scalar(10f64));
         let output = template.render(&mut context).unwrap();
-        assert_eq!(output, Some("5 wat wot\n".to_owned()));
+        assert_eq!(output, "5 wat wot\n");
     }
 
     #[test]

--- a/src/tags/interrupt_tags.rs
+++ b/src/tags/interrupt_tags.rs
@@ -1,5 +1,6 @@
-use error::Result;
+use std::io::Write;
 
+use error::Result;
 use compiler::unexpected_token_error;
 use compiler::LiquidOptions;
 use compiler::Token;
@@ -10,9 +11,9 @@ use interpreter::{Context, Interrupt};
 struct Break;
 
 impl Renderable for Break {
-    fn render(&self, context: &mut Context) -> Result<Option<String>> {
+    fn render_to(&self, _writer: &mut Write, context: &mut Context) -> Result<()> {
         context.set_interrupt(Interrupt::Break);
-        Ok(None)
+        Ok(())
     }
 }
 
@@ -32,9 +33,9 @@ pub fn break_tag(
 struct Continue;
 
 impl Renderable for Continue {
-    fn render(&self, context: &mut Context) -> Result<Option<String>> {
+    fn render_to(&self, _writer: &mut Write, context: &mut Context) -> Result<()> {
         context.set_interrupt(Interrupt::Continue);
-        Ok(None)
+        Ok(())
     }
 }
 
@@ -92,7 +93,7 @@ mod test {
         let output = template.render(&mut ctx).unwrap();
         assert_eq!(
             output,
-            Some(concat!("enter-0;exit-0\n", "enter-1;exit-1\n", "enter-2;break-2\n").to_owned())
+            concat!("enter-0;exit-0\n", "enter-1;exit-1\n", "enter-2;break-2\n")
         );
     }
 
@@ -118,12 +119,10 @@ mod test {
         let output = template.render(&mut ctx).unwrap();
         assert_eq!(
             output,
-            Some(
-                concat!(
-                    "enter-0; 6, 7, break, exit-0\n",
-                    "enter-1; 6, 7, break, exit-1\n",
-                    "enter-2; 6, 7, break, exit-2\n"
-                ).to_owned()
+            concat!(
+                "enter-0; 6, 7, break, exit-0\n",
+                "enter-1; 6, 7, break, exit-1\n",
+                "enter-2; 6, 7, break, exit-2\n"
             )
         );
     }
@@ -146,14 +145,12 @@ mod test {
         let output = template.render(&mut ctx).unwrap();
         assert_eq!(
             output,
-            Some(
-                concat!(
-                    "enter-0;exit-0\n",
-                    "enter-1;exit-1\n",
-                    "enter-2;continue-2\n",
-                    "enter-3;exit-3\n",
-                    "enter-4;exit-4\n"
-                ).to_owned()
+            concat!(
+                "enter-0;exit-0\n",
+                "enter-1;exit-1\n",
+                "enter-2;continue-2\n",
+                "enter-3;exit-3\n",
+                "enter-4;exit-4\n"
             )
         );
     }
@@ -180,12 +177,10 @@ mod test {
         let output = template.render(&mut ctx).unwrap();
         assert_eq!(
             output,
-            Some(
-                concat!(
-                    "enter-0; 6, 7, continue, 9, exit-0\n",
-                    "enter-1; 6, 7, continue, 9, exit-1\n",
-                    "enter-2; 6, 7, continue, 9, exit-2\n"
-                ).to_owned()
+            concat!(
+                "enter-0; 6, 7, continue, 9, exit-0\n",
+                "enter-1; 6, 7, continue, 9, exit-1\n",
+                "enter-2; 6, 7, continue, 9, exit-2\n"
             )
         );
     }

--- a/src/tags/raw_block.rs
+++ b/src/tags/raw_block.rs
@@ -1,5 +1,6 @@
-use error::Result;
+use std::io::Write;
 
+use error::{Result, ResultLiquidChainExt};
 use compiler::Element;
 use compiler::LiquidOptions;
 use compiler::Token;
@@ -12,8 +13,9 @@ struct RawT {
 }
 
 impl Renderable for RawT {
-    fn render(&self, _context: &mut Context) -> Result<Option<String>> {
-        Ok(Some(self.content.to_owned()))
+    fn render_to(&self, writer: &mut Write, _context: &mut Context) -> Result<()> {
+        write!(writer, "{}", self.content).chain("Failed to render")?;
+        Ok(())
     }
 }
 
@@ -56,7 +58,7 @@ mod test {
             &options(),
         ).unwrap();
         let output = raw.render(&mut Default::default()).unwrap();
-        assert_eq!(output, Some("This is a test".to_owned()));
+        assert_eq!(output, "This is a test");
     }
 
     #[test]
@@ -70,7 +72,7 @@ mod test {
 
         let mut context = Context::new();
         let output = template.render(&mut context).unwrap();
-        assert_eq!(output, Some("{%if%}".to_owned()));
+        assert_eq!(output,"{%if%}");
     }
 
     #[test]
@@ -84,6 +86,6 @@ mod test {
 
         let mut context = Context::new();
         let output = template.render(&mut context).unwrap();
-        assert_eq!(output, Some("hello{%if%}world".to_owned()));
+        assert_eq!(output, "hello{%if%}world");
     }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::io::Write;
 use std::sync;
 
 use super::Object;
@@ -15,12 +16,17 @@ pub struct Template {
 impl Template {
     /// Renders an instance of the Template, using the given globals.
     pub fn render(&self, globals: &Object) -> Result<String> {
+        let mut data = Vec::new();
+        self.render_to(&mut data, globals)?;
+        Ok(String::from_utf8(data).expect("render only writes UTF-8"))
+    }
+
+    /// Renders an instance of the Template, using the given globals.
+    pub fn render_to(&self, writer: &mut Write, globals: &Object) -> Result<()> {
         let mut data = interpreter::Context::new()
             .with_filters(&self.filters)
             .with_values(globals.clone());
-        let output = self.template
-            .render(&mut data)?
-            .expect("template never returns `None`");
-        Ok(output)
+        self.template
+            .render_to(writer, &mut data)
     }
 }


### PR DESCRIPTION
`render_to` uses an `io::Write`.  This is hopefully better than string
concatenation, especially if you can write directly to file. `render` is
still available for convinience (though it no longer returns an
`Option`).

Fixes #187

BREAKING CHANGES: Changed focus to `io::Write`
- `Renderable`s must implement `render_to`.
- `render` no longer returns an `Option`.