### PR TITLE
Windows line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-*.txt		lf
-*.rs		lf
+*.txt		text eol=lf
+*.rs		text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.txt		lf
+*.rs		lf


### PR DESCRIPTION
When checking out the master branch of liquid-rust on Windows, a number of unit tests were failing due to line-ending differences.

This PR makes Windows users check out the Rust and text files in the depot with Unix line endings to avoid such issues.

