### PR TITLE
feat(if_block): support multiple conditions with `and` and `or`

### DIFF
--- a/liquid-compiler/src/lexer.rs
+++ b/liquid-compiler/src/lexer.rs
@@ -138,6 +138,7 @@ pub fn granularize(block: &str) -> Result<Vec<Token>> {
             "?" => Token::Question,
             "-" => Token::Dash,
             "=" => Token::Assignment,
+            "and" => Token::And,
             "or" => Token::Or,
 
             "==" => Token::Comparison(ComparisonOperator::Equals),

--- a/liquid-compiler/src/token.rs
+++ b/liquid-compiler/src/token.rs
@@ -52,6 +52,7 @@ pub enum Token {
     BooleanLiteral(bool),
     DotDot,
     Comparison(ComparisonOperator),
+    And,
     Or,
 }
 
@@ -108,6 +109,7 @@ impl fmt::Display for Token {
             Token::Dash => write!(f, "-"),
             Token::DotDot => write!(f, ".."),
             Token::Assignment => write!(f, "="),
+            Token::And => write!(f, "and"),
             Token::Or => write!(f, "or"),
 
             Token::Comparison(ref x) => write!(f, "{}", x),


### PR DESCRIPTION
Implement disjunction and conjunction operators to if and unless blocks, as documented in the [shopify help center](https://help.shopify.com/en/themes/liquid/tags/control-flow-tags#multiple-conditions-and-or).
