### PR TITLE
feat(interpreter): Allow named stack frames

### DIFF
--- a/liquid-interpreter/src/context.rs
+++ b/liquid-interpreter/src/context.rs
@@ -141,6 +141,19 @@ impl<'g> Context<'g> {
         self.stack.pop_frame();
         result
     }
+
+    /// Sets up a new stack frame, executes the supplied function and then
+    /// tears the stack frame down before returning the function's result
+    /// to the caller.
+    pub fn run_in_named_scope<RvalT, S: Into<String>, FnT>(&mut self, name: S, f: FnT) -> RvalT
+    where
+        FnT: FnOnce(&mut Context) -> RvalT,
+    {
+        self.stack.push_named_frame(name);
+        let result = f(self);
+        self.stack.pop_frame();
+        result
+    }
 }
 
 impl<'g> Default for Context<'g> {

--- a/src/tags/include_tag.rs
+++ b/src/tags/include_tag.rs
@@ -17,10 +17,12 @@ struct Include {
 }
 
 impl Renderable for Include {
-    fn render_to(&self, writer: &mut Write, mut context: &mut Context) -> Result<()> {
-        self.partial
-            .render_to(writer, &mut context)
-            .trace_with(|| format!("{{% include {} %}}", self.name).into())?;
+    fn render_to(&self, writer: &mut Write, context: &mut Context) -> Result<()> {
+        context.run_in_named_scope(self.name.clone(), |mut scope| -> Result<()> {
+            self.partial
+                .render_to(writer, &mut scope)
+                .trace_with(|| format!("{{% include {} %}}", self.name).into())
+        })?;
 
         Ok(())
     }


### PR DESCRIPTION
The goal of this is so that runtime includes of partials can set this
and then any error (usually the `trace`) that happens within that partial can be prefixed with
the name.  Eventually we also want these to include line numbers (see #247).

In the end, this will make the errors look more like what you'd expect
from a compiler error.

- [ ] Tests created for any new feature or regression tests for bugfixes.
