### PR TITLE
fix(parser): blocks can accept invalid liquid

### DIFF
--- a/liquid-compiler/src/grammar.pest
+++ b/liquid-compiler/src/grammar.pest
@@ -23,7 +23,7 @@ Expression = { ExpressionStart ~ WHITESPACE* ~ ExpressionInner ~ WHITESPACE* ~ E
 // Not allowing Tag/Expression Start/End might become a problem
 // for {% raw %}, {% comment %} and other blocks that don't parse
 // the elements inside with liquid: unclosed delimiters won't be accepted
-Raw = @{ (!(TagStart | ExpressionStart | TagEnd | ExpressionEnd) ~ ANY)+ }
+Raw = @{ (!(TagStart | ExpressionStart) ~ ANY)+ }
 
 
 // Inner parsing

--- a/liquid-compiler/src/grammar.pest
+++ b/liquid-compiler/src/grammar.pest
@@ -1,6 +1,12 @@
 WHITESPACE = _{" " | NEWLINE }
 NON_WHITESPACE_CONTROL_HYPHEN = _{ !"-}}" ~ !"-%}" ~ "-" }
+// Lax liquid file won't raise errors. This allows blocks to override
+// liquid rules and parse their content on their own.
+LaxLiquidFile = ${ SOI ~ (Element | InvalidLiquid)* ~ EOI }
 LiquidFile = ${ SOI ~ Element* ~ EOI }
+
+// A token that could not be parsed as valid liquid
+InvalidLiquid = { !Expression ~ ANY }
 
 // Element-level parsing
 Element = _{ Expression | Tag | Raw }

--- a/src/tags/comment_block.rs
+++ b/src/tags/comment_block.rs
@@ -2,7 +2,6 @@ use std::io::Write;
 
 use liquid_error::Result;
 
-use compiler::BlockElement;
 use compiler::Language;
 use compiler::TagBlock;
 use compiler::TagTokenIter;
@@ -19,22 +18,15 @@ impl Renderable for Comment {
 }
 
 pub fn comment_block(
-    tag_name: &str,
+    _tag_name: &str,
     mut arguments: TagTokenIter,
     mut tokens: TagBlock,
-    options: &Language,
+    _options: &Language,
 ) -> Result<Box<Renderable>> {
     // no arguments should be supplied, trying to supply them is an error
     arguments.expect_nothing()?;
 
-    while let Some(token) = tokens.next()? {
-        // Only parse `{% comment %}` tags (in order to allow nesting)
-        if let BlockElement::Tag(tag) = token {
-            if tag.name() == tag_name {
-                tag.parse(&mut tokens, options)?;
-            }
-        }
-    }
+    tokens.escape_liquid(true)?;
 
     tokens.assert_empty();
     Ok(Box::new(Comment))

--- a/src/tags/raw_block.rs
+++ b/src/tags/raw_block.rs
@@ -29,10 +29,7 @@ pub fn raw_block(
     // no arguments should be supplied, trying to supply them is an error
     arguments.expect_nothing()?;
 
-    let mut content = String::new();
-    while let Some(element) = tokens.next()? {
-        content.push_str(element.as_str());
-    }
+    let content = tokens.escape_liquid(false)?.to_string();
 
     tokens.assert_empty();
     Ok(Box::new(RawT { content }))

--- a/tests/conformance_ruby/tags/raw_tag_test.rs
+++ b/tests/conformance_ruby/tags/raw_tag_test.rs
@@ -12,7 +12,6 @@ fn test_output_in_raw() {
 }
 
 #[test]
-#[should_panic] // liquid-ignore#277
 fn test_open_tag_in_raw() {
     assert_template_result!(
         " Foobar {% invalid ",

--- a/tests/conformance_ruby/tags/standard_tag_test.rs
+++ b/tests/conformance_ruby/tags/standard_tag_test.rs
@@ -18,7 +18,6 @@ fn test_no_transform() {
 }
 
 #[test]
-#[should_panic] // liquid-rust#277
 fn test_has_a_block_which_does_nothing() {
     assert_template_result!(
         "the comment block should be removed  .. right?",


### PR DESCRIPTION
Fixes #277 

I don't really like this fix as it is a bit messy, but I guess it gets to do its job, so I think we can consider it even if only as a temporary fix, until we find a better way to handle this issue.

What motivated me into having this fixed was that @Geobert and @epage run into this issue, as reported in #320 and #277 , which means that there might be some urgency in getting this at least working.

Blocks will now be free to parse whatever inside them without liquid restrictions, using `escape_liquid` method. This means invalid liquid will be accepted by `{% raw %}` and `{% comment %}`, as well as any future block that wishes to override liquid rules.

This works by creating a new rule, `LaxLiquidFile`, which instead of directly raising any errors, it produces `InvalidLiquid` tokens, but still tries to parse the rest of the file. Only when parsed, these invalid tokens actually raise an error. This means errors can be avoided by never getting to parse the tokens that would be `InvalidLiquid` (which blocks that override liquid do, by using `escape_liquid` or using `as_str` instead of `parse` in a `BlockElement`).

When calling `parse` in an `InvalidLiquid`, however, it reparses the input (using pest) from the line it is on, this time not allowing `InvalidLiquid` and raising the supposed error. 

This error is then manipulated, so as to add the correct line offset of the input. In the future, having #248 implemented, we can replace this manipulation with the use of an offset in `liquid::error::Error`.


I've also thought of some other solutions, but ended up prefering this one:
- Making comment and raw built-ins
  - This would be another temporary solution, and probably more complicated to implement and it would bring more problems than solutions.
- Using pest to parse Element by Element, instead of the whole file
  - I don't know exactly how pest is implemented. I was afraid that it would not be optimized for this use case and that having to call pest to parse after every single element would be a big hit on performance.
  - Line/col information would be even harder to track than in this case.
- Creating a rule `{%block%} ... {%endblock%}`
  - Again, I don't know how pest works but this seemed like a bad idea. Because tags and blocks cannot be distinguished during pest parsing, the parser would basically need to look for a block closer until the end of the file for **every** tag it encountered.


Note: Some tests were changed to work based on reasons I gave in #277 . 