### PR TITLE
 feat(value): dot notation form of size for arrays and objects

### DIFF
--- a/liquid-interpreter/src/expression.rs
+++ b/liquid-interpreter/src/expression.rs
@@ -26,10 +26,7 @@ impl Expression {
     pub fn evaluate(&self, context: &Context) -> Result<Value> {
         let val = match *self {
             Expression::Literal(ref x) => x.clone(),
-            Expression::Variable(ref x) => {
-                let path = x.evaluate(context)?;
-                context.stack().get(&path)?.clone()
-            }
+            Expression::Variable(ref x) => x.evaluate(context)?,
         };
         Ok(val)
     }

--- a/liquid-interpreter/src/variable.rs
+++ b/liquid-interpreter/src/variable.rs
@@ -4,6 +4,7 @@ use std::io::Write;
 use error::{Error, Result, ResultLiquidChainExt};
 use value::Path;
 use value::Scalar;
+use value::Value;
 
 use super::Context;
 use super::Expression;
@@ -30,7 +31,7 @@ impl Variable {
     }
 
     /// Convert to a `Path`.
-    pub fn evaluate(&self, context: &Context) -> Result<Path> {
+    pub fn evaluate(&self, context: &Context) -> Result<Value> {
         let path: Result<Path> = self
             .path
             .iter()
@@ -43,7 +44,11 @@ impl Variable {
                     .clone();
                 Ok(s)
             }).collect();
-        path
+        let path = path?;
+
+        let value = context.stack().get(&path)?.clone();
+
+        Ok(value)
     }
 }
 
@@ -78,8 +83,7 @@ impl fmt::Display for Variable {
 
 impl Renderable for Variable {
     fn render_to(&self, writer: &mut Write, context: &mut Context) -> Result<()> {
-        let path = self.evaluate(context)?;
-        let value = context.stack().get(&path)?;
+        let value = self.evaluate(context)?;
         write!(writer, "{}", value).chain("Failed to render")?;
         Ok(())
     }

--- a/liquid-value/src/path.rs
+++ b/liquid-value/src/path.rs
@@ -31,6 +31,11 @@ impl Path {
         self
     }
 
+    /// Removes the last index from the path and returns it, or None if it is empty.
+    pub fn pop(&mut self) -> Option<Scalar> {
+        self.indexes.pop()
+    }
+
     /// Access the `Value` reference.
     pub fn iter(&self) -> ScalarIter {
         ScalarIter(self.indexes.iter())


### PR DESCRIPTION
Resolves #136

My proposal is to implement this feature in `Variable::evaluate` instead of `Value::get`. I find that this makes more sense because when we use `.size` we are actually _evaluating_ the size of a value (as in, creating a new `Value`) instead of retrieving a value from inside another value. On the other hand, this avoids changing the signature of `Value::get`, to return actual `Value`s instead of references, which would imply changing the code in many other places.

Another change that is tightly related to this feature is refactoring `Variable::evaluate` to return ` Result<Value>` instead of `Result<Path>`. This also makes more sense in my head because evaluating seems to imply calculating the value held in the variable, while resolving the path to the value seems to be just the first step to do that. On the other hand, that avoids code duplication regarding the `.size` feature.