### PR TITLE
feat(filters): Allow the input to index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: rust
 rust:
-- 1.22.0  # Oldest supported version
+- 1.27.0  # Oldest supported version
 - stable
 - beta
 - nightly

--- a/liquid-interpreter/src/variable.rs
+++ b/liquid-interpreter/src/variable.rs
@@ -16,9 +16,22 @@ pub struct Variable {
 
 impl Variable {
     /// Create a `Value` reference.
+    #[deprecated(since = "0.16.1", note = "please use `with_index` instead")]
     pub fn new<I: Into<Index>>(value: I) -> Self {
         let path = Path::with_index(value);
         Self { path }
+    }
+
+    /// Create a `Value` reference.
+    pub fn with_index<I: Into<Index>>(value: I) -> Self {
+        let path = Path::with_index(value);
+        Self { path }
+    }
+
+    /// Append an `Index`.
+    pub fn push_index<I: Into<Index>>(mut self, value: I) -> Self {
+        self.path = self.path.push(value);
+        self
     }
 
     /// The path to the variable in the stack.
@@ -62,7 +75,7 @@ mod test {
 test_a: ["test"]
 "#,
         ).unwrap();
-        let mut actual = Variable::new("test_a");
+        let mut actual = Variable::with_index("test_a");
         let index = vec![Index::with_index(0)];
         actual.extend(index);
 
@@ -78,7 +91,7 @@ test_a: ["test"]
 test_a: ["test1", "test2"]
 "#,
         ).unwrap();
-        let mut actual = Variable::new("test_a");
+        let mut actual = Variable::with_index("test_a");
         let index = vec![Index::with_index(-1)];
         actual.extend(index);
 
@@ -95,7 +108,7 @@ test_a:
   - test_h: 5
 "#,
         ).unwrap();
-        let mut actual = Variable::new("test_a");
+        let mut actual = Variable::with_index("test_a");
         let index = vec![Index::with_index(0), Index::with_key("test_h")];
         actual.extend(index);
 

--- a/liquid-value/src/index.rs
+++ b/liquid-value/src/index.rs
@@ -67,6 +67,12 @@ impl fmt::Display for Index {
     }
 }
 
+impl From<isize> for Index {
+    fn from(k: isize) -> Self {
+        Self::with_index(k)
+    }
+}
+
 impl From<String> for Index {
     fn from(k: String) -> Self {
         Self::with_key(k)

--- a/liquid-value/src/path.rs
+++ b/liquid-value/src/path.rs
@@ -25,6 +25,12 @@ impl Path {
         Self { indexes }
     }
 
+    /// Append an index.
+    pub fn push<I: Into<Index>>(mut self, value: I) -> Self {
+        self.indexes.push(value.into());
+        self
+    }
+
     /// Access the `Value` reference.
     pub fn iter(&self) -> IndexIter {
         IndexIter(self.indexes.iter())


### PR DESCRIPTION
This does not fix it so the filter arguments support indexing.

Fixes #207

Note: This touches
- liquid-value
- liquid-interpreter
- liquid-compiler
- liquid
