### PR TITLE
Iterate by proper char indices

### DIFF
--- a/src/filters/html.rs
+++ b/src/filters/html.rs
@@ -25,7 +25,7 @@ fn _escape(input: &Value, args: &[Value], once_p: bool) -> FilterResult {
     let mut result = String::new();
     let mut last = 0;
     let mut skip = 0;
-    for (i, c) in s.chars().enumerate() {
+    for (i, c) in s.char_indices() {
         if skip > 0 {
             skip -= 1;
             continue;
@@ -135,6 +135,14 @@ mod tests {
         assert_eq!(
             unit!(escape, tos!("Tetsuro Takara")),
             tos!("Tetsuro Takara")
+        );
+    }
+
+    #[test]
+    fn unit_escape_non_ascii() {
+        assert_eq!(
+            unit!(escape, tos!("word¹ <br> word¹")),
+            tos!("word¹ &lt;br&gt; word¹")
         );
     }
 


### PR DESCRIPTION
Not every "char" is just one byte wide. Enumerating `chars()` will lead
to off-by-one (or more) errors with wider characters (e.g. ¹), it could
even panic when accessign a subslice (`&s[last..i]`).

- [x] Tests created for any new feature or regression tests for bugfixes.
