### PR TITLE
Modularize Context

### DIFF
--- a/src/compiler/include.rs
+++ b/src/compiler/include.rs
@@ -58,7 +58,8 @@ impl FilesystemInclude {
 
 impl Include for FilesystemInclude {
     fn include(&self, relative_path: &str) -> Result<String> {
-        let root = self.root
+        let root = self
+            .root
             .canonicalize()
             .chain("Snippet does not exist")
             .context_with(|| {
@@ -68,7 +69,8 @@ impl Include for FilesystemInclude {
             })?;
         let mut path = root.clone();
         path.extend(relative_path.split('/'));
-        let path = path.canonicalize()
+        let path = path
+            .canonicalize()
             .chain("Snippet does not exist")
             .context_with(|| ("non-existent path".into(), path.to_string_lossy().into()))?;
         if !path.starts_with(&root) {

--- a/src/compiler/lexer.rs
+++ b/src/compiler/lexer.rs
@@ -153,10 +153,12 @@ pub fn granularize(block: &str) -> Result<Vec<Token>> {
             x if SINGLE_STRING_LITERAL.is_match(x) || DOUBLE_STRING_LITERAL.is_match(x) => {
                 Token::StringLiteral(x[1..x.len() - 1].to_owned())
             }
-            x if NUMBER_LITERAL.is_match(x) => x.parse::<i32>()
+            x if NUMBER_LITERAL.is_match(x) => x
+                .parse::<i32>()
                 .map(Token::IntegerLiteral)
                 .unwrap_or_else(|_e| {
-                    let x = x.parse::<f64>()
+                    let x = x
+                        .parse::<f64>()
                         .expect("matches to NUMBER_LITERAL are parseable as floats");
                     Token::FloatLiteral(x)
                 }),

--- a/src/compiler/token.rs
+++ b/src/compiler/token.rs
@@ -179,7 +179,7 @@ mod test {
     #[test]
     fn evaluate_handles_identifiers() {
         let mut ctx = Context::new();
-        ctx.set_global_val("var0", Value::scalar(42f64));
+        ctx.stack_mut().set_global_val("var0", Value::scalar(42f64));
         assert_eq!(
             Token::Identifier("var0".to_owned())
                 .to_arg()

--- a/src/filters/math.rs
+++ b/src/filters/math.rs
@@ -8,7 +8,8 @@ pub fn abs(input: &Value, args: &[Value]) -> FilterResult {
     check_args_len(args, 0, 0)?;
 
     match *input {
-        Value::Scalar(ref s) => s.to_integer()
+        Value::Scalar(ref s) => s
+            .to_integer()
             .map(|i| Value::scalar(i.abs()))
             .or_else(|| s.to_float().map(|i| Value::scalar(i.abs())))
             .ok_or_else(|| FilterError::InvalidType("Numeric value expected".to_owned())),

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -114,7 +114,8 @@ pub fn slice(input: &Value, args: &[Value]) -> FilterResult {
         .ok_or_else(|| FilterError::InvalidArgument(0, "Whole number expected".to_owned()))?;
     let offset = offset as isize;
 
-    let length = args.get(1)
+    let length = args
+        .get(1)
         .unwrap_or(&Value::scalar(1))
         .as_scalar()
         .and_then(Scalar::to_integer)
@@ -178,14 +179,16 @@ pub fn slice(input: &Value, args: &[Value]) -> FilterResult {
 pub fn truncate(input: &Value, args: &[Value]) -> FilterResult {
     check_args_len(args, 0, 2)?;
 
-    let length = args.get(0)
+    let length = args
+        .get(0)
         .unwrap_or(&Value::scalar(50i32))
         .as_scalar()
         .and_then(Scalar::to_integer)
         .ok_or_else(|| FilterError::InvalidArgument(0, "Whole number expected".to_owned()))?;
     let length = length as usize;
 
-    let truncate_string = args.get(1)
+    let truncate_string = args
+        .get(1)
         .map(Value::to_str)
         .unwrap_or_else(|| "...".into());
 
@@ -209,14 +212,16 @@ pub fn truncate(input: &Value, args: &[Value]) -> FilterResult {
 pub fn truncatewords(input: &Value, args: &[Value]) -> FilterResult {
     check_args_len(args, 0, 2)?;
 
-    let words = args.get(0)
+    let words = args
+        .get(0)
         .unwrap_or(&Value::scalar(50i32))
         .as_scalar()
         .and_then(Scalar::to_integer)
         .ok_or_else(|| FilterError::InvalidArgument(0, "Whole number expected".to_owned()))?;
     let words = words as usize;
 
-    let truncate_string = args.get(1)
+    let truncate_string = args
+        .get(1)
         .map(Value::to_str)
         .unwrap_or_else(|| "...".into());
 
@@ -243,7 +248,10 @@ pub fn split(input: &Value, args: &[Value]) -> FilterResult {
 
     // Split and construct resulting Array
     Ok(Value::Array(
-        input.split(pattern.as_ref()).map(|s| Value::scalar(s.to_owned())).collect(),
+        input
+            .split(pattern.as_ref())
+            .map(|s| Value::scalar(s.to_owned()))
+            .collect(),
     ))
 }
 
@@ -509,7 +517,8 @@ pub fn first(input: &Value, args: &[Value]) -> FilterResult {
 
     match *input {
         Value::Scalar(ref x) => {
-            let c = x.to_str()
+            let c = x
+                .to_str()
                 .chars()
                 .next()
                 .map(|c| c.to_string())
@@ -528,7 +537,8 @@ pub fn last(input: &Value, args: &[Value]) -> FilterResult {
 
     match *input {
         Value::Scalar(ref x) => {
-            let c = x.to_str()
+            let c = x
+                .to_str()
                 .chars()
                 .last()
                 .map(|c| c.to_string())
@@ -545,7 +555,8 @@ pub fn last(input: &Value, args: &[Value]) -> FilterResult {
 pub fn round(input: &Value, args: &[Value]) -> FilterResult {
     check_args_len(args, 0, 1)?;
 
-    let n = args.get(0)
+    let n = args
+        .get(0)
         .unwrap_or(&Value::scalar(0i32))
         .as_scalar()
         .and_then(Scalar::to_integer)

--- a/src/interpreter/argument.rs
+++ b/src/interpreter/argument.rs
@@ -16,7 +16,10 @@ impl Argument {
     pub fn evaluate(&self, context: &Context) -> Result<Value> {
         let val = match *self {
             Argument::Val(ref x) => x.clone(),
-            Argument::Var(ref x) => context.stack().get_val_by_index(x.indexes().iter())?.clone(),
+            Argument::Var(ref x) => context
+                .stack()
+                .get_val_by_index(x.indexes().iter())?
+                .clone(),
         };
         Ok(val)
     }

--- a/src/interpreter/argument.rs
+++ b/src/interpreter/argument.rs
@@ -16,7 +16,7 @@ impl Argument {
     pub fn evaluate(&self, context: &Context) -> Result<Value> {
         let val = match *self {
             Argument::Val(ref x) => x.clone(),
-            Argument::Var(ref x) => context.get_val_by_index(x.indexes().iter())?.clone(),
+            Argument::Var(ref x) => context.stack().get_val_by_index(x.indexes().iter())?.clone(),
         };
         Ok(val)
     }

--- a/src/interpreter/context.rs
+++ b/src/interpreter/context.rs
@@ -87,56 +87,27 @@ impl<'a> CycleState<'a> {
     }
 }
 
-#[derive(Default)]
-pub struct Context {
-    stack: Vec<Object>,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Stack {
     globals: Object,
-
-    interrupt: InterruptState,
-    cycles: CycleStateInner,
-
-    filters: sync::Arc<HashMap<&'static str, BoxedValueFilter>>,
+    stack: Vec<Object>,
 }
 
-impl Context {
-    /// Creates a new, empty rendering context.
+impl Stack {
     pub fn new() -> Self {
-        Default::default()
-    }
-
-    pub fn with_values(mut self, values: Object) -> Self {
-        self.globals = values;
-        self
-    }
-
-    pub fn with_filters(mut self, filters: &sync::Arc<HashMap<&'static str, BoxedValueFilter>>) -> Self {
-        self.filters = sync::Arc::clone(filters);
-        self
-    }
-
-    pub fn get_filter<'b>(&'b self, name: &str) -> Option<&'b FilterValue> {
-        self.filters.get(name).map(|f| {
-            let f: &FilterValue = f;
-            f
-        })
-    }
-
-    pub fn interrupt(&self) -> &InterruptState {
-        &self.interrupt
-    }
-
-    pub fn interrupt_mut(&mut self) -> &mut InterruptState {
-        &mut self.interrupt
-    }
-
-    pub fn cycles<'a>(&'a mut self) -> CycleState<'a> {
-        CycleState {
-            context: self,
+        Self {
+            globals: Object::new(),
+            // Mutable frame for globals.
+            stack: vec![Object::new()],
         }
     }
 
+    pub fn with_globals(&mut self, values: Object) {
+        self.globals = values;
+    }
+
     /// Creates a new variable scope chained to a parent scope.
-    fn push_scope(&mut self) {
+    fn push_frame(&mut self) {
         self.stack.push(Object::new());
     }
 
@@ -148,23 +119,10 @@ impl Context {
     /// empty stack. Given that a context is created with a top-level stack
     /// frame already in place, empyting the stack should never happen in a
     /// well-formed program.
-    fn pop_scope(&mut self) {
+    fn pop_frame(&mut self) {
         if self.stack.pop().is_none() {
             panic!("Pop leaves empty stack")
         };
-    }
-
-    /// Sets up a new stack frame, executes the supplied function and then
-    /// tears the stack frame down before returning the function's result
-    /// to the caller.
-    pub fn run_in_scope<RvalT, FnT>(&mut self, f: FnT) -> RvalT
-    where
-        FnT: FnOnce(&mut Context) -> RvalT,
-    {
-        self.push_scope();
-        let result = f(self);
-        self.pop_scope();
-        result
     }
 
     /// Gets a value from the rendering context.
@@ -204,7 +162,7 @@ impl Context {
     where
         S: Into<borrow::Cow<'static, str>>,
     {
-        self.globals.insert(name.into(), val)
+        self.global_frame().insert(name.into(), val)
     }
 
     /// Sets a value to the rendering context.
@@ -219,10 +177,96 @@ impl Context {
     where
         S: Into<borrow::Cow<'static, str>>,
     {
+        self.current_frame().insert(name.into(), val)
+    }
+
+    fn current_frame(&mut self) -> &mut Object {
         match self.stack.last_mut() {
-            Some(frame) => frame.insert(name.into(), val),
-            None => panic!("Cannot insert into an empty stack"),
+            Some(frame) => frame,
+            None => panic!("Global frame removed."),
         }
+    }
+
+    fn global_frame(&mut self) -> &mut Object {
+        match self.stack.first_mut() {
+            Some(frame) => frame,
+            None => panic!("Global frame removed."),
+        }
+    }
+}
+
+impl Default for Stack {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Default)]
+pub struct Context {
+    stack: Stack,
+
+    interrupt: InterruptState,
+    cycles: CycleStateInner,
+
+    filters: sync::Arc<HashMap<&'static str, BoxedValueFilter>>,
+}
+
+impl Context {
+    /// Creates a new, empty rendering context.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn with_values(mut self, values: Object) -> Self {
+        self.stack.with_globals(values);
+        self
+    }
+
+    pub fn with_filters(mut self, filters: &sync::Arc<HashMap<&'static str, BoxedValueFilter>>) -> Self {
+        self.filters = sync::Arc::clone(filters);
+        self
+    }
+
+    pub fn get_filter<'b>(&'b self, name: &str) -> Option<&'b FilterValue> {
+        self.filters.get(name).map(|f| {
+            let f: &FilterValue = f;
+            f
+        })
+    }
+
+    pub fn interrupt(&self) -> &InterruptState {
+        &self.interrupt
+    }
+
+    pub fn interrupt_mut(&mut self) -> &mut InterruptState {
+        &mut self.interrupt
+    }
+
+    pub fn cycles<'a>(&'a mut self) -> CycleState<'a> {
+        CycleState {
+            context: self,
+        }
+    }
+
+    pub fn stack(&self) -> &Stack {
+        &self.stack
+    }
+
+    pub fn stack_mut(&mut self) -> &mut Stack {
+        &mut self.stack
+    }
+
+    /// Sets up a new stack frame, executes the supplied function and then
+    /// tears the stack frame down before returning the function's result
+    /// to the caller.
+    pub fn run_in_scope<RvalT, FnT>(&mut self, f: FnT) -> RvalT
+    where
+        FnT: FnOnce(&mut Context) -> RvalT,
+    {
+        self.stack.push_frame();
+        let result = f(self);
+        self.stack.pop_frame();
+        result
     }
 }
 
@@ -233,8 +277,8 @@ mod test {
     #[test]
     fn get_val() {
         let mut ctx = Context::new();
-        ctx.set_global_val("number", Value::scalar(42f64));
-        assert_eq!(ctx.get_val("number").unwrap(), &Value::scalar(42f64));
+        ctx.stack_mut().set_global_val("number", Value::scalar(42f64));
+        assert_eq!(ctx.stack().get_val("number").unwrap(), &Value::scalar(42f64));
     }
 
     #[test]
@@ -242,8 +286,8 @@ mod test {
         let mut ctx = Context::new();
         let mut post = Object::new();
         post.insert("number".into(), Value::scalar(42f64));
-        ctx.set_global_val("post", Value::Object(post));
-        assert!(ctx.get_val("post.number").is_none());
+        ctx.stack_mut().set_global_val("post", Value::Object(post));
+        assert!(ctx.stack().get_val("post.number").is_none());
     }
 
     #[test]
@@ -251,10 +295,10 @@ mod test {
         let mut ctx = Context::new();
         let mut post = Object::new();
         post.insert("number".into(), Value::scalar(42f64));
-        ctx.set_global_val("post", Value::Object(post));
+        ctx.stack_mut().set_global_val("post", Value::Object(post));
         let indexes = vec![Index::with_key("post"), Index::with_key("number")];
         assert_eq!(
-            ctx.get_val_by_index(indexes.iter()).unwrap(),
+            ctx.stack().get_val_by_index(indexes.iter()).unwrap(),
             &Value::scalar(42f64)
         );
     }
@@ -262,23 +306,23 @@ mod test {
     #[test]
     fn scoped_variables() {
         let mut ctx = Context::new();
-        ctx.set_global_val("test", Value::scalar(42f64));
-        assert_eq!(ctx.get_val("test").unwrap(), &Value::scalar(42f64));
+        ctx.stack_mut().set_global_val("test", Value::scalar(42f64));
+        assert_eq!(ctx.stack().get_val("test").unwrap(), &Value::scalar(42f64));
 
         ctx.run_in_scope(|new_scope| {
             // assert that values are chained to the parent scope
-            assert_eq!(new_scope.get_val("test").unwrap(), &Value::scalar(42f64));
+            assert_eq!(new_scope.stack().get_val("test").unwrap(), &Value::scalar(42f64));
 
             // set a new local value, and assert that it overrides the previous value
-            new_scope.set_val("test", Value::scalar(3.14f64));
-            assert_eq!(new_scope.get_val("test").unwrap(), &Value::scalar(3.14f64));
+            new_scope.stack_mut().set_val("test", Value::scalar(3.14f64));
+            assert_eq!(new_scope.stack().get_val("test").unwrap(), &Value::scalar(3.14f64));
 
             // sat a new val that we will pick up outside the scope
-            new_scope.set_global_val("global", Value::scalar("some value"));
+            new_scope.stack_mut().set_global_val("global", Value::scalar("some value"));
         });
 
         // assert that the value has reverted to the old one
-        assert_eq!(ctx.get_val("test").unwrap(), &Value::scalar(42f64));
-        assert_eq!(ctx.get_val("global").unwrap(), &Value::scalar("some value"));
+        assert_eq!(ctx.stack().get_val("test").unwrap(), &Value::scalar(42f64));
+        assert_eq!(ctx.stack().get_val("global").unwrap(), &Value::scalar("some value"));
     }
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -8,7 +8,9 @@ mod text;
 mod variable;
 
 pub use self::argument::Argument;
-pub use self::context::{unexpected_value_error, ContextBuilder, Context, Interrupt, InterruptState};
+pub use self::context::{
+    unexpected_value_error, Context, ContextBuilder, Interrupt, InterruptState,
+};
 pub use self::filter::{BoxedValueFilter, FilterError, FilterResult, FilterValue, FnFilterValue};
 pub use self::output::{FilterPrototype, Output};
 pub use self::renderable::Renderable;

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -8,7 +8,7 @@ mod text;
 mod variable;
 
 pub use self::argument::Argument;
-pub use self::context::{unexpected_value_error, Context, Interrupt};
+pub use self::context::{unexpected_value_error, Context, Interrupt, InterruptState};
 pub use self::filter::{BoxedValueFilter, FilterError, FilterResult, FilterValue, FnFilterValue};
 pub use self::output::{FilterPrototype, Output};
 pub use self::renderable::Renderable;

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -8,7 +8,7 @@ mod text;
 mod variable;
 
 pub use self::argument::Argument;
-pub use self::context::{unexpected_value_error, Context, Interrupt, InterruptState};
+pub use self::context::{unexpected_value_error, ContextBuilder, Context, Interrupt, InterruptState};
 pub use self::filter::{BoxedValueFilter, FilterError, FilterResult, FilterValue, FnFilterValue};
 pub use self::output::{FilterPrototype, Output};
 pub use self::renderable::Renderable;

--- a/src/interpreter/output.rs
+++ b/src/interpreter/output.rs
@@ -82,7 +82,8 @@ impl Output {
                 .map(|a| a.evaluate(context))
                 .collect();
             let arguments = arguments?;
-            entry = f.filter(&entry, &*arguments)
+            entry = f
+                .filter(&entry, &*arguments)
                 .chain("Filter error")
                 .context("input", &entry)
                 .context_with(|| ("args".into(), itertools::join(&arguments, ", ")))?;

--- a/src/interpreter/renderable.rs
+++ b/src/interpreter/renderable.rs
@@ -1,8 +1,8 @@
 use std::fmt::Debug;
 use std::io::Write;
 
-use error::Result;
 use super::Context;
+use error::Result;
 
 /// Any object (tag/block) that can be rendered by liquid must implement this trait.
 pub trait Renderable: Send + Sync + Debug {

--- a/src/interpreter/template.rs
+++ b/src/interpreter/template.rs
@@ -1,8 +1,8 @@
 use std::io::Write;
 
-use error::Result;
 use super::Context;
 use super::Renderable;
+use error::Result;
 
 #[derive(Debug)]
 pub struct Template {

--- a/src/interpreter/template.rs
+++ b/src/interpreter/template.rs
@@ -18,7 +18,7 @@ impl Renderable for Template {
             // need to abandon the rest of our child elements and just
             // return what we've got. This is usually in response to a
             // `break` or `continue` tag being rendered.
-            if context.interrupted() {
+            if context.interrupt().interrupted() {
                 break;
             }
         }

--- a/src/interpreter/text.rs
+++ b/src/interpreter/text.rs
@@ -1,8 +1,8 @@
 use std::io::Write;
 
-use error::{Result, ResultLiquidChainExt};
 use super::Context;
 use super::Renderable;
+use error::{Result, ResultLiquidChainExt};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Text {

--- a/src/interpreter/variable.rs
+++ b/src/interpreter/variable.rs
@@ -40,7 +40,7 @@ impl fmt::Display for Variable {
 
 impl Renderable for Variable {
     fn render_to(&self, writer: &mut Write, context: &mut Context) -> Result<()> {
-        let value = context.get_val_by_index(self.indexes.iter())?;
+        let value = context.stack().get_val_by_index(self.indexes.iter())?;
         write!(writer, "{}", value).chain("Failed to render")?;
         Ok(())
     }

--- a/src/tags/assign_tag.rs
+++ b/src/tags/assign_tag.rs
@@ -1,10 +1,10 @@
 use std::io::Write;
 
-use error::Result;
 use compiler::LiquidOptions;
 use compiler::ResultLiquidExt;
 use compiler::Token;
 use compiler::{expect, parse_output, unexpected_token_error};
+use error::Result;
 use interpreter::Context;
 use interpreter::Output;
 use interpreter::Renderable;
@@ -23,10 +23,13 @@ impl Assign {
 
 impl Renderable for Assign {
     fn render_to(&self, _writer: &mut Write, context: &mut Context) -> Result<()> {
-        let value = self.src
+        let value = self
+            .src
             .apply_filters(context)
             .trace_with(|| self.trace().into())?;
-        context.stack_mut().set_global_val(self.dst.to_owned(), value);
+        context
+            .stack_mut()
+            .set_global_val(self.dst.to_owned(), value);
         Ok(())
     }
 }
@@ -101,7 +104,10 @@ mod test {
             );
 
             let output = template.render(&mut context).unwrap();
-            assert_eq!(context.stack().get_val("freestyle"), Some(&Value::scalar(false)));
+            assert_eq!(
+                context.stack().get_val("freestyle"),
+                Some(&Value::scalar(false))
+            );
             assert_eq!(output, "");
         }
 
@@ -119,7 +125,10 @@ mod test {
             );
 
             let output = template.render(&mut context).unwrap();
-            assert_eq!(context.stack().get_val("freestyle"), Some(&Value::scalar(true)));
+            assert_eq!(
+                context.stack().get_val("freestyle"),
+                Some(&Value::scalar(true))
+            );
             assert_eq!(output, "<p>Freestyle!</p>");
         }
     }

--- a/src/tags/assign_tag.rs
+++ b/src/tags/assign_tag.rs
@@ -26,7 +26,7 @@ impl Renderable for Assign {
         let value = self.src
             .apply_filters(context)
             .trace_with(|| self.trace().into())?;
-        context.set_global_val(self.dst.to_owned(), value);
+        context.stack_mut().set_global_val(self.dst.to_owned(), value);
         Ok(())
     }
 }
@@ -91,7 +91,7 @@ mod test {
         // test one: no matching value in `tags`
         {
             let mut context = Context::new();
-            context.set_global_val(
+            context.stack_mut().set_global_val(
                 "tags",
                 Value::Array(vec![
                     Value::scalar("alpha"),
@@ -101,14 +101,14 @@ mod test {
             );
 
             let output = template.render(&mut context).unwrap();
-            assert_eq!(context.get_val("freestyle"), Some(&Value::scalar(false)));
+            assert_eq!(context.stack().get_val("freestyle"), Some(&Value::scalar(false)));
             assert_eq!(output, "");
         }
 
         // test two: matching value in `tags`
         {
             let mut context = Context::new();
-            context.set_global_val(
+            context.stack_mut().set_global_val(
                 "tags",
                 Value::Array(vec![
                     Value::scalar("alpha"),
@@ -119,7 +119,7 @@ mod test {
             );
 
             let output = template.render(&mut context).unwrap();
-            assert_eq!(context.get_val("freestyle"), Some(&Value::scalar(true)));
+            assert_eq!(context.stack().get_val("freestyle"), Some(&Value::scalar(true)));
             assert_eq!(output, "<p>Freestyle!</p>");
         }
     }

--- a/src/tags/capture_block.rs
+++ b/src/tags/capture_block.rs
@@ -1,10 +1,10 @@
 use std::io::Write;
 
-use error::{Result, ResultLiquidExt};
 use compiler::Element;
 use compiler::LiquidOptions;
 use compiler::Token;
 use compiler::{parse, unexpected_token_error};
+use error::{Result, ResultLiquidExt};
 use interpreter::Context;
 use interpreter::Renderable;
 use interpreter::Template;
@@ -30,7 +30,9 @@ impl Renderable for Capture {
             .trace_with(|| self.trace().into())?;
 
         let output = String::from_utf8(captured).expect("render only writes UTF-8");
-        context.stack_mut().set_global_val(self.id.to_owned(), Value::scalar(output));
+        context
+            .stack_mut()
+            .set_global_val(self.id.to_owned(), Value::scalar(output));
         Ok(())
     }
 }
@@ -53,7 +55,7 @@ pub fn capture_block(
     };
 
     let t = Template::new(
-        parse(tokens, options).trace_with(|| format!("{{% capture {} %}}", &id).into())?
+        parse(tokens, options).trace_with(|| format!("{{% capture {} %}}", &id).into())?,
     );
 
     Ok(Box::new(Capture { id, template: t }))
@@ -87,7 +89,8 @@ mod test {
             .unwrap();
 
         let mut ctx = Context::new();
-        ctx.stack_mut().set_global_val("item", Value::scalar("potato"));
+        ctx.stack_mut()
+            .set_global_val("item", Value::scalar("potato"));
         ctx.stack_mut().set_global_val("i", Value::scalar(42f64));
 
         let output = template.render(&mut ctx).unwrap();

--- a/src/tags/capture_block.rs
+++ b/src/tags/capture_block.rs
@@ -30,7 +30,7 @@ impl Renderable for Capture {
             .trace_with(|| self.trace().into())?;
 
         let output = String::from_utf8(captured).expect("render only writes UTF-8");
-        context.set_global_val(self.id.to_owned(), Value::scalar(output));
+        context.stack_mut().set_global_val(self.id.to_owned(), Value::scalar(output));
         Ok(())
     }
 }
@@ -87,12 +87,12 @@ mod test {
             .unwrap();
 
         let mut ctx = Context::new();
-        ctx.set_global_val("item", Value::scalar("potato"));
-        ctx.set_global_val("i", Value::scalar(42f64));
+        ctx.stack_mut().set_global_val("item", Value::scalar("potato"));
+        ctx.stack_mut().set_global_val("i", Value::scalar(42f64));
 
         let output = template.render(&mut ctx).unwrap();
         assert_eq!(
-            ctx.get_val("attribute_name"),
+            ctx.stack().get_val("attribute_name"),
             Some(&Value::scalar("potato-42-color"))
         );
         assert_eq!(output, "");

--- a/src/tags/case_block.rs
+++ b/src/tags/case_block.rs
@@ -2,11 +2,11 @@ use std::io::Write;
 
 use itertools;
 
-use error::{Error, Result, ResultLiquidExt};
 use compiler::Element;
 use compiler::LiquidOptions;
 use compiler::Token;
 use compiler::{consume_value_token, parse, split_block, unexpected_token_error, BlockSplit};
+use error::{Error, Result, ResultLiquidExt};
 use interpreter::Argument;
 use interpreter::Context;
 use interpreter::Renderable;
@@ -57,7 +57,8 @@ impl Renderable for Case {
         let value = self.target.evaluate(context)?;
         for case in &self.cases {
             if case.evaluate(&value, context)? {
-                return case.template
+                return case
+                    .template
                     .render_to(writer, context)
                     .trace_with(|| case.trace().into())
                     .trace_with(|| self.trace().into())
@@ -66,7 +67,8 @@ impl Renderable for Case {
         }
 
         if let Some(ref t) = self.else_block {
-            return t.render_to(writer, context)
+            return t
+                .render_to(writer, context)
                 .trace_with(|| "{{% else %}}".to_owned().into())
                 .trace_with(|| self.trace().into())
                 .context_with(|| (self.target.to_string().into(), value.to_string()));
@@ -131,7 +133,7 @@ fn parse_sections<'e>(
         Conditional::Else => {
             if case.else_block.is_none() {
                 let template = Template::new(
-                    parse(leading, options).trace_with(|| "{{% else %}}".to_owned().into())?
+                    parse(leading, options).trace_with(|| "{{% else %}}".to_owned().into())?,
                 );
                 case.else_block = Some(template)
             } else {
@@ -210,28 +212,18 @@ mod test {
 
         let mut context = Context::new();
         context.stack_mut().set_global_val("x", Value::scalar(2f64));
-        assert_eq!(
-            template.render(&mut context).unwrap(),
-            "two"
-        );
+        assert_eq!(template.render(&mut context).unwrap(), "two");
 
         context.stack_mut().set_global_val("x", Value::scalar(3f64));
-        assert_eq!(
-            template.render(&mut context).unwrap(),
-            "three and a half"
-        );
+        assert_eq!(template.render(&mut context).unwrap(), "three and a half");
 
         context.stack_mut().set_global_val("x", Value::scalar(4f64));
-        assert_eq!(
-            template.render(&mut context).unwrap(),
-            "three and a half"
-        );
+        assert_eq!(template.render(&mut context).unwrap(), "three and a half");
 
-        context.stack_mut().set_global_val("x", Value::scalar("nope"));
-        assert_eq!(
-            template.render(&mut context).unwrap(),
-            "otherwise"
-        );
+        context
+            .stack_mut()
+            .set_global_val("x", Value::scalar("nope"));
+        assert_eq!(template.render(&mut context).unwrap(), "otherwise");
     }
 
     #[test]
@@ -251,7 +243,9 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.stack_mut().set_global_val("x", Value::scalar("nope"));
+        context
+            .stack_mut()
+            .set_global_val("x", Value::scalar("nope"));
         assert_eq!(template.render(&mut context).unwrap(), "");
     }
 

--- a/src/tags/case_block.rs
+++ b/src/tags/case_block.rs
@@ -209,25 +209,25 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.set_global_val("x", Value::scalar(2f64));
+        context.stack_mut().set_global_val("x", Value::scalar(2f64));
         assert_eq!(
             template.render(&mut context).unwrap(),
             "two"
         );
 
-        context.set_global_val("x", Value::scalar(3f64));
+        context.stack_mut().set_global_val("x", Value::scalar(3f64));
         assert_eq!(
             template.render(&mut context).unwrap(),
             "three and a half"
         );
 
-        context.set_global_val("x", Value::scalar(4f64));
+        context.stack_mut().set_global_val("x", Value::scalar(4f64));
         assert_eq!(
             template.render(&mut context).unwrap(),
             "three and a half"
         );
 
-        context.set_global_val("x", Value::scalar("nope"));
+        context.stack_mut().set_global_val("x", Value::scalar("nope"));
         assert_eq!(
             template.render(&mut context).unwrap(),
             "otherwise"
@@ -251,7 +251,7 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.set_global_val("x", Value::scalar("nope"));
+        context.stack_mut().set_global_val("x", Value::scalar("nope"));
         assert_eq!(template.render(&mut context).unwrap(), "");
     }
 

--- a/src/tags/comment_block.rs
+++ b/src/tags/comment_block.rs
@@ -1,9 +1,9 @@
 use std::io::Write;
 
-use error::Result;
 use compiler::Element;
 use compiler::LiquidOptions;
 use compiler::Token;
+use error::Result;
 use interpreter::Context;
 use interpreter::Renderable;
 

--- a/src/tags/cycle_tag.rs
+++ b/src/tags/cycle_tag.rs
@@ -175,9 +175,9 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.set_global_val("alpha", Value::scalar(1f64));
-        context.set_global_val("beta", Value::scalar(2f64));
-        context.set_global_val("gamma", Value::scalar(3f64));
+        context.stack_mut().set_global_val("alpha", Value::scalar(1f64));
+        context.stack_mut().set_global_val("beta", Value::scalar(2f64));
+        context.stack_mut().set_global_val("gamma", Value::scalar(3f64));
 
         let output = template.render(&mut context);
 

--- a/src/tags/cycle_tag.rs
+++ b/src/tags/cycle_tag.rs
@@ -2,10 +2,10 @@ use std::io::Write;
 
 use itertools;
 
-use error::{Result, ResultLiquidChainExt, ResultLiquidExt};
 use compiler::LiquidOptions;
 use compiler::Token;
 use compiler::{consume_value_token, unexpected_token_error, value_token};
+use error::{Result, ResultLiquidChainExt, ResultLiquidExt};
 use interpreter::Argument;
 use interpreter::Context;
 use interpreter::Renderable;
@@ -28,7 +28,8 @@ impl Cycle {
 impl Renderable for Cycle {
     fn render_to(&self, writer: &mut Write, context: &mut Context) -> Result<()> {
         let value = context
-            .cycles().cycle_element(&self.name, &self.values)
+            .cycles()
+            .cycle_element(&self.name, &self.values)
             .trace_with(|| self.trace().into())?;
         write!(writer, "{}", value).chain("Failed to render")?;
         Ok(())
@@ -175,9 +176,15 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.stack_mut().set_global_val("alpha", Value::scalar(1f64));
-        context.stack_mut().set_global_val("beta", Value::scalar(2f64));
-        context.stack_mut().set_global_val("gamma", Value::scalar(3f64));
+        context
+            .stack_mut()
+            .set_global_val("alpha", Value::scalar(1f64));
+        context
+            .stack_mut()
+            .set_global_val("beta", Value::scalar(2f64));
+        context
+            .stack_mut()
+            .set_global_val("gamma", Value::scalar(3f64));
 
         let output = template.render(&mut context);
 

--- a/src/tags/cycle_tag.rs
+++ b/src/tags/cycle_tag.rs
@@ -28,11 +28,9 @@ impl Cycle {
 impl Renderable for Cycle {
     fn render_to(&self, writer: &mut Write, context: &mut Context) -> Result<()> {
         let value = context
-            .cycle_element(&self.name, &self.values)
+            .cycles().cycle_element(&self.name, &self.values)
             .trace_with(|| self.trace().into())?;
-        if let Some(ref value) = value {
-            write!(writer, "{}", value).chain("Failed to render")?;
-        }
+        write!(writer, "{}", value).chain("Failed to render")?;
         Ok(())
     }
 }

--- a/src/tags/for_block.rs
+++ b/src/tags/for_block.rs
@@ -155,7 +155,7 @@ impl Renderable for For {
                         // already, dealing with a `continue` signal is just
                         // clearing the interrupt and carrying on as normal. A
                         // `break` requires some special handling, though.
-                        if let Some(Interrupt::Break) = scope.pop_interrupt() {
+                        if let Some(Interrupt::Break) = scope.interrupt_mut().pop_interrupt() {
                             break;
                         }
                     }

--- a/src/tags/for_block.rs
+++ b/src/tags/for_block.rs
@@ -299,6 +299,7 @@ mod test {
     use std::collections::HashMap;
     use std::sync;
 
+    use interpreter::ContextBuilder;
     use compiler;
     use interpreter;
 
@@ -636,7 +637,7 @@ mod test {
                 as interpreter::FnFilterValue)
                 .into(),
                     );
-        let mut context = Context::new().with_filters(&sync::Arc::new(filters));
+        let mut context = ContextBuilder::new().set_filters(&sync::Arc::new(filters)).build();
 
         context.stack_mut().set_global_val(
             "array",

--- a/src/tags/for_block.rs
+++ b/src/tags/for_block.rs
@@ -143,8 +143,8 @@ impl Renderable for For {
                         helper_vars.insert("first".into(), Value::scalar(i == 0));
                         helper_vars.insert("last".into(), Value::scalar(i == (range_len - 1)));
 
-                        scope.set_val("forloop", Value::Object(helper_vars.clone()));
-                        scope.set_val(self.var_name.to_owned(), v.clone());
+                        scope.stack_mut().set_val("forloop", Value::Object(helper_vars.clone()));
+                        scope.stack_mut().set_val(self.var_name.to_owned(), v.clone());
                         self.item_template
                             .render_to(writer, &mut scope)
                             .trace_with(|| self.trace().into())
@@ -326,8 +326,8 @@ mod test {
             &options,
         ).unwrap();
 
-        let mut data: Context = Default::default();
-        data.set_global_val(
+        let mut context: Context = Default::default();
+        context.stack_mut().set_global_val(
             "array",
             Value::Array(vec![
                 Value::scalar(22f64),
@@ -336,7 +336,7 @@ mod test {
                 Value::scalar("wat".to_owned()),
             ]),
         );
-        let output = for_tag.render(&mut data).unwrap();
+        let output = for_tag.render(&mut context).unwrap();
         assert_eq!(output, "test 22 test 23 test 24 test wat ");
     }
 
@@ -379,8 +379,8 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.set_global_val("alpha", Value::scalar(42i32));
-        context.set_global_val("omega", Value::scalar(46i32));
+        context.stack_mut().set_global_val("alpha", Value::scalar(42i32));
+        context.stack_mut().set_global_val("omega", Value::scalar(46i32));
         let output = template.render(&mut context).unwrap();
         assert_eq!(
             output,
@@ -436,13 +436,13 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.set_global_val("i", Value::scalar(0i32));
-        context.set_global_val("j", Value::scalar(0i32));
+        context.stack_mut().set_global_val("i", Value::scalar(0i32));
+        context.stack_mut().set_global_val("j", Value::scalar(0i32));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "empty outer");
 
-        context.set_global_val("i", Value::scalar(1i32));
-        context.set_global_val("j", Value::scalar(0i32));
+        context.stack_mut().set_global_val("i", Value::scalar(1i32));
+        context.stack_mut().set_global_val("j", Value::scalar(0i32));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "empty inner");
     }
@@ -636,9 +636,9 @@ mod test {
                 as interpreter::FnFilterValue)
                 .into(),
                     );
-        let mut data = Context::new().with_filters(&sync::Arc::new(filters));
+        let mut context = Context::new().with_filters(&sync::Arc::new(filters));
 
-        data.set_global_val(
+        context.stack_mut().set_global_val(
             "array",
             Value::Array(vec![
                 Value::scalar("alpha"),
@@ -646,7 +646,7 @@ mod test {
                 Value::scalar("gamma"),
             ]),
         );
-        let output = for_tag.render(&mut data).unwrap();
+        let output = for_tag.render(&mut context).unwrap();
         assert_eq!(output, "test ALPHA test BETA test GAMMA ");
     }
 }

--- a/src/tags/if_block.rs
+++ b/src/tags/if_block.rs
@@ -317,19 +317,19 @@ mod test {
 
         // Explicit nil
         let mut context = Context::new();
-        context.set_global_val("truthy", Value::Nil);
+        context.stack_mut().set_global_val("truthy", Value::Nil);
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "nope");
 
         // false
         let mut context = Context::new();
-        context.set_global_val("truthy", Value::scalar(false));
+        context.stack_mut().set_global_val("truthy", Value::scalar(false));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "nope");
 
         // true
         let mut context = Context::new();
-        context.set_global_val("truthy", Value::scalar(true));
+        context.stack_mut().set_global_val("truthy", Value::scalar(true));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "yep");
     }
@@ -348,7 +348,7 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.set_global_val("some_value", Value::scalar(1f64));
+        context.stack_mut().set_global_val("some_value", Value::scalar(1f64));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "");
 
@@ -358,7 +358,7 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.set_global_val("some_value", Value::scalar(42f64));
+        context.stack_mut().set_global_val("some_value", Value::scalar(42f64));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "unless body");
     }
@@ -383,8 +383,8 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.set_global_val("truthy", Value::scalar(true));
-        context.set_global_val("also_truthy", Value::scalar(false));
+        context.stack_mut().set_global_val("truthy", Value::scalar(true));
+        context.stack_mut().set_global_val("also_truthy", Value::scalar(false));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "yep, not also truthy");
     }
@@ -409,7 +409,7 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.set_global_val("a", Value::scalar(1f64));
+        context.stack_mut().set_global_val("a", Value::scalar(1f64));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "first");
 
@@ -419,7 +419,7 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.set_global_val("a", Value::scalar(2f64));
+        context.stack_mut().set_global_val("a", Value::scalar(2f64));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "second");
 
@@ -429,7 +429,7 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.set_global_val("a", Value::scalar(3f64));
+        context.stack_mut().set_global_val("a", Value::scalar(3f64));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "third");
 
@@ -439,7 +439,7 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.set_global_val("a", Value::scalar("else"));
+        context.stack_mut().set_global_val("a", Value::scalar("else"));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "fourth");
     }
@@ -476,7 +476,7 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.set_global_val("movie", Value::scalar("Star Wars"));
+        context.stack_mut().set_global_val("movie", Value::scalar("Star Wars"));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "if true");
 
@@ -487,7 +487,7 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.set_global_val("movie", Value::scalar("Batman"));
+        context.stack_mut().set_global_val("movie", Value::scalar("Batman"));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "if false");
     }
@@ -503,7 +503,7 @@ mod test {
         let mut context = Context::new();
         let mut obj = Object::new();
         obj.insert("Star Wars".into(), Value::scalar("1977"));
-        context.set_global_val("movies", Value::Object(obj));
+        context.stack_mut().set_global_val("movies", Value::Object(obj));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "if true");
     }
@@ -518,7 +518,7 @@ mod test {
 
         let mut context = Context::new();
         let obj = Object::new();
-        context.set_global_val("movies", Value::Object(obj));
+        context.stack_mut().set_global_val("movies", Value::Object(obj));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "if false");
     }
@@ -537,7 +537,7 @@ mod test {
             Value::scalar("Star Trek"),
             Value::scalar("Alien"),
         ];
-        context.set_global_val("movies", Value::Array(arr));
+        context.stack_mut().set_global_val("movies", Value::Array(arr));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "if true");
     }
@@ -552,7 +552,7 @@ mod test {
 
         let mut context = Context::new();
         let arr = vec![Value::scalar("Alien")];
-        context.set_global_val("movies", Value::Array(arr));
+        context.stack_mut().set_global_val("movies", Value::Array(arr));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "if false");
     }

--- a/src/tags/if_block.rs
+++ b/src/tags/if_block.rs
@@ -139,10 +139,10 @@ impl Renderable for Conditional {
                 .render_to(writer, context)
                 .trace_with(|| self.trace().into())?;
         } else if let Some(ref template) = self.if_false {
-                template
-                    .render_to(writer, context)
-                    .trace_with(|| "{{% else %}}".to_owned().into())
-                    .trace_with(|| self.trace().into())?;
+            template
+                .render_to(writer, context)
+                .trace_with(|| "{{% else %}}".to_owned().into())
+                .trace_with(|| self.trace().into())?;
         }
 
         Ok(())
@@ -323,13 +323,17 @@ mod test {
 
         // false
         let mut context = Context::new();
-        context.stack_mut().set_global_val("truthy", Value::scalar(false));
+        context
+            .stack_mut()
+            .set_global_val("truthy", Value::scalar(false));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "nope");
 
         // true
         let mut context = Context::new();
-        context.stack_mut().set_global_val("truthy", Value::scalar(true));
+        context
+            .stack_mut()
+            .set_global_val("truthy", Value::scalar(true));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "yep");
     }
@@ -348,7 +352,9 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.stack_mut().set_global_val("some_value", Value::scalar(1f64));
+        context
+            .stack_mut()
+            .set_global_val("some_value", Value::scalar(1f64));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "");
 
@@ -358,7 +364,9 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.stack_mut().set_global_val("some_value", Value::scalar(42f64));
+        context
+            .stack_mut()
+            .set_global_val("some_value", Value::scalar(42f64));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "unless body");
     }
@@ -383,8 +391,12 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.stack_mut().set_global_val("truthy", Value::scalar(true));
-        context.stack_mut().set_global_val("also_truthy", Value::scalar(false));
+        context
+            .stack_mut()
+            .set_global_val("truthy", Value::scalar(true));
+        context
+            .stack_mut()
+            .set_global_val("also_truthy", Value::scalar(false));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "yep, not also truthy");
     }
@@ -439,7 +451,9 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.stack_mut().set_global_val("a", Value::scalar("else"));
+        context
+            .stack_mut()
+            .set_global_val("a", Value::scalar("else"));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "fourth");
     }
@@ -476,7 +490,9 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.stack_mut().set_global_val("movie", Value::scalar("Star Wars"));
+        context
+            .stack_mut()
+            .set_global_val("movie", Value::scalar("Star Wars"));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "if true");
 
@@ -487,7 +503,9 @@ mod test {
             .unwrap();
 
         let mut context = Context::new();
-        context.stack_mut().set_global_val("movie", Value::scalar("Batman"));
+        context
+            .stack_mut()
+            .set_global_val("movie", Value::scalar("Batman"));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "if false");
     }
@@ -503,7 +521,9 @@ mod test {
         let mut context = Context::new();
         let mut obj = Object::new();
         obj.insert("Star Wars".into(), Value::scalar("1977"));
-        context.stack_mut().set_global_val("movies", Value::Object(obj));
+        context
+            .stack_mut()
+            .set_global_val("movies", Value::Object(obj));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "if true");
     }
@@ -518,7 +538,9 @@ mod test {
 
         let mut context = Context::new();
         let obj = Object::new();
-        context.stack_mut().set_global_val("movies", Value::Object(obj));
+        context
+            .stack_mut()
+            .set_global_val("movies", Value::Object(obj));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "if false");
     }
@@ -537,7 +559,9 @@ mod test {
             Value::scalar("Star Trek"),
             Value::scalar("Alien"),
         ];
-        context.stack_mut().set_global_val("movies", Value::Array(arr));
+        context
+            .stack_mut()
+            .set_global_val("movies", Value::Array(arr));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "if true");
     }
@@ -552,7 +576,9 @@ mod test {
 
         let mut context = Context::new();
         let arr = vec![Value::scalar("Alien")];
-        context.stack_mut().set_global_val("movies", Value::Array(arr));
+        context
+            .stack_mut()
+            .set_global_val("movies", Value::Array(arr));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "if false");
     }

--- a/src/tags/include_tag.rs
+++ b/src/tags/include_tag.rs
@@ -65,6 +65,7 @@ mod test {
     use value;
     use compiler;
     use filters;
+    use interpreter::ContextBuilder;
     use interpreter;
 
     use super::*;
@@ -97,7 +98,7 @@ mod test {
 
         let mut filters: HashMap<&'static str, interpreter::BoxedValueFilter> = HashMap::new();
         filters.insert("size",(filters::size as interpreter::FnFilterValue).into());
-        let mut context = Context::new().with_filters(&sync::Arc::new(filters));
+        let mut context = ContextBuilder::new().set_filters(&sync::Arc::new(filters)).build();
         context.stack_mut().set_global_val("num", value::Value::scalar(5f64));
         context.stack_mut().set_global_val("numTwo", value::Value::scalar(10f64));
         let output = template.render(&mut context).unwrap();
@@ -114,7 +115,7 @@ mod test {
 
         let mut filters: HashMap<&'static str, interpreter::BoxedValueFilter> = HashMap::new();
         filters.insert("size",(filters::size as interpreter::FnFilterValue).into());
-        let mut context = Context::new().with_filters(&sync::Arc::new(filters));
+        let mut context = ContextBuilder::new().set_filters(&sync::Arc::new(filters)).build();
         context.stack_mut().set_global_val("num", value::Value::scalar(5f64));
         context.stack_mut().set_global_val("numTwo", value::Value::scalar(10f64));
         let output = template.render(&mut context).unwrap();

--- a/src/tags/include_tag.rs
+++ b/src/tags/include_tag.rs
@@ -1,10 +1,10 @@
 use std::io::Write;
 
-use error::{Result, ResultLiquidExt};
 use compiler::tokenize;
 use compiler::LiquidOptions;
 use compiler::Token;
 use compiler::{parse, unexpected_token_error};
+use error::{Result, ResultLiquidExt};
 use interpreter::Context;
 use interpreter::Renderable;
 use interpreter::Template;
@@ -56,17 +56,17 @@ pub fn include_tag(
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
     use std::iter::FromIterator;
     use std::path;
-    use std::collections::HashMap;
     use std::sync;
 
-    use tags;
-    use value;
     use compiler;
     use filters;
-    use interpreter::ContextBuilder;
     use interpreter;
+    use interpreter::ContextBuilder;
+    use tags;
+    use value;
 
     use super::*;
 
@@ -97,10 +97,16 @@ mod test {
             .unwrap();
 
         let mut filters: HashMap<&'static str, interpreter::BoxedValueFilter> = HashMap::new();
-        filters.insert("size",(filters::size as interpreter::FnFilterValue).into());
-        let mut context = ContextBuilder::new().set_filters(&sync::Arc::new(filters)).build();
-        context.stack_mut().set_global_val("num", value::Value::scalar(5f64));
-        context.stack_mut().set_global_val("numTwo", value::Value::scalar(10f64));
+        filters.insert("size", (filters::size as interpreter::FnFilterValue).into());
+        let mut context = ContextBuilder::new()
+            .set_filters(&sync::Arc::new(filters))
+            .build();
+        context
+            .stack_mut()
+            .set_global_val("num", value::Value::scalar(5f64));
+        context
+            .stack_mut()
+            .set_global_val("numTwo", value::Value::scalar(10f64));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "5 wat wot\n");
     }
@@ -114,10 +120,16 @@ mod test {
             .unwrap();
 
         let mut filters: HashMap<&'static str, interpreter::BoxedValueFilter> = HashMap::new();
-        filters.insert("size",(filters::size as interpreter::FnFilterValue).into());
-        let mut context = ContextBuilder::new().set_filters(&sync::Arc::new(filters)).build();
-        context.stack_mut().set_global_val("num", value::Value::scalar(5f64));
-        context.stack_mut().set_global_val("numTwo", value::Value::scalar(10f64));
+        filters.insert("size", (filters::size as interpreter::FnFilterValue).into());
+        let mut context = ContextBuilder::new()
+            .set_filters(&sync::Arc::new(filters))
+            .build();
+        context
+            .stack_mut()
+            .set_global_val("num", value::Value::scalar(5f64));
+        context
+            .stack_mut()
+            .set_global_val("numTwo", value::Value::scalar(10f64));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "5 wat wot\n");
     }

--- a/src/tags/include_tag.rs
+++ b/src/tags/include_tag.rs
@@ -98,8 +98,8 @@ mod test {
         let mut filters: HashMap<&'static str, interpreter::BoxedValueFilter> = HashMap::new();
         filters.insert("size",(filters::size as interpreter::FnFilterValue).into());
         let mut context = Context::new().with_filters(&sync::Arc::new(filters));
-        context.set_global_val("num", value::Value::scalar(5f64));
-        context.set_global_val("numTwo", value::Value::scalar(10f64));
+        context.stack_mut().set_global_val("num", value::Value::scalar(5f64));
+        context.stack_mut().set_global_val("numTwo", value::Value::scalar(10f64));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "5 wat wot\n");
     }
@@ -115,8 +115,8 @@ mod test {
         let mut filters: HashMap<&'static str, interpreter::BoxedValueFilter> = HashMap::new();
         filters.insert("size",(filters::size as interpreter::FnFilterValue).into());
         let mut context = Context::new().with_filters(&sync::Arc::new(filters));
-        context.set_global_val("num", value::Value::scalar(5f64));
-        context.set_global_val("numTwo", value::Value::scalar(10f64));
+        context.stack_mut().set_global_val("num", value::Value::scalar(5f64));
+        context.stack_mut().set_global_val("numTwo", value::Value::scalar(10f64));
         let output = template.render(&mut context).unwrap();
         assert_eq!(output, "5 wat wot\n");
     }

--- a/src/tags/interrupt_tags.rs
+++ b/src/tags/interrupt_tags.rs
@@ -1,9 +1,9 @@
 use std::io::Write;
 
-use error::Result;
 use compiler::unexpected_token_error;
 use compiler::LiquidOptions;
 use compiler::Token;
+use error::Result;
 use interpreter::Renderable;
 use interpreter::{Context, Interrupt};
 

--- a/src/tags/interrupt_tags.rs
+++ b/src/tags/interrupt_tags.rs
@@ -12,7 +12,7 @@ struct Break;
 
 impl Renderable for Break {
     fn render_to(&self, _writer: &mut Write, context: &mut Context) -> Result<()> {
-        context.set_interrupt(Interrupt::Break);
+        context.interrupt_mut().set_interrupt(Interrupt::Break);
         Ok(())
     }
 }
@@ -34,7 +34,7 @@ struct Continue;
 
 impl Renderable for Continue {
     fn render_to(&self, _writer: &mut Write, context: &mut Context) -> Result<()> {
-        context.set_interrupt(Interrupt::Continue);
+        context.interrupt_mut().set_interrupt(Interrupt::Continue);
         Ok(())
     }
 }

--- a/src/tags/raw_block.rs
+++ b/src/tags/raw_block.rs
@@ -1,9 +1,9 @@
 use std::io::Write;
 
-use error::{Result, ResultLiquidChainExt};
 use compiler::Element;
 use compiler::LiquidOptions;
 use compiler::Token;
+use error::{Result, ResultLiquidChainExt};
 use interpreter::Context;
 use interpreter::Renderable;
 
@@ -72,7 +72,7 @@ mod test {
 
         let mut context = Context::new();
         let output = template.render(&mut context).unwrap();
-        assert_eq!(output,"{%if%}");
+        assert_eq!(output, "{%if%}");
     }
 
     #[test]

--- a/src/template.rs
+++ b/src/template.rs
@@ -23,9 +23,10 @@ impl Template {
 
     /// Renders an instance of the Template, using the given globals.
     pub fn render_to(&self, writer: &mut Write, globals: &Object) -> Result<()> {
-        let mut data = interpreter::Context::new()
-            .with_filters(&self.filters)
-            .with_values(globals.clone());
+        let mut data = interpreter::ContextBuilder::new()
+            .set_filters(&self.filters)
+            .set_globals(globals.clone())
+            .build();
         self.template
             .render_to(writer, &mut data)
     }

--- a/src/template.rs
+++ b/src/template.rs
@@ -27,7 +27,6 @@ impl Template {
             .set_filters(&self.filters)
             .set_globals(globals.clone())
             .build();
-        self.template
-            .render_to(writer, &mut data)
+        self.template.render_to(writer, &mut data)
     }
 }

--- a/src/value/values.rs
+++ b/src/value/values.rs
@@ -56,9 +56,7 @@ impl Value {
                 borrow::Cow::Owned(arr.join(", "))
             }
             Value::Object(ref x) => {
-                let arr: Vec<String> = x.iter()
-                    .map(|(k, v)| format!("{}: {}", k, v))
-                    .collect();
+                let arr: Vec<String> = x.iter().map(|(k, v)| format!("{}: {}", k, v)).collect();
                 borrow::Cow::Owned(arr.join(", "))
             }
             Value::Nil => borrow::Cow::Borrowed(""),


### PR DESCRIPTION
This is an attempt to modularize Context's logic while allowing for future evolution without breaking anyone.

The concern of breaking people is why traits aren't used.   Instead, independently accessibly pieces that hide what state is needed for each

Future work:
- Making globals a trait.

Potential future work:
- Switching the stack and interrupt state to a reference struct approach like CycleState
- Possibly going more of an ECS approach with decoupled systems, removing tag-specific knowledge from the interpreter