### PR TITLE
perf(value): Support str's

### DIFF
--- a/src/compiler/token.rs
+++ b/src/compiler/token.rs
@@ -60,7 +60,7 @@ impl Token {
     /// be interpreted as a Value.
     pub fn to_value(&self) -> Result<Value> {
         match self {
-            &Token::StringLiteral(ref x) => Ok(Value::scalar(x.as_str())),
+            &Token::StringLiteral(ref x) => Ok(Value::scalar(x.to_owned())),
             &Token::IntegerLiteral(x) => Ok(Value::scalar(x)),
             &Token::FloatLiteral(x) => Ok(Value::scalar(x)),
             &Token::BooleanLiteral(x) => Ok(Value::scalar(x)),
@@ -74,7 +74,7 @@ impl Token {
         match *self {
             Token::IntegerLiteral(f) => Ok(Argument::Val(Value::scalar(f))),
             Token::FloatLiteral(f) => Ok(Argument::Val(Value::scalar(f))),
-            Token::StringLiteral(ref s) => Ok(Argument::Val(Value::scalar(s.as_str()))),
+            Token::StringLiteral(ref s) => Ok(Argument::Val(Value::scalar(s.to_owned()))),
             Token::BooleanLiteral(b) => Ok(Argument::Val(Value::scalar(b))),
             Token::Identifier(ref id) => {
                 let mut var = Variable::default();

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -243,7 +243,7 @@ pub fn split(input: &Value, args: &[Value]) -> FilterResult {
 
     // Split and construct resulting Array
     Ok(Value::Array(
-        input.split(pattern.as_ref()).map(Value::scalar).collect(),
+        input.split(pattern.as_ref()).map(|s| Value::scalar(s.to_owned())).collect(),
     ))
 }
 
@@ -258,7 +258,7 @@ pub fn strip(input: &Value, args: &[Value]) -> FilterResult {
     check_args_len(args, 0, 0)?;
 
     let input = input.to_str();
-    Ok(Value::scalar(input.trim()))
+    Ok(Value::scalar(input.trim().to_owned()))
 }
 
 /// Removes all whitespaces (tabs, spaces, and newlines) from the beginning of a string.
@@ -271,7 +271,7 @@ pub fn lstrip(input: &Value, args: &[Value]) -> FilterResult {
     check_args_len(args, 0, 0)?;
 
     let input = input.to_str();
-    Ok(Value::scalar(input.trim_left()))
+    Ok(Value::scalar(input.trim_left().to_owned()))
 }
 
 /// Removes all whitespace (tabs, spaces, and newlines) from the right side of a string.
@@ -284,7 +284,7 @@ pub fn rstrip(input: &Value, args: &[Value]) -> FilterResult {
     check_args_len(args, 0, 0)?;
 
     let input = input.to_str();
-    Ok(Value::scalar(input.trim_right()))
+    Ok(Value::scalar(input.trim_right().to_owned()))
 }
 
 /// Removes any newline characters (line breaks) from a string.

--- a/src/value/scalar.rs
+++ b/src/value/scalar.rs
@@ -21,7 +21,7 @@ enum ScalarEnum {
     Bool(bool),
     #[cfg_attr(feature = "serde", serde(with = "friendly_date"))]
     Date(Date),
-    Str(String),
+    Str(borrow::Cow<'static, str>),
 }
 
 impl Scalar {
@@ -35,7 +35,7 @@ impl Scalar {
             ScalarEnum::Float(ref x) => borrow::Cow::Owned(x.to_string()),
             ScalarEnum::Bool(ref x) => borrow::Cow::Owned(x.to_string()),
             ScalarEnum::Date(ref x) => borrow::Cow::Owned(x.format(DATE_FORMAT).to_string()),
-            ScalarEnum::Str(ref x) => borrow::Cow::Borrowed(x.as_str()),
+            ScalarEnum::Str(ref x) => borrow::Cow::Borrowed(x.as_ref()),
         }
     }
 
@@ -45,7 +45,7 @@ impl Scalar {
             ScalarEnum::Float(x) => x.to_string(),
             ScalarEnum::Bool(x) => x.to_string(),
             ScalarEnum::Date(x) => x.to_string(),
-            ScalarEnum::Str(x) => x,
+            ScalarEnum::Str(x) => x.into_owned(),
         }
     }
 
@@ -80,7 +80,7 @@ impl Scalar {
     pub fn to_date(&self) -> Option<Date> {
         match self.0 {
             ScalarEnum::Date(ref x) => Some(*x),
-            ScalarEnum::Str(ref x) => parse_date(x.as_str()),
+            ScalarEnum::Str(ref x) => parse_date(x.as_ref()),
             _ => None,
         }
     }
@@ -150,7 +150,7 @@ impl From<Date> for Scalar {
 impl From<String> for Scalar {
     fn from(s: String) -> Self {
         Scalar {
-            0: ScalarEnum::Str(s),
+            0: ScalarEnum::Str(s.into()),
         }
     }
 }
@@ -158,15 +158,15 @@ impl From<String> for Scalar {
 impl<'a> From<&'a String> for Scalar {
     fn from(s: &String) -> Self {
         Scalar {
-            0: ScalarEnum::Str(s.to_owned()),
+            0: ScalarEnum::Str(s.to_owned().into()),
         }
     }
 }
 
-impl<'a> From<&'a str> for Scalar {
-    fn from(s: &str) -> Self {
+impl From<&'static str> for Scalar {
+    fn from(s: &'static str) -> Self {
         Scalar {
-            0: ScalarEnum::Str(s.to_owned()),
+            0: ScalarEnum::Str(s.into()),
         }
     }
 }


### PR DESCRIPTION
The benchmarks come back as a wash.  The benchmarks don't exercise this
case (ie see the benefit) so this means we aren't worse off then before.

BREAKING CHANGE: Any `str` passed in must have `&'static` lifetime.

- [ ] Tests created for any new feature or regression tests for bugfixes.
