### PR TITLE
tests: Annotate incompat with issues

### DIFF
--- a/tests/conformance_ruby/blank_test.rs
+++ b/tests/conformance_ruby/blank_test.rs
@@ -49,13 +49,13 @@ fn test_new_tags_are_not_blank_by_default() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#244
 fn test_loops_are_blank() {
     assert_template_result!("", wrap_in_for(" "));
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#244
 fn test_if_else_are_blank() {
     assert_template_result!("", "{% if true %} {% elsif false %} {% else %} {% endif %}",);
 }
@@ -74,19 +74,19 @@ fn test_mark_as_blank_only_during_parsing() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#244
 fn test_comments_are_blank() {
     assert_template_result!("", wrap(" {% comment %} whatever {% endcomment %} "),);
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#244
 fn test_captures_are_blank() {
     assert_template_result!("", wrap(" {% capture foo %} whatever {% endcapture %} "),);
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#244
 fn test_nested_blocks_are_blank_but_only_if_all_children_are() {
     assert_template_result!("", &wrap(wrap(" ")));
     assert_template_result!(
@@ -99,13 +99,13 @@ fn test_nested_blocks_are_blank_but_only_if_all_children_are() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#244
 fn test_assigns_are_blank() {
     assert_template_result!("", &wrap(r#" {% assign foo = "bar" %} "#));
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#244
 fn test_whitespace_is_blank() {
     assert_template_result!("", wrap(" "));
     assert_template_result!("", wrap("\t"));
@@ -137,7 +137,6 @@ fn test_raw_is_not_blank() {
 }
 
 #[test]
-#[ignore]
 fn test_include_is_blank() {
     let liquid = liquid::ParserBuilder::with_liquid()
         .include_source(Box::new(BlankTestFilesystem))
@@ -164,7 +163,7 @@ fn test_include_is_blank() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#244
 fn test_case_is_blank() {
     assert_template_result!("", wrap(" {% assign foo = 'bar' %} {% case foo %} {% when 'bar' %} {% when 'whatever' %} {% else %} {% endcase %} "));
     assert_template_result!("", wrap(" {% assign foo = 'else' %} {% case foo %} {% when 'bar' %} {% when 'whatever' %} {% else %} {% endcase %} "));

--- a/tests/conformance_ruby/capture_test.rs
+++ b/tests/conformance_ruby/capture_test.rs
@@ -1,7 +1,7 @@
 use liquid;
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#245
 fn test_captures_block_content_in_variable() {
     assert_template_result!(
         r#"test string"#,

--- a/tests/conformance_ruby/error_handling_test.rs
+++ b/tests/conformance_ruby/error_handling_test.rs
@@ -25,7 +25,6 @@ fn test_argument() {
 }
 
 #[test]
-#[ignore]
 fn test_missing_endtag_parse_time_error() {
     assert_parse_error!(" {% for a in b %} ... ");
 }
@@ -60,7 +59,6 @@ fn test_parsing_warn_with_line_numbers_adds_numbers_to_lexer_errors() {
 }
 
 #[test]
-#[ignore]
 fn test_parsing_strict_with_line_numbers_adds_numbers_to_lexer_errors() {
     let err = assert_parse_error!(
         r#"
@@ -73,13 +71,13 @@ fn test_parsing_strict_with_line_numbers_adds_numbers_to_lexer_errors() {
     );
     let err = err.to_string();
 
-    let expected = regex::Regex::new(r#"\bline 4\b"#).unwrap();
+    let expected = regex::Regex::new(r#"4 \|"#).unwrap();
     println!("err={}", err);
     assert!(expected.is_match(&err));
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#247
 fn test_syntax_errors_in_nested_blocks_have_correct_line_number() {
     let err = assert_parse_error!(
         r#"

--- a/tests/conformance_ruby/filter_test.rs
+++ b/tests/conformance_ruby/filter_test.rs
@@ -74,7 +74,7 @@ fn test_join() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#250
 fn test_sort() {
     let assigns = v!({
         "value": 3,
@@ -96,7 +96,7 @@ fn test_sort() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#249
 fn test_sort_natural() {
     let assigns = v!({
         "words": ["case", "Assert", "Insensitive"],
@@ -122,7 +122,7 @@ fn test_sort_natural() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#246
 fn test_compact() {
     let assigns = v!({
         "words": ["a", nil, "b", nil, "c"],
@@ -171,7 +171,7 @@ fn test_nonexistent_filter_is_ignored() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#92
 fn test_filter_with_keyword_arguments() {
     let assigns = v!({
         "surname": "john",

--- a/tests/conformance_ruby/output_test.rs
+++ b/tests/conformance_ruby/output_test.rs
@@ -79,11 +79,10 @@ fn test_variable() {
 }
 
 #[test]
-#[ignore]
 fn test_variable_traversing_with_two_brackets() {
     let text = "{{ site.data.menu[include.menu][include.locale] }}";
     assert_template_result!(
-        "it works",
+        "it works!",
         text,
         v!({
       "site": { "data": { "menu": { "foo": { "bar": "it works!" } } } },

--- a/tests/conformance_ruby/parsing_quirks_test.rs
+++ b/tests/conformance_ruby/parsing_quirks_test.rs
@@ -5,19 +5,16 @@ fn test_parsing_css() {
 }
 
 #[test]
-#[ignore]
 fn test_raise_on_single_close_bracet() {
     assert_parse_error!("text {{method} oh nos!");
 }
 
 #[test]
-#[ignore]
 fn test_raise_on_label_and_no_close_bracets() {
     assert_parse_error!("TEST {{ ");
 }
 
 #[test]
-#[ignore]
 fn test_raise_on_label_and_no_close_bracets_percent() {
     assert_parse_error!("TEST {% ");
 }

--- a/tests/conformance_ruby/standard_filter_test.rs
+++ b/tests/conformance_ruby/standard_filter_test.rs
@@ -22,7 +22,7 @@ fn test_upcase() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#261
 fn test_slice() {
     assert_eq!(v!("oob"), filters!(slice, v!("foobar"), v!(1), v!(3)));
     assert_eq!(v!("oobar"), filters!(slice, v!("foobar"), v!(1), v!(1000)));
@@ -41,7 +41,7 @@ fn test_slice() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#261
 fn test_slice_on_arrays() {
     let input = v!(["f", "o", "o", "b", "a", "r"]);
     assert_eq!(v!(["o", "o", "b"]), filters!(slice, input, v!(1), v!(3)));
@@ -60,7 +60,7 @@ fn test_slice_on_arrays() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#264
 fn test_truncate() {
     assert_eq!(v!("1234..."), filters!(truncate, v!("1234567890"), v!(7)));
     assert_eq!(
@@ -80,7 +80,7 @@ fn test_truncate() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#263
 fn test_split() {
     assert_eq!(v!(["12", "34"]), filters!(split, v!("12~34"), v!("~")));
     assert_eq!(
@@ -93,7 +93,7 @@ fn test_split() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#253
 fn test_escape() {
     assert_eq!(v!("&lt;strong&gt;"), filters!(escape, v!("<strong>")));
     assert_eq!(v!("1"), filters!(escape, v!(1)));
@@ -102,8 +102,9 @@ fn test_escape() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#269
 fn test_h() {
+    panic!("Implement this filter");
     /*
     assert_eq!(v!("&lt;strong&gt;"), filters!(h, v!("<strong>")));
     assert_eq!(v!("1"), filters!(h, 1));
@@ -121,7 +122,7 @@ fn test_escape_once() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#253
 fn test_url_encode() {
     assert_eq!(
         v!("foo%2B1%40example.com"),
@@ -133,7 +134,7 @@ fn test_url_encode() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#268
 fn test_url_decode() {
     assert_eq!(v!("foo bar"), filters!(url_decode, v!("foo+bar")));
     assert_eq!(v!("foo bar"), filters!(url_decode, v!("foo%20bar")));
@@ -211,7 +212,7 @@ fn test_join() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#257
 fn test_sort() {
     assert_eq!(v!([1, 2, 3, 4]), filters!(sort, v!([4, 3, 2, 1])));
     assert_eq!(
@@ -225,7 +226,7 @@ fn test_sort() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#262
 fn test_sort_with_nils() {
     assert_eq!(v!([1, 2, 3, 4, nil]), filters!(sort, v!([nil, 4, 3, 2, 1])));
     assert_eq!(
@@ -239,7 +240,7 @@ fn test_sort_with_nils() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#257
 fn test_sort_when_property_is_sometimes_missing_puts_nils_last() {
     let input = v!([
       { "price": 4, "handle": "alpha" },
@@ -259,7 +260,7 @@ fn test_sort_when_property_is_sometimes_missing_puts_nils_last() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#257
 fn test_sort_natural() {
     assert_eq!(
         v!(["a", "B", "c", "D"]),
@@ -276,7 +277,7 @@ fn test_sort_natural() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#262
 fn test_sort_natural_with_nils() {
     assert_eq!(
         v!(["a", "B", "c", "D", nil]),
@@ -293,7 +294,7 @@ fn test_sort_natural_with_nils() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#257
 fn test_sort_natural_when_property_is_sometimes_missing_puts_nils_last() {
     let input = v!([
       { "price": "4", "handle": "alpha" },
@@ -313,7 +314,7 @@ fn test_sort_natural_when_property_is_sometimes_missing_puts_nils_last() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#257
 fn test_sort_natural_case_check() {
     let input = v!([
       { "key": "X" },
@@ -341,19 +342,19 @@ fn test_sort_natural_case_check() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#257
 fn test_sort_empty_array() {
     assert_eq!(v!([]), filters!(sort, v!([]), v!("a")));
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#257
 fn test_sort_natural_empty_array() {
     assert_eq!(v!([]), filters!(sort_natural, v!([]), v!("a")));
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#257
 fn test_legacy_sort_hash() {
     assert_eq!(
         v!([{ "a": 1, "b": 2 }]),
@@ -362,7 +363,7 @@ fn test_legacy_sort_hash() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#257
 fn test_numerical_vs_lexicographical_sort() {
     assert_eq!(v!([2, 10]), filters!(sort, v!([10, 2])));
     assert_eq!(
@@ -377,7 +378,7 @@ fn test_numerical_vs_lexicographical_sort() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#266
 fn test_uniq() {
     assert_eq!(v!(["foo"]), filters!(uniq, v!("foo")));
     assert_eq!(
@@ -396,7 +397,7 @@ fn test_uniq() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#267
 fn test_uniq_empty_array() {
     assert_eq!(v!([]), filters!(uniq, v!([]), v!("a")));
 }
@@ -412,7 +413,7 @@ fn test_reverse() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#256
 fn test_legacy_reverse_hash() {
     assert_eq!(
         v!([{ "a": 1, "b": 2 }]),
@@ -421,7 +422,7 @@ fn test_legacy_reverse_hash() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#258
 fn test_map() {
     assert_eq!(
         v!([1, 2, 3, 4]),
@@ -451,7 +452,7 @@ fn test_map_calls_to_liquid() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#255
 fn test_map_on_hashes() {
     assert_template_result!(
         "4217",
@@ -461,7 +462,7 @@ fn test_map_on_hashes() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#255
 fn test_legacy_map_on_hashes_with_dynamic_key() {
     let template = r#"{% assign key = "foo" %}{{ thing | map: key | map: "bar" }}"#;
     let hash = v!({ "foo": { "bar": 42 } });
@@ -511,7 +512,7 @@ fn test_truncate_calls_to_liquid() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#252
 fn test_date() {
     assert_eq!(
         v!("May"),
@@ -594,7 +595,7 @@ fn test_date() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#254
 fn test_first_last() {
     assert_eq!(v!(1), filters!(first, v!([1, 2, 3])));
     assert_eq!(v!(3), filters!(last, v!([1, 2, 3])));
@@ -695,7 +696,7 @@ fn test_newlines_to_br() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#260
 fn test_plus() {
     assert_template_result!("2", r#"{{ 1 | plus:1 }}"#);
     assert_template_result!("2.0", r#"{{ "1" | plus:"1.0" }}"#);
@@ -704,7 +705,6 @@ fn test_plus() {
 }
 
 #[test]
-#[ignore]
 fn test_minus() {
     assert_template_result!(
         "4",
@@ -717,7 +717,6 @@ fn test_minus() {
 }
 
 #[test]
-#[ignore]
 fn test_abs() {
     assert_template_result!("17", r#"{{ 17 | abs }}"#);
     assert_template_result!("17", r#"{{ -17 | abs }}"#);
@@ -732,7 +731,7 @@ fn test_abs() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#265
 fn test_times() {
     assert_template_result!("12", r#"{{ 3 | times:4 }}"#);
     assert_template_result!("0", r#"{{ "foo" | times:4 }}"#);
@@ -748,7 +747,7 @@ fn test_times() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#251
 fn test_divided_by() {
     assert_template_result!("4", r#"{{ 12 | divided_by:3 }}"#);
     assert_template_result!("4", r#"{{ 14 | divided_by:3 }}"#);
@@ -763,7 +762,7 @@ fn test_divided_by() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#251
 fn test_modulo() {
     assert_template_result!("1", r#"{{ 3 | modulo:2 }}"#);
     assert_render_error!("{{ 1 | modulo:0 }}");
@@ -772,7 +771,7 @@ fn test_modulo() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#251
 fn test_round() {
     assert_template_result!("5", r#"{{ input | round }}"#, v!({"input": 4.6}));
     assert_template_result!("4", r#"{{ "4.3" | round }}"#);
@@ -783,7 +782,7 @@ fn test_round() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#251
 fn test_ceil() {
     assert_template_result!("5", r#"{{ input | ceil }}"#, v!({"input": 4.6}));
     assert_template_result!("5", r#"{{ "4.3" | ceil }}"#);
@@ -793,7 +792,7 @@ fn test_ceil() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#251
 fn test_floor() {
     assert_template_result!("4", r#"{{ input | floor }}"#, v!({"input": 4.6}));
     assert_template_result!("4", r#"{{ "4.3" | floor }}"#);
@@ -868,8 +867,9 @@ fn test_date_raises_nothing() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#291
 fn test_where() {
+    panic!("where is unimplemented");
     /*
     let input = v!([
       { "handle": "alpha", "ok": true },
@@ -889,8 +889,9 @@ fn test_where() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#291
 fn test_where_no_key_set() {
+    panic!("where is unimplemented");
     /*
     input = [
       { v!("handle"): v!("alpha"), v!("ok"): true },
@@ -910,8 +911,9 @@ fn test_where_no_key_set() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#291
 fn test_where_non_array_map_input() {
+    panic!("where is unimplemented");
     /*
     assert_eq!([{ v!("a"): v!("ok") }], filters!(where, { v!("a"): v!("ok") }, "a", r#"ok")#);
     assert_eq!([], filters!(where, { v!("a"): v!("not ok") }, "a", r#"ok")#);
@@ -919,8 +921,9 @@ fn test_where_non_array_map_input() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#291
 fn test_where_indexable_but_non_map_value() {
+    panic!("where is unimplemented");
     /*
     assert_raises(Liquid::ArgumentError) { filters!(where, 1, v!("ok"), true) }
     assert_raises(Liquid::ArgumentError) { filters!(where, 1, v!("ok")) }
@@ -928,8 +931,9 @@ fn test_where_indexable_but_non_map_value() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#291
 fn test_where_non_boolean_value() {
+    panic!("where is unimplemented");
     /*
     input = [
       { v!("message"): v!("Bonjour!"), v!("language"): v!("French") },
@@ -944,8 +948,9 @@ fn test_where_non_boolean_value() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#291
 fn test_where_array_of_only_unindexable_values() {
+    panic!("where is unimplemented");
     /*
     assert_eq!(Nil, filters!(where, [Nil], v!("ok"), true));
     assert_eq!(Nil, filters!(where, [Nil], v!("ok")));
@@ -953,8 +958,9 @@ fn test_where_array_of_only_unindexable_values() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#291
 fn test_where_no_target_value() {
+    panic!("where is unimplemented");
     /*
     input = [
       { v!("foo"): false },

--- a/tests/conformance_ruby/tags/for_tag_test.rs
+++ b/tests/conformance_ruby/tags/for_tag_test.rs
@@ -44,7 +44,7 @@ fn test_for_reversed() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#273
 fn test_for_with_range() {
     assert_template_result!(
         " 1  2  3 ",
@@ -171,7 +171,7 @@ fn test_for_and_if() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#294
 fn test_for_else() {
     assert_template_result!(
         "+++",
@@ -247,7 +247,7 @@ fn test_offset_only() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#274
 fn test_pause_resume() {
     let assigns = v!({ "array": { "items": [1, 2, 3, 4, 5, 6, 7, 8, 9, 0] } });
     let markup = r#"
@@ -268,7 +268,7 @@ fn test_pause_resume() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#274
 fn test_pause_resume_limit() {
     let assigns = v!({ "array": { "items": [1, 2, 3, 4, 5, 6, 7, 8, 9, 0] } });
     let markup = r#"
@@ -289,7 +289,7 @@ fn test_pause_resume_limit() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#274
 fn test_pause_resume_big_limit() {
     let assigns = v!({ "array": { "items": [1, 2, 3, 4, 5, 6, 7, 8, 9, 0] } });
     let markup = r#"
@@ -310,7 +310,7 @@ fn test_pause_resume_big_limit() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#274
 fn test_pause_resume_big_offset() {
     let assigns = v!({ "array": { "items": [1, 2, 3, 4, 5, 6, 7, 8, 9, 0] } });
     let markup = "{%for i in array.items limit:3 %}{{i}}{%endfor%}
@@ -420,7 +420,7 @@ fn test_for_with_continue() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#270
 fn test_for_tag_string() {
     // ruby 1.8.7 "String".each: Enumerator with single "String" element.
     // ruby 1.9.3 no longer supports .each on String though we mimic
@@ -457,7 +457,7 @@ fn test_for_tag_string() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#271
 fn test_for_parentloop_references_parent_loop() {
     assert_template_result!(
         "1.1 1.2 1.3 2.1 2.2 2.3 ",
@@ -471,7 +471,7 @@ fn test_for_parentloop_references_parent_loop() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#271
 fn test_for_parentloop_nil_when_not_present() {
     assert_template_result!(
         ".1 .2 ",
@@ -485,7 +485,7 @@ fn test_for_parentloop_nil_when_not_present() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#222
 fn test_inner_for_over_empty_input() {
     assert_template_result!(
         "oo",
@@ -495,7 +495,7 @@ fn test_inner_for_over_empty_input() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#270
 fn test_blank_string_not_iterable() {
     assert_template_result!(
         "",
@@ -505,7 +505,6 @@ fn test_blank_string_not_iterable() {
 }
 
 #[test]
-#[ignore]
 fn test_bad_variable_naming_in_for_loop() {
     assert_parse_error!("{% for a/b in x %}{% endfor %}");
 }

--- a/tests/conformance_ruby/tags/if_else_tag_test.rs
+++ b/tests/conformance_ruby/tags/if_else_tag_test.rs
@@ -15,7 +15,7 @@ fn test_if() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#223
 fn test_literal_comparisons() {
     assert_template_result!(
         " NO ",
@@ -253,7 +253,7 @@ fn test_nested_if() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#223
 fn test_comparisons_on_null() {
     assert_template_result!("", "{% if null < 10 %} NO {% endif %}");
     assert_template_result!("", "{% if null <= 10 %} NO {% endif %}");
@@ -285,9 +285,10 @@ fn test_else_if() {
 }
 
 #[test]
-#[ignore]
 fn test_syntax_error_no_variable() {
-    assert_render_error!("{% if jerry == 1 %}");
+    // Modified: since missing variables are render errors, we would hit a syntax error due to no
+    // close block, preventing us from testing the real thing.
+    assert_render_error!("{% if jerry == 1 %}{% endif %}");
 }
 
 #[test]
@@ -304,6 +305,7 @@ fn test_if_with_custom_condition() {
 #[test]
 #[ignore]
 fn test_operators_are_ignored_unless_isolated() {
+    panic!("TODO: Figure out what this is testing");
     /*
     original_op = Condition.operators["contains"]
     Condition.operators["contains"] = :[]

--- a/tests/conformance_ruby/tags/include_tag_test.rs
+++ b/tests/conformance_ruby/tags/include_tag_test.rs
@@ -38,7 +38,7 @@ fn test_include_tag_looks_for_file_system_in_registers_first() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#237
 fn test_include_tag_with() {
     assert_template_result!(
         "Product: Draft 151cm ",
@@ -59,7 +59,7 @@ fn test_include_tag_with_default_name() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#237
 fn test_include_tag_for() {
     assert_template_result!(
         "Product: Draft 151cm Product: Element 155cm ",
@@ -70,7 +70,7 @@ fn test_include_tag_for() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#237
 fn test_include_tag_with_local_variables() {
     assert_template_result!(
         "Locale: test123 ",
@@ -81,7 +81,7 @@ fn test_include_tag_with_local_variables() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#237
 fn test_include_tag_with_multiple_local_variables() {
     assert_template_result!(
         "Locale: test123 test321",
@@ -92,7 +92,7 @@ fn test_include_tag_with_multiple_local_variables() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#237
 fn test_include_tag_with_multiple_local_variables_from_context() {
     assert_template_result!(
         "Locale: test123 test321",
@@ -125,7 +125,7 @@ fn test_nested_include_tag() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#237
 fn test_nested_include_with_variable() {
     assert_template_result!(
         "Product: Draft 151cm details ",
@@ -152,7 +152,6 @@ impl liquid::compiler::Include for InfiniteFileSystem {
 }
 
 #[test]
-#[ignore]
 #[should_panic]
 fn test_recursively_included_template_does_not_produce_endless_loop() {
     panic!("We don't check recursion depth");
@@ -163,7 +162,7 @@ fn test_recursively_included_template_does_not_produce_endless_loop() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#275
 fn test_dynamically_choosen_template() {
     assert_template_result!(
         "Test123",
@@ -235,14 +234,14 @@ fn test_passing_options_to_included_templates() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#275
 fn test_render_raise_argument_error_when_template_is_undefined() {
     assert_parse_error!("{% include undefined_variable %}", liquid());
     assert_parse_error!("{% include nil %}", liquid());
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#275
 fn test_including_via_variable_value() {
     assert_template_result!(
         "from TestFileSystem",

--- a/tests/conformance_ruby/tags/increment_tag_test.rs
+++ b/tests/conformance_ruby/tags/increment_tag_test.rs
@@ -8,7 +8,7 @@ fn test_inc() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#276
 fn test_dec() {
     assert_template_result!("9", "{%decrement port %}", v!({ "port": 10 }));
     assert_template_result!("-1 -2", "{%decrement port %} {%decrement port%}", v!({}));

--- a/tests/conformance_ruby/tags/raw_tag_test.rs
+++ b/tests/conformance_ruby/tags/raw_tag_test.rs
@@ -12,7 +12,7 @@ fn test_output_in_raw() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-ignore#277
 fn test_open_tag_in_raw() {
     assert_template_result!(
         " Foobar {% invalid ",
@@ -49,7 +49,6 @@ fn test_open_tag_in_raw() {
 }
 
 #[test]
-#[ignore]
 fn test_invalid_raw() {
     assert_parse_error!("{% raw %} foo");
     assert_parse_error!("{% raw } foo {% endraw %}");

--- a/tests/conformance_ruby/tags/standard_tag_test.rs
+++ b/tests/conformance_ruby/tags/standard_tag_test.rs
@@ -18,7 +18,7 @@ fn test_no_transform() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#277
 fn test_has_a_block_which_does_nothing() {
     assert_template_result!(
         "the comment block should be removed  .. right?",
@@ -158,7 +158,7 @@ fn test_case_with_else() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#136
 fn test_case_on_size() {
     assert_template_result!(
         "",
@@ -193,7 +193,7 @@ fn test_case_on_size() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#136
 fn test_case_on_size_with_else() {
     assert_template_result!(
         "else",
@@ -233,7 +233,7 @@ fn test_case_on_size_with_else() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#278
 fn test_case_on_length_with_else() {
     assert_template_result!(
         "else",
@@ -304,7 +304,7 @@ fn test_assign_from_case() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#223
 fn test_case_when_or() {
     let code = "{% case condition %}{% when 1 or 2 or 3 %} its 1 or 2 or 3 {% when 4 %} its 4 {% endcase %}";
     assert_template_result!(" its 1 or 2 or 3 ", code, v!({ "condition": 1 }));
@@ -321,7 +321,7 @@ fn test_case_when_or() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#279
 fn test_case_when_comma() {
     let code =
         "{% case condition %}{% when 1, 2, 3 %} its 1 or 2 or 3 {% when 4 %} its 4 {% endcase %}";
@@ -408,7 +408,7 @@ fn test_multiple_named_cycles_with_names_from_context() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#136
 fn test_size_of_array() {
     let assigns = v!({ "array": [1, 2, 3, 4] });
     assert_template_result!(
@@ -419,7 +419,7 @@ fn test_size_of_array() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#136
 fn test_size_of_hash() {
     let assigns = v!({ "hash": { "a": 1, "b": 2, "c": 3, "d": 4 } });
     assert_template_result!(

--- a/tests/conformance_ruby/tags/statements_test.rs
+++ b/tests/conformance_ruby/tags/statements_test.rs
@@ -35,7 +35,7 @@ fn test_zero_lq_or_equal_one() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#223
 fn test_zero_lq_or_equal_one_involving_nil() {
     let text = " {% if null <= 0 %} true {% else %} false {% endif %} ";
     assert_template_result!("  false  ", text);
@@ -96,21 +96,21 @@ fn test_var_and_long_string_are_equal_backwards() {
 */
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#222
 fn test_is_collection_empty() {
     let text = " {% if array == empty %} true {% else %} false {% endif %} ";
     assert_template_result!("  true  ", text, v!({"array": []}));
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#222
 fn test_is_not_collection_empty() {
     let text = " {% if array == empty %} true {% else %} false {% endif %} ";
     assert_template_result!("  false  ", text, v!({"array": [1, 2, 3]}));
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#223
 fn test_nil() {
     let text = " {% if var == nil %} true {% else %} false {% endif %} ";
     assert_template_result!("  true  ", text, v!({ "var": nil }));
@@ -120,7 +120,7 @@ fn test_nil() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#223
 fn test_not_nil() {
     let text = " {% if var != nil %} true {% else %} false {% endif %} ";
     assert_template_result!("  true  ", text, v!({"var": 1}));

--- a/tests/conformance_ruby/tags/table_row_test.rs
+++ b/tests/conformance_ruby/tags/table_row_test.rs
@@ -1,5 +1,5 @@
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#282
 fn test_table_row() {
     assert_template_result!(
         "<tr class=\"row1\">\n<td class=\"col1\"> 1 </td><td class=\"col2\"> 2 </td><td class=\"col3\"> 3 </td></tr>\n<tr class=\"row2\"><td class=\"col1\"> 4 </td><td class=\"col2\"> 5 </td><td class=\"col3\"> 6 </td></tr>\n",
@@ -14,7 +14,7 @@ fn test_table_row() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#282
 fn test_table_row_with_different_cols() {
     assert_template_result!(
         "<tr class=\"row1\">\n<td class=\"col1\"> 1 </td><td class=\"col2\"> 2 </td><td class=\"col3\"> 3 </td><td class=\"col4\"> 4 </td><td class=\"col5\"> 5 </td></tr>\n<tr class=\"row2\"><td class=\"col1\"> 6 </td></tr>\n",
@@ -23,7 +23,7 @@ fn test_table_row_with_different_cols() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#282
 fn test_table_col_counter() {
     assert_template_result!(
         "<tr class=\"row1\">\n<td class=\"col1\">1</td><td class=\"col2\">2</td></tr>\n<tr class=\"row2\"><td class=\"col1\">1</td><td class=\"col2\">2</td></tr>\n<tr class=\"row3\"><td class=\"col1\">1</td><td class=\"col2\">2</td></tr>\n",
@@ -32,7 +32,7 @@ fn test_table_col_counter() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#282
 fn test_quoted_fragment() {
     assert_template_result!(
         "<tr class=\"row1\">\n<td class=\"col1\"> 1 </td><td class=\"col2\"> 2 </td><td class=\"col3\"> 3 </td></tr>\n<tr class=\"row2\"><td class=\"col1\"> 4 </td><td class=\"col2\"> 5 </td><td class=\"col3\"> 6 </td></tr>\n",
@@ -51,7 +51,7 @@ fn test_enumerable_drop() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#282
 fn test_offset_and_limit() {
     assert_template_result!(
         "<tr class=\"row1\">\n<td class=\"col1\"> 1 </td><td class=\"col2\"> 2 </td><td class=\"col3\"> 3 </td></tr>\n<tr class=\"row2\"><td class=\"col1\"> 4 </td><td class=\"col2\"> 5 </td><td class=\"col3\"> 6 </td></tr>\n",

--- a/tests/conformance_ruby/tags/unless_else_tag_test.rs
+++ b/tests/conformance_ruby/tags/unless_else_tag_test.rs
@@ -15,7 +15,6 @@ fn test_unless() {
 }
 
 #[test]
-#[ignore]
 fn test_unless_else() {
     assert_template_result!(
         " YES ",

--- a/tests/conformance_ruby/template_test.rs
+++ b/tests/conformance_ruby/template_test.rs
@@ -176,13 +176,13 @@ fn test_undefined_filters() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#284
 fn test_undefined_filters_raise() {
     assert_render_error!("{x | somefilter1 | upcase | somefilter2}", v!({"x": "foo"}));
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#224
 fn test_using_range_literal_works_as_expected() {
     let template = liquid::ParserBuilder::with_liquid()
         .build()

--- a/tests/conformance_ruby/variable_test.rs
+++ b/tests/conformance_ruby/variable_test.rs
@@ -36,13 +36,13 @@ fn test_ignore_unknown() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#222
 fn test_using_blank_as_variable_name() {
     assert_template_result!(r#""#, r#"{% assign foo = blank %}{{ foo }}"#);
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#222
 fn test_using_empty_as_variable_name() {
     assert_template_result!(r#""#, r#"{% assign foo = empty %}{{ foo }}"#);
 }
@@ -64,7 +64,7 @@ fn test_false_renders_as_false() {
 }
 
 #[test]
-#[ignore]
+#[should_panic] // liquid-rust#223
 fn test_nil_renders_as_empty_string() {
     assert_template_result!(r#""#, r#"{{ nil }}"#);
 


### PR DESCRIPTION
- Switched almost all `ignore` to `should_panic` so when someone fixes a test, it'll yell at them
- Found a lot of my `ignore`s were fixed when rebasing against the new parser! Thanks @Goncalerta !