### PR TITLE
fix(perf): Don't clone globals

### DIFF
--- a/src/interpreter/globals.rs
+++ b/src/interpreter/globals.rs
@@ -1,0 +1,14 @@
+use std::fmt;
+
+use value::Object;
+use value::Value;
+
+pub trait Globals: fmt::Debug {
+    fn get<'a>(&'a self, name: &str) -> Option<&'a Value>;
+}
+
+impl Globals for Object {
+    fn get<'a>(&'a self, name: &str) -> Option<&'a Value> {
+        self.get(name)
+    }
+}

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1,6 +1,7 @@
 mod argument;
 mod context;
 mod filter;
+mod globals;
 mod output;
 mod renderable;
 mod template;
@@ -12,6 +13,7 @@ pub use self::context::{
     unexpected_value_error, Context, ContextBuilder, Interrupt, InterruptState,
 };
 pub use self::filter::{BoxedValueFilter, FilterError, FilterResult, FilterValue, FnFilterValue};
+pub use self::globals::Globals;
 pub use self::output::{FilterPrototype, Output};
 pub use self::renderable::Renderable;
 pub use self::template::Template;

--- a/src/template.rs
+++ b/src/template.rs
@@ -7,6 +7,7 @@ use error::Result;
 
 use interpreter;
 use interpreter::Renderable;
+use interpreter::Globals;
 
 pub struct Template {
     pub(crate) template: interpreter::Template,
@@ -22,10 +23,10 @@ impl Template {
     }
 
     /// Renders an instance of the Template, using the given globals.
-    pub fn render_to(&self, writer: &mut Write, globals: &Object) -> Result<()> {
+    pub fn render_to(&self, writer: &mut Write, globals: &Globals) -> Result<()> {
         let mut data = interpreter::ContextBuilder::new()
             .set_filters(&self.filters)
-            .set_globals(globals.clone())
+            .set_globals(globals)
             .build();
         self.template.render_to(writer, &mut data)
     }


### PR DESCRIPTION
Part of #95

Before
test bench_parse_template  ... bench:      27,407 ns/iter (+/- 11,395)
test bench_parse_text      ... bench:         638 ns/iter (+/- 46)
test bench_parse_variable  ... bench:       2,479 ns/iter (+/- 212)
test bench_render_template ... bench:       8,046 ns/iter (+/- 2,514)
test bench_render_text     ... bench:         344 ns/iter (+/- 23)
test bench_render_variable ... bench:       1,578 ns/iter (+/- 243)

After
test bench_parse_template  ... bench:      26,348 ns/iter (+/- 4,703)
test bench_parse_text      ... bench:         653 ns/iter (+/- 169)
test bench_parse_variable  ... bench:       2,647 ns/iter (+/- 187)
test bench_render_template ... bench:       6,898 ns/iter (+/- 1,526)
test bench_render_text     ... bench:         276 ns/iter (+/- 28)
test bench_render_variable ... bench:         418 ns/iter (+/- 29)

BREAKING CHANGE: `Context` now works with a `&dyn Globals` instead of an
`Object`.

- [ ] Tests created for any new feature or regression tests for bugfixes.
