### PR TITLE
Low hanging fruit for performance

### DIFF
--- a/liquid-interpreter/src/variable.rs
+++ b/liquid-interpreter/src/variable.rs
@@ -33,7 +33,7 @@ impl Variable {
 
     /// Convert to a `Path`.
     pub fn try_evaluate<'c>(&'c self, context: &'c Context) -> Option<Path<'c>> {
-        let mut path = Path::with_index(self.variable.clone());
+        let mut path = Path::with_index(self.variable.as_ref());
         path.reserve(self.indexes.len());
         for expr in &self.indexes {
             let v = expr.try_evaluate(context)?;

--- a/src/template.rs
+++ b/src/template.rs
@@ -17,7 +17,8 @@ impl Template {
         const BEST_GUESS: usize = 10_000;
         let mut data = Vec::with_capacity(BEST_GUESS);
         self.render_to(&mut data, globals)?;
-        Ok(String::from_utf8(data).expect("render only writes UTF-8"))
+
+        Ok(convert_buffer(data))
     }
 
     /// Renders an instance of the Template, using the given globals.
@@ -28,4 +29,15 @@ impl Template {
             .build();
         self.template.render_to(writer, &mut data)
     }
+}
+
+#[cfg(debug_assertions)]
+fn convert_buffer(buffer: Vec<u8>) -> String {
+    String::from_utf8(buffer)
+        .expect("render can only write UTF-8 because all inputs and processing preserve utf-8")
+}
+
+#[cfg(not(debug_assertions))]
+fn convert_buffer(buffer: Vec<u8>) -> String {
+    unsafe { String::from_utf8_unchecked(buffer) }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -14,7 +14,8 @@ pub struct Template {
 impl Template {
     /// Renders an instance of the Template, using the given globals.
     pub fn render(&self, globals: &interpreter::Globals) -> Result<String> {
-        let mut data = Vec::new();
+        const BEST_GUESS: usize = 10_000;
+        let mut data = Vec::with_capacity(BEST_GUESS);
         self.render_to(&mut data, globals)?;
         Ok(String::from_utf8(data).expect("render only writes UTF-8"))
     }


### PR DESCRIPTION
Taking care of ideas from #234 all except changing stack frames.

tl;dr we are now competitive with Tera.  On some (bigtable), we are slower.  On a lot of others (bigobject), we are a lot faster.

Before
```
     Running target/release/deps/handlebars_baseline-7bc95501ed86afa7

running 3 tests
test large_loop_helper ... bench:   4,688,450 ns/iter (+/- 418,530)
test parse_template    ... bench:      31,014 ns/iter (+/- 2,958)
test render_template   ... bench:      34,726 ns/iter (+/- 2,384)

test result: ok. 0 passed; 0 failed; 0 ignored; 3 measured; 0 filtered out

     Running target/release/deps/handlebars_liquid-9a990ffdd1daf4b0

running 3 tests
test large_loop_helper ... bench:   1,503,200 ns/iter (+/- 205,392)
test parse_template    ... bench:      36,345 ns/iter (+/- 2,511)
test render_template   ... bench:      18,116 ns/iter (+/- 1,619)

test result: ok. 0 passed; 0 failed; 0 ignored; 3 measured; 0 filtered out

     Running target/release/deps/liquid-994e4c59512c0f5b

running 2 tests
test bench_parse_text  ... bench:         645 ns/iter (+/- 69)
test bench_render_text ... bench:         277 ns/iter (+/- 50)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out

     Running target/release/deps/tera_bigcontext_baseline-cfa1b3639fc2be60

running 4 tests
test bench_big_loop_big_object                 ... bench:     561,012 ns/iter (+/- 74,923)
test bench_macro_big_object                    ... bench:     854,800 ns/iter (+/- 92,227)
test bench_macro_big_object_no_loop_macro_call ... bench:   8,899,100 ns/iter (+/- 785,615)
test bench_macro_big_object_no_loop_with_set   ... bench:   9,608,700 ns/iter (+/- 651,110)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out

     Running target/release/deps/tera_bigcontext_liquid-72bcca8b5fd38864

running 1 test
test bench_big_loop_big_object ... bench:   1,266,575 ns/iter (+/- 102,088)

test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 0 filtered out

     Running target/release/deps/tera_template_baseline-2c9fbebb4cbac152

running 2 tests
test big_table ... bench:   3,400,100 ns/iter (+/- 266,525)
test teams     ... bench:      10,281 ns/iter (+/- 3,463)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out

     Running target/release/deps/tera_template_liquid-b865b09b5af126ac

running 2 tests
test big_table ... bench:  18,675,900 ns/iter (+/- 1,197,820)
test teams     ... bench:      17,947 ns/iter (+/- 1,518)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out

     Running target/release/deps/tera_tera_baseline-e08b6d3894063e8f

running 13 tests
test access_deep_object                        ... bench:       8,607 ns/iter (+/- 773)
test access_deep_object_with_literal           ... bench:      10,425 ns/iter (+/- 796)
test bench_build_inheritance_chains            ... bench:       3,890 ns/iter (+/- 309)
test bench_escape_html                         ... bench:         126 ns/iter (+/- 9)
test bench_huge_loop                           ... bench:     891,075 ns/iter (+/- 87,557)
test bench_parsing_basic_template              ... bench:      30,512 ns/iter (+/- 4,004)
test bench_parsing_with_inheritance_and_macros ... bench:      62,837 ns/iter (+/- 10,037)
test bench_rendering_basic_template            ... bench:       8,206 ns/iter (+/- 656)
test bench_rendering_inheritance_and_macros    ... bench:       8,706 ns/iter (+/- 733)
test bench_rendering_only_inheritance          ... bench:       3,217 ns/iter (+/- 245)
test bench_rendering_only_macro_call           ... bench:       7,050 ns/iter (+/- 529)
test bench_rendering_only_parent               ... bench:       1,963 ns/iter (+/- 145)
test bench_rendering_only_variable             ... bench:       2,636 ns/iter (+/- 1,165)

test result: ok. 0 passed; 0 failed; 0 ignored; 13 measured; 0 filtered out

     Running target/release/deps/tera_tera_liquid-ff47786c9fff304e

running 5 tests
test access_deep_object              ... bench:      11,545 ns/iter (+/- 741)
test access_deep_object_with_literal ... bench:      13,943 ns/iter (+/- 1,206)
test bench_parsing_basic_template    ... bench:      32,184 ns/iter (+/- 2,343)
test bench_rendering_basic_template  ... bench:       7,085 ns/iter (+/- 615)
test bench_rendering_only_variable   ... bench:         664 ns/iter (+/- 41)

test result: ok. 0 passed; 0 failed; 0 ignored; 5 measured; 0 filtered out
```

After
```
     Running target/release/deps/handlebars_baseline-7bc95501ed86afa7

running 3 tests
test large_loop_helper ... bench:   4,734,450 ns/iter (+/- 404,525)
test parse_template    ... bench:      30,563 ns/iter (+/- 2,622)
test render_template   ... bench:      35,400 ns/iter (+/- 2,677)

test result: ok. 0 passed; 0 failed; 0 ignored; 3 measured; 0 filtered out

     Running target/release/deps/handlebars_liquid-9a990ffdd1daf4b0

running 3 tests
test large_loop_helper ... bench:   1,253,400 ns/iter (+/- 76,622)
test parse_template    ... bench:      36,540 ns/iter (+/- 9,588)
test render_template   ... bench:      12,928 ns/iter (+/- 855)

test result: ok. 0 passed; 0 failed; 0 ignored; 3 measured; 0 filtered out

     Running target/release/deps/liquid-994e4c59512c0f5b

running 2 tests
test bench_parse_text  ... bench:         639 ns/iter (+/- 63)
test bench_render_text ... bench:         271 ns/iter (+/- 19)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out

     Running target/release/deps/tera_bigcontext_baseline-cfa1b3639fc2be60

running 4 tests
test bench_big_loop_big_object                 ... bench:     565,962 ns/iter (+/- 50,638)
test bench_macro_big_object                    ... bench:     847,612 ns/iter (+/- 82,045)
test bench_macro_big_object_no_loop_macro_call ... bench:   8,992,950 ns/iter (+/- 801,660)
test bench_macro_big_object_no_loop_with_set   ... bench:   9,290,850 ns/iter (+/- 869,725)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out

     Running target/release/deps/tera_bigcontext_liquid-72bcca8b5fd38864

running 1 test
test bench_big_loop_big_object ... bench:     388,687 ns/iter (+/- 46,786)

test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 0 filtered out

     Running target/release/deps/tera_template_baseline-2c9fbebb4cbac152

running 2 tests
test big_table ... bench:   3,408,500 ns/iter (+/- 279,445)
test teams     ... bench:      10,210 ns/iter (+/- 4,381)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out

     Running target/release/deps/tera_template_liquid-b865b09b5af126ac

running 2 tests
test big_table ... bench:  13,917,700 ns/iter (+/- 942,570)
test teams     ... bench:      13,199 ns/iter (+/- 1,228)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out

     Running target/release/deps/tera_tera_baseline-e08b6d3894063e8f

running 13 tests
test access_deep_object                        ... bench:       8,735 ns/iter (+/- 585)
test access_deep_object_with_literal           ... bench:      10,506 ns/iter (+/- 936)
test bench_build_inheritance_chains            ... bench:       3,801 ns/iter (+/- 689)
test bench_escape_html                         ... bench:         124 ns/iter (+/- 29)
test bench_huge_loop                           ... bench:     859,862 ns/iter (+/- 67,728)
test bench_parsing_basic_template              ... bench:      30,542 ns/iter (+/- 2,270)
test bench_parsing_with_inheritance_and_macros ... bench:      61,492 ns/iter (+/- 5,255)
test bench_rendering_basic_template            ... bench:       8,168 ns/iter (+/- 723)
test bench_rendering_inheritance_and_macros    ... bench:       8,726 ns/iter (+/- 823)
test bench_rendering_only_inheritance          ... bench:       3,229 ns/iter (+/- 221)
test bench_rendering_only_macro_call           ... bench:       6,983 ns/iter (+/- 468)
test bench_rendering_only_parent               ... bench:       1,942 ns/iter (+/- 127)
test bench_rendering_only_variable             ... bench:       2,645 ns/iter (+/- 185)

test result: ok. 0 passed; 0 failed; 0 ignored; 13 measured; 0 filtered out

     Running target/release/deps/tera_tera_liquid-ff47786c9fff304e

running 5 tests
test access_deep_object              ... bench:       7,221 ns/iter (+/- 485)
test access_deep_object_with_literal ... bench:       9,471 ns/iter (+/- 754)
test bench_parsing_basic_template    ... bench:      32,100 ns/iter (+/- 1,720)
test bench_rendering_basic_template  ... bench:       6,950 ns/iter (+/- 721)
test bench_rendering_only_variable   ... bench:         653 ns/iter (+/- 50)

test result: ok. 0 passed; 0 failed; 0 ignored; 5 measured; 0 filtered out
```