### PR TITLE
fix(errors): List alternative filters

### DIFF
--- a/liquid-interpreter/src/context.rs
+++ b/liquid-interpreter/src/context.rs
@@ -361,11 +361,18 @@ impl<'g> Context<'g> {
     }
 
     /// Grab a `FilterValue`.
-    pub fn get_filter<'b>(&'b self, name: &str) -> Option<&'b FilterValue> {
-        self.filters.get(name).map(|f| {
-            let f: &FilterValue = f;
-            f
-        })
+    pub fn get_filter<'b>(&'b self, name: &str) -> Result<&'b FilterValue> {
+        self.filters
+            .get(name)
+            .map(|f| {
+                let f: &FilterValue = f;
+                f
+            }).ok_or_else(|| {
+                let available = itertools::join(self.filters.keys(), ", ");
+                Error::with_msg("Unknown filter")
+                    .context("requested filter", name.to_owned())
+                    .context("available filters", available)
+            })
     }
 
     /// Access the block's `InterruptState`.

--- a/liquid-interpreter/src/filter_chain.rs
+++ b/liquid-interpreter/src/filter_chain.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 
 use itertools;
 
-use error::{Error, Result, ResultLiquidChainExt, ResultLiquidExt};
+use error::{Result, ResultLiquidChainExt, ResultLiquidExt};
 use value::Value;
 
 use super::Context;
@@ -58,9 +58,7 @@ impl FilterChain {
 
         // apply all specified filters
         for filter in &self.filters {
-            let f = context.get_filter(&filter.name).ok_or_else(|| {
-                Error::with_msg("Unsupported filter").context("filter", filter.name.clone())
-            })?;
+            let f = context.get_filter(&filter.name)?;
 
             let arguments: Result<Vec<Value>> = filter
                 .arguments


### PR DESCRIPTION
BREAKING CHANGE: `Context::get_filter` now returns `Result`.

- [ ] Tests created for any new feature or regression tests for bugfixes.
