### PR TITLE
Feature/modernize

### DIFF
--- a/liquid-compiler/src/block.rs
+++ b/liquid-compiler/src/block.rs
@@ -35,29 +35,29 @@ pub trait ParseBlock: Send + Sync + ParseBlockClone + BlockReflection {
         arguments: TagTokenIter,
         block: TagBlock,
         options: &Language,
-    ) -> Result<Box<Renderable>>;
+    ) -> Result<Box<dyn Renderable>>;
 }
 
 pub trait ParseBlockClone {
-    fn clone_box(&self) -> Box<ParseBlock>;
+    fn clone_box(&self) -> Box<dyn ParseBlock>;
 }
 
 impl<T> ParseBlockClone for T
 where
     T: 'static + ParseBlock + Clone,
 {
-    fn clone_box(&self) -> Box<ParseBlock> {
+    fn clone_box(&self) -> Box<dyn ParseBlock> {
         Box::new(self.clone())
     }
 }
 
-impl Clone for Box<ParseBlock> {
-    fn clone(&self) -> Box<ParseBlock> {
+impl Clone for Box<dyn ParseBlock> {
+    fn clone(&self) -> Box<dyn ParseBlock> {
         self.clone_box()
     }
 }
 
-impl<T> From<T> for Box<ParseBlock>
+impl<T> From<T> for Box<dyn ParseBlock>
 where
     T: 'static + ParseBlock,
 {

--- a/liquid-compiler/src/filter.rs
+++ b/liquid-compiler/src/filter.rs
@@ -63,8 +63,8 @@ pub trait FilterParameters<'a>: Sized + FilterParametersReflection + Debug + Dis
 
 /// Structure that holds the unparsed arguments of a filter, both positional and keyword.
 pub struct FilterArguments<'a> {
-    pub positional: Box<Iterator<Item = Expression>>,
-    pub keyword: Box<Iterator<Item = (&'a str, Expression)> + 'a>,
+    pub positional: Box<dyn Iterator<Item = Expression>>,
+    pub keyword: Box<dyn Iterator<Item = (&'a str, Expression)> + 'a>,
 }
 
 /// A trait that holds a filter, ready to evaluate.
@@ -220,31 +220,31 @@ pub trait Filter: Send + Sync + Debug + Display {
 /// ```
 pub trait ParseFilter: Send + Sync + ParseFilterClone + FilterReflection {
     /// Filter `input` based on `arguments`.
-    fn parse(&self, arguments: FilterArguments) -> Result<Box<Filter>>;
+    fn parse(&self, arguments: FilterArguments) -> Result<Box<dyn Filter>>;
 }
 
 /// Support cloning of `Box<ParseFilter>`.
 pub trait ParseFilterClone {
     /// Cloning of `dyn ParseFilter`.
-    fn clone_box(&self) -> Box<ParseFilter>;
+    fn clone_box(&self) -> Box<dyn ParseFilter>;
 }
 
 impl<T> ParseFilterClone for T
 where
     T: 'static + ParseFilter + Clone,
 {
-    fn clone_box(&self) -> Box<ParseFilter> {
+    fn clone_box(&self) -> Box<dyn ParseFilter> {
         Box::new(self.clone())
     }
 }
 
-impl Clone for Box<ParseFilter> {
-    fn clone(&self) -> Box<ParseFilter> {
+impl Clone for Box<dyn ParseFilter> {
+    fn clone(&self) -> Box<dyn ParseFilter> {
         self.clone_box()
     }
 }
 
-impl<T> From<T> for Box<ParseFilter>
+impl<T> From<T> for Box<dyn ParseFilter>
 where
     T: 'static + ParseFilter,
 {

--- a/liquid-compiler/src/filter_chain.rs
+++ b/liquid-compiler/src/filter_chain.rs
@@ -14,12 +14,12 @@ use liquid_value::Value;
 #[derive(Debug)]
 pub struct FilterChain {
     entry: Expression,
-    filters: Vec<Box<Filter>>,
+    filters: Vec<Box<dyn Filter>>,
 }
 
 impl FilterChain {
     /// Create a new expression.
-    pub fn new(entry: Expression, filters: Vec<Box<Filter>>) -> Self {
+    pub fn new(entry: Expression, filters: Vec<Box<dyn Filter>>) -> Self {
         Self { entry, filters }
     }
 
@@ -55,7 +55,7 @@ impl fmt::Display for FilterChain {
 }
 
 impl Renderable for FilterChain {
-    fn render_to(&self, writer: &mut Write, context: &mut Context) -> Result<()> {
+    fn render_to(&self, writer: &mut dyn Write, context: &mut Context) -> Result<()> {
         let entry = self.evaluate(context)?;
         write!(writer, "{}", entry.to_str()).replace("Failed to render")?;
         Ok(())

--- a/liquid-compiler/src/lang.rs
+++ b/liquid-compiler/src/lang.rs
@@ -5,9 +5,9 @@ use super::PluginRegistry;
 
 #[derive(Clone)]
 pub struct Language {
-    pub blocks: PluginRegistry<Box<ParseBlock>>,
-    pub tags: PluginRegistry<Box<ParseTag>>,
-    pub filters: PluginRegistry<Box<ParseFilter>>,
+    pub blocks: PluginRegistry<Box<dyn ParseBlock>>,
+    pub tags: PluginRegistry<Box<dyn ParseTag>>,
+    pub filters: PluginRegistry<Box<dyn ParseFilter>>,
     non_exhaustive: (),
 }
 

--- a/liquid-compiler/src/parser.rs
+++ b/liquid-compiler/src/parser.rs
@@ -58,7 +58,7 @@ fn error_from_pair(pair: Pair, msg: String) -> Error {
 }
 
 /// Parses the provided &str into a number of Renderable items.
-pub fn parse(text: &str, options: &Language) -> Result<Vec<Box<Renderable>>> {
+pub fn parse(text: &str, options: &Language) -> Result<Vec<Box<dyn Renderable>>> {
     let mut liquid = LiquidParser::parse(Rule::LaxLiquidFile, text)
         .expect("Parsing with Rule::LaxLiquidFile should not raise errors, but InvalidLiquid tokens instead.")
         .next()
@@ -173,7 +173,7 @@ fn parse_value(value: Pair) -> Expression {
 
 /// Parses a `FilterCall` from a `Pair` with a filter.
 /// This `Pair` must be `Rule::Filter`.
-fn parse_filter(filter: Pair, options: &Language) -> Result<Box<Filter>> {
+fn parse_filter(filter: Pair, options: &Language) -> Result<Box<dyn Filter>> {
     if filter.as_rule() != Rule::Filter {
         panic!("Expected a filter.");
     }
@@ -249,12 +249,12 @@ fn parse_filter_chain(chain: Pair, options: &Language) -> Result<FilterChain> {
 /// An interface to access elements inside a block.
 pub struct TagBlock<'a: 'b, 'b> {
     name: &'b str,
-    iter: &'b mut Iterator<Item = Pair<'a>>,
+    iter: &'b mut dyn Iterator<Item = Pair<'a>>,
     closed: bool,
 }
 
 impl<'a, 'b> TagBlock<'a, 'b> {
-    fn new(name: &'b str, next_elements: &'b mut Iterator<Item = Pair<'a>>) -> Self {
+    fn new(name: &'b str, next_elements: &'b mut dyn Iterator<Item = Pair<'a>>) -> Self {
         TagBlock {
             name,
             iter: next_elements,
@@ -395,7 +395,7 @@ impl<'a, 'b> TagBlock<'a, 'b> {
     }
 
     /// A convenient method that parses every element remaining in the block.
-    pub fn parse_all(&mut self, options: &Language) -> Result<Vec<Box<Renderable>>> {
+    pub fn parse_all(&mut self, options: &Language) -> Result<Vec<Box<dyn Renderable>>> {
         let mut renderables = Vec::new();
         while let Some(r) = self.parse_next(options)? {
             renderables.push(r);
@@ -406,7 +406,7 @@ impl<'a, 'b> TagBlock<'a, 'b> {
     /// Parses the next element in the block just as if it weren't inside any block.
     ///
     /// Returns none if no element is left and raises the same errors as `next()`.
-    pub fn parse_next(&mut self, options: &Language) -> Result<Option<Box<Renderable>>> {
+    pub fn parse_next(&mut self, options: &Language) -> Result<Option<Box<dyn Renderable>>> {
         match self.next()? {
             None => Ok(None),
             Some(element) => Ok(Some(element.parse(self, options)?)),
@@ -447,7 +447,7 @@ impl<'a> Into<&'a str> for Raw<'a> {
 }
 impl<'a> Raw<'a> {
     /// Turns the text into a Renderable.
-    pub fn to_renderable(self) -> Box<Renderable> {
+    pub fn to_renderable(self) -> Box<dyn Renderable> {
         Box::new(Text::new(self.as_str()))
     }
 
@@ -520,16 +520,16 @@ impl<'a> Tag<'a> {
     }
 
     /// Parses the tag just as if it weren't inside any block.
-    pub fn parse(self, tag_block: &mut TagBlock, options: &Language) -> Result<Box<Renderable>> {
+    pub fn parse(self, tag_block: &mut TagBlock, options: &Language) -> Result<Box<dyn Renderable>> {
         self.parse_pair(&mut tag_block.iter, options)
     }
 
     /// The same as `parse`, but directly takes an iterator over `Pair`s instead of a TagBlock.
     fn parse_pair(
         self,
-        next_elements: &mut Iterator<Item = Pair>,
+        next_elements: &mut dyn Iterator<Item = Pair>,
         options: &Language,
-    ) -> Result<Box<Renderable>> {
+    ) -> Result<Box<dyn Renderable>> {
         let (name, tokens) = (self.name, self.tokens);
         let position = name.as_span();
         let name = name.as_str();
@@ -578,7 +578,7 @@ impl<'a> From<Pair<'a>> for Exp<'a> {
 
 impl<'a> Exp<'a> {
     /// Parses the expression just as if it weren't inside any block.
-    pub fn parse(self, options: &Language) -> Result<Box<Renderable>> {
+    pub fn parse(self, options: &Language) -> Result<Box<dyn Renderable>> {
         let filter_chain = self
             .element
             .into_inner()
@@ -612,13 +612,13 @@ impl<'a> InvalidLiquidToken<'a> {
 
     /// Tries to parse this as valid liquid, which will inevitably raise an error.
     /// This is needed in order to raise the right error message.
-    pub fn parse(self, tag_block: &mut TagBlock) -> Result<Box<Renderable>> {
+    pub fn parse(self, tag_block: &mut TagBlock) -> Result<Box<dyn Renderable>> {
         self.parse_pair(&mut tag_block.iter)
     }
 
     /// Tries to parse this as valid liquid, which will inevitably raise an error.
     /// This is needed in order to raise the correct error message.
-    fn parse_pair(self, next_elements: &mut Iterator<Item = Pair>) -> Result<Box<Renderable>> {
+    fn parse_pair(self, next_elements: &mut dyn Iterator<Item = Pair>) -> Result<Box<dyn Renderable>> {
         use pest::error::LineColLocation;
 
         let invalid_token_span = self.element.as_span();
@@ -694,7 +694,7 @@ impl<'a> BlockElement<'a> {
         self,
         block: &mut TagBlock<'a, '_>,
         options: &Language,
-    ) -> Result<Box<Renderable>> {
+    ) -> Result<Box<dyn Renderable>> {
         match self {
             BlockElement::Raw(raw) => Ok(raw.to_renderable()),
             BlockElement::Tag(tag) => tag.parse(block, options),
@@ -706,9 +706,9 @@ impl<'a> BlockElement<'a> {
     /// The same as `parse`, but directly takes an iterator over `Pair`s instead of a TagBlock.
     fn parse_pair(
         self,
-        next_elements: &mut Iterator<Item = Pair>,
+        next_elements: &mut dyn Iterator<Item = Pair>,
         options: &Language,
-    ) -> Result<Box<Renderable>> {
+    ) -> Result<Box<dyn Renderable>> {
         match self {
             BlockElement::Raw(raw) => Ok(raw.to_renderable()),
             BlockElement::Tag(tag) => tag.parse_pair(next_elements, options),
@@ -732,7 +732,7 @@ impl<'a> BlockElement<'a> {
 ///
 /// The awareness of the position allows more precise error messages.
 pub struct TagTokenIter<'a> {
-    iter: Box<Iterator<Item = TagToken<'a>> + 'a>,
+    iter: Box<dyn Iterator<Item = TagToken<'a>> + 'a>,
     position: ::pest::Position<'a>,
 }
 impl<'a> Iterator for TagTokenIter<'a> {

--- a/liquid-compiler/src/parser.rs
+++ b/liquid-compiler/src/parser.rs
@@ -520,7 +520,11 @@ impl<'a> Tag<'a> {
     }
 
     /// Parses the tag just as if it weren't inside any block.
-    pub fn parse(self, tag_block: &mut TagBlock, options: &Language) -> Result<Box<dyn Renderable>> {
+    pub fn parse(
+        self,
+        tag_block: &mut TagBlock,
+        options: &Language,
+    ) -> Result<Box<dyn Renderable>> {
         self.parse_pair(&mut tag_block.iter, options)
     }
 
@@ -618,7 +622,10 @@ impl<'a> InvalidLiquidToken<'a> {
 
     /// Tries to parse this as valid liquid, which will inevitably raise an error.
     /// This is needed in order to raise the correct error message.
-    fn parse_pair(self, next_elements: &mut dyn Iterator<Item = Pair>) -> Result<Box<dyn Renderable>> {
+    fn parse_pair(
+        self,
+        next_elements: &mut dyn Iterator<Item = Pair>,
+    ) -> Result<Box<dyn Renderable>> {
         use pest::error::LineColLocation;
 
         let invalid_token_span = self.element.as_span();

--- a/liquid-compiler/src/tag.rs
+++ b/liquid-compiler/src/tag.rs
@@ -25,29 +25,29 @@ pub trait TagReflection {
 /// specify the name of the tag, the argument [Tokens](lexer/enum.Token.html) passed to
 /// the tag and the global [`Language`](struct.Language.html).
 pub trait ParseTag: Send + Sync + ParseTagClone + TagReflection {
-    fn parse(&self, arguments: TagTokenIter, options: &Language) -> Result<Box<Renderable>>;
+    fn parse(&self, arguments: TagTokenIter, options: &Language) -> Result<Box<dyn Renderable>>;
 }
 
 pub trait ParseTagClone {
-    fn clone_box(&self) -> Box<ParseTag>;
+    fn clone_box(&self) -> Box<dyn ParseTag>;
 }
 
 impl<T> ParseTagClone for T
 where
     T: 'static + ParseTag + Clone,
 {
-    fn clone_box(&self) -> Box<ParseTag> {
+    fn clone_box(&self) -> Box<dyn ParseTag> {
         Box::new(self.clone())
     }
 }
 
-impl Clone for Box<ParseTag> {
-    fn clone(&self) -> Box<ParseTag> {
+impl Clone for Box<dyn ParseTag> {
+    fn clone(&self) -> Box<dyn ParseTag> {
         self.clone_box()
     }
 }
 
-impl<T> From<T> for Box<ParseTag>
+impl<T> From<T> for Box<dyn ParseTag>
 where
     T: 'static + ParseTag,
 {

--- a/liquid-compiler/src/text.rs
+++ b/liquid-compiler/src/text.rs
@@ -18,7 +18,7 @@ impl Text {
 }
 
 impl Renderable for Text {
-    fn render_to(&self, writer: &mut Write, _context: &mut Context) -> Result<()> {
+    fn render_to(&self, writer: &mut dyn Write, _context: &mut Context) -> Result<()> {
         write!(writer, "{}", &self.text).replace("Failed to render")?;
         Ok(())
     }

--- a/liquid-error/src/clone.rs
+++ b/liquid-error/src/clone.rs
@@ -4,20 +4,20 @@ use std::fmt;
 /// An error that can be cloned.
 pub trait ErrorClone: error::Error + Send + Sync + 'static {
     /// Clone the error.
-    fn clone_box(&self) -> Box<ErrorClone>;
+    fn clone_box(&self) -> Box<dyn ErrorClone>;
 }
 
 impl<E> ErrorClone for E
 where
     E: error::Error + Clone + Send + Sync + 'static,
 {
-    fn clone_box(&self) -> Box<ErrorClone> {
+    fn clone_box(&self) -> Box<dyn ErrorClone> {
         Box::new(self.clone())
     }
 }
 
-impl Clone for Box<ErrorClone> {
-    fn clone(&self) -> Box<ErrorClone> {
+impl Clone for Box<dyn ErrorClone> {
+    fn clone(&self) -> Box<dyn ErrorClone> {
         self.clone_box()
     }
 }
@@ -51,7 +51,7 @@ impl error::Error for CloneableError {
         self.error.as_str()
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         None
     }
 }

--- a/liquid-error/src/clone.rs
+++ b/liquid-error/src/clone.rs
@@ -51,7 +51,7 @@ impl error::Error for CloneableError {
         self.error.as_str()
     }
 
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         None
     }
 }

--- a/liquid-error/src/error.rs
+++ b/liquid-error/src/error.rs
@@ -9,7 +9,7 @@ use super::Trace;
 /// Convenience type alias for Liquid compiler errors
 pub type Result<T> = result::Result<T, Error>;
 
-type BoxedError = Box<ErrorClone>;
+type BoxedError = Box<dyn ErrorClone>;
 
 /// Compiler error
 #[derive(Debug, Clone)]
@@ -130,7 +130,7 @@ impl error::Error for Error {
         ERROR_DESCRIPTION
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         self.inner.cause.as_ref().and_then(|e| e.cause())
     }
 }

--- a/liquid-error/src/error.rs
+++ b/liquid-error/src/error.rs
@@ -130,7 +130,7 @@ impl error::Error for Error {
         ERROR_DESCRIPTION
     }
 
-    fn cause(&self) -> Option<&dyn error::Error> {
-        self.inner.cause.as_ref().and_then(|e| e.cause())
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        self.inner.cause.as_ref().and_then(|e| e.source())
     }
 }

--- a/liquid-interpreter/src/context.rs
+++ b/liquid-interpreter/src/context.rs
@@ -59,19 +59,19 @@ impl PartialStore for NullPartials {
         Vec::new()
     }
 
-    fn try_get(&self, _name: &str) -> Option<sync::Arc<Renderable>> {
+    fn try_get(&self, _name: &str) -> Option<sync::Arc<dyn Renderable>> {
         None
     }
 
-    fn get(&self, name: &str) -> Result<sync::Arc<Renderable>> {
+    fn get(&self, name: &str) -> Result<sync::Arc<dyn Renderable>> {
         Err(Error::with_msg("Partial does not exist").context("name", name.to_owned()))
     }
 }
 
 /// Create processing context for a template.
 pub struct ContextBuilder<'g> {
-    globals: Option<&'g ValueStore>,
-    partials: Option<&'g PartialStore>,
+    globals: Option<&'g dyn ValueStore>,
+    partials: Option<&'g dyn PartialStore>,
 }
 
 impl<'g> ContextBuilder<'g> {
@@ -84,13 +84,13 @@ impl<'g> ContextBuilder<'g> {
     }
 
     /// Initialize the stack with the given globals.
-    pub fn set_globals(mut self, values: &'g ValueStore) -> Self {
+    pub fn set_globals(mut self, values: &'g dyn ValueStore) -> Self {
         self.globals = Some(values);
         self
     }
 
     /// Initialize partial-templates availible for including.
-    pub fn set_partials(mut self, values: &'g PartialStore) -> Self {
+    pub fn set_partials(mut self, values: &'g dyn PartialStore) -> Self {
         self.partials = Some(values);
         self
     }
@@ -120,7 +120,7 @@ impl<'g> Default for ContextBuilder<'g> {
 /// Processing context for a template.
 pub struct Context<'g> {
     stack: Stack<'g>,
-    partials: &'g PartialStore,
+    partials: &'g dyn PartialStore,
 
     registers: anymap::AnyMap,
     interrupt: InterruptState,
@@ -145,7 +145,7 @@ impl<'g> Context<'g> {
     }
 
     /// Partial templates for inclusion.
-    pub fn partials(&self) -> &PartialStore {
+    pub fn partials(&self) -> &dyn PartialStore {
         self.partials
     }
 
@@ -153,7 +153,7 @@ impl<'g> Context<'g> {
     ///
     /// If a plugin needs state, it creates a `struct State : Default` and accesses it via
     /// `get_register_mut`.
-    pub fn get_register_mut<T: anymap::any::IntoBox<anymap::any::Any> + Default>(
+    pub fn get_register_mut<T: anymap::any::IntoBox<dyn anymap::any::Any> + Default>(
         &mut self,
     ) -> &mut T {
         self.registers.entry::<T>().or_insert_with(Default::default)

--- a/liquid-interpreter/src/partials.rs
+++ b/liquid-interpreter/src/partials.rs
@@ -14,8 +14,8 @@ pub trait PartialStore: fmt::Debug {
     fn names(&self) -> Vec<&str>;
 
     /// Access a partial-template.
-    fn try_get(&self, name: &str) -> Option<sync::Arc<Renderable>>;
+    fn try_get(&self, name: &str) -> Option<sync::Arc<dyn Renderable>>;
 
     /// Access a .partial-template
-    fn get(&self, name: &str) -> Result<sync::Arc<Renderable>>;
+    fn get(&self, name: &str) -> Result<sync::Arc<dyn Renderable>>;
 }

--- a/liquid-interpreter/src/renderable.rs
+++ b/liquid-interpreter/src/renderable.rs
@@ -15,5 +15,5 @@ pub trait Renderable: Send + Sync + Debug {
     }
 
     /// Renders the Renderable instance given a Liquid context.
-    fn render_to(&self, writer: &mut Write, context: &mut Context) -> Result<()>;
+    fn render_to(&self, writer: &mut dyn Write, context: &mut Context) -> Result<()>;
 }

--- a/liquid-interpreter/src/stack.rs
+++ b/liquid-interpreter/src/stack.rs
@@ -28,7 +28,7 @@ impl Frame {
 /// Stack of variables.
 #[derive(Debug, Clone)]
 pub struct Stack<'g> {
-    globals: Option<&'g ValueStore>,
+    globals: Option<&'g dyn ValueStore>,
     stack: Vec<Frame>,
     // State of variables created through increment or decrement tags.
     indexes: Object,
@@ -46,7 +46,7 @@ impl<'g> Stack<'g> {
     }
 
     /// Create a stack initialized with read-only `ValueStore`.
-    pub fn with_globals(globals: &'g ValueStore) -> Self {
+    pub fn with_globals(globals: &'g dyn ValueStore) -> Self {
         let mut stack = Self::empty();
         stack.globals = Some(globals);
         stack
@@ -118,13 +118,13 @@ impl<'g> Stack<'g> {
         globals
     }
 
-    fn find_path_frame<'a>(&'a self, path: PathRef) -> Option<&'a ValueStore> {
+    fn find_path_frame<'a>(&'a self, path: PathRef) -> Option<&'a dyn ValueStore> {
         let key = path.iter().next()?;
         let key = key.to_str();
         self.find_frame(key.as_ref())
     }
 
-    fn find_frame<'a>(&'a self, name: &str) -> Option<&'a ValueStore> {
+    fn find_frame<'a>(&'a self, name: &str) -> Option<&'a dyn ValueStore> {
         for frame in self.stack.iter().rev() {
             if frame.data.contains_root(name) {
                 return Some(&frame.data);

--- a/liquid-interpreter/src/template.rs
+++ b/liquid-interpreter/src/template.rs
@@ -8,18 +8,18 @@ use super::Renderable;
 /// An executable template block.
 #[derive(Debug)]
 pub struct Template {
-    elements: Vec<Box<Renderable>>,
+    elements: Vec<Box<dyn Renderable>>,
 }
 
 impl Template {
     /// Create an executable template block.
-    pub fn new(elements: Vec<Box<Renderable>>) -> Template {
+    pub fn new(elements: Vec<Box<dyn Renderable>>) -> Template {
         Template { elements }
     }
 }
 
 impl Renderable for Template {
-    fn render_to(&self, writer: &mut Write, context: &mut Context) -> Result<()> {
+    fn render_to(&self, writer: &mut dyn Write, context: &mut Context) -> Result<()> {
         for el in &self.elements {
             el.render_to(writer, context)?;
 

--- a/liquid-value/src/ser.rs
+++ b/liquid-value/src/ser.rs
@@ -38,7 +38,7 @@ impl ::std::error::Error for SerError {
         self.0.description()
     }
 
-    fn cause(&self) -> Option<&::std::error::Error> {
+    fn cause(&self) -> Option<&dyn (::std::error::Error)> {
         ::std::error::Error::cause(&self.0)
     }
 }

--- a/liquid-value/src/ser.rs
+++ b/liquid-value/src/ser.rs
@@ -38,8 +38,8 @@ impl ::std::error::Error for SerError {
         self.0.description()
     }
 
-    fn cause(&self) -> Option<&dyn (::std::error::Error)> {
-        ::std::error::Error::cause(&self.0)
+    fn source(&self) -> Option<&(dyn (::std::error::Error) + 'static)> {
+        ::std::error::Error::source(&self.0)
     }
 }
 

--- a/src/filters/std/string/strip.rs
+++ b/src/filters/std/string/strip.rs
@@ -10,7 +10,7 @@ use liquid_value::Value;
 /// It does not affect spaces between words.  Note that while this works for the case of tabs,
 /// spaces, and newlines, it also removes any other codepoints defined by the Unicode Derived Core
 /// Property `White_Space` (per [rust
-/// documentation](https://doc.rust-lang.org/std/primitive.str.html#method.trim_left).
+/// documentation](https://doc.rust-lang.org/std/primitive.str.html#method.trim_start).
 #[derive(Clone, ParseFilter, FilterReflection)]
 #[filter(
     name = "strip",
@@ -35,7 +35,7 @@ impl Filter for StripFilter {
 /// The filter does not affect spaces between words.  Note that while this works for the case of
 /// tabs, spaces, and newlines, it also removes any other codepoints defined by the Unicode Derived
 /// Core Property `White_Space` (per [rust
-/// documentation](https://doc.rust-lang.org/std/primitive.str.html#method.trim_left).
+/// documentation](https://doc.rust-lang.org/std/primitive.str.html#method.trim_start).
 #[derive(Clone, ParseFilter, FilterReflection)]
 #[filter(
     name = "lstrip",
@@ -51,7 +51,7 @@ struct LstripFilter;
 impl Filter for LstripFilter {
     fn evaluate(&self, input: &Value, _context: &Context) -> Result<Value> {
         let input = input.to_str();
-        Ok(Value::scalar(input.trim_left().to_owned()))
+        Ok(Value::scalar(input.trim_start().to_owned()))
     }
 }
 
@@ -60,7 +60,7 @@ impl Filter for LstripFilter {
 /// The filter does not affect spaces between words.  Note that while this works for the case of
 /// tabs, spaces, and newlines, it also removes any other codepoints defined by the Unicode Derived
 /// Core Property `White_Space` (per [rust
-/// documentation](https://doc.rust-lang.org/std/primitive.str.html#method.trim_left).
+/// documentation](https://doc.rust-lang.org/std/primitive.str.html#method.trim_start).
 #[derive(Clone, ParseFilter, FilterReflection)]
 #[filter(
     name = "rstrip",
@@ -76,7 +76,7 @@ struct RstripFilter;
 impl Filter for RstripFilter {
     fn evaluate(&self, input: &Value, _context: &Context) -> Result<Value> {
         let input = input.to_str();
-        Ok(Value::scalar(input.trim_right().to_owned()))
+        Ok(Value::scalar(input.trim_end().to_owned()))
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -21,9 +21,9 @@ pub struct ParserBuilder<P = Partials>
 where
     P: partials::PartialCompiler,
 {
-    blocks: compiler::PluginRegistry<Box<compiler::ParseBlock>>,
-    tags: compiler::PluginRegistry<Box<compiler::ParseTag>>,
-    filters: compiler::PluginRegistry<Box<compiler::ParseFilter>>,
+    blocks: compiler::PluginRegistry<Box<dyn compiler::ParseBlock>>,
+    tags: compiler::PluginRegistry<Box<dyn compiler::ParseTag>>,
+    filters: compiler::PluginRegistry<Box<dyn compiler::ParseFilter>>,
     partials: Option<P>,
 }
 
@@ -153,21 +153,21 @@ where
     }
 
     /// Inserts a new custom block into the parser
-    pub fn block<B: Into<Box<compiler::ParseBlock>>>(mut self, block: B) -> Self {
+    pub fn block<B: Into<Box<dyn compiler::ParseBlock>>>(mut self, block: B) -> Self {
         let block = block.into();
         self.blocks.register(block.start_tag(), block);
         self
     }
 
     /// Inserts a new custom tag into the parser
-    pub fn tag<T: Into<Box<compiler::ParseTag>>>(mut self, tag: T) -> Self {
+    pub fn tag<T: Into<Box<dyn compiler::ParseTag>>>(mut self, tag: T) -> Self {
         let tag = tag.into();
         self.tags.register(tag.tag(), tag);
         self
     }
 
     /// Inserts a new custom filter into the parser
-    pub fn filter<F: Into<Box<compiler::ParseFilter>>>(mut self, filter: F) -> Self {
+    pub fn filter<F: Into<Box<dyn compiler::ParseFilter>>>(mut self, filter: F) -> Self {
         let filter = filter.into();
         self.filters.register(filter.name(), filter);
         self
@@ -229,7 +229,7 @@ where
 #[derive(Default, Clone)]
 pub struct Parser {
     options: sync::Arc<compiler::Language>,
-    partials: Option<sync::Arc<interpreter::PartialStore + Send + Sync>>,
+    partials: Option<sync::Arc<dyn interpreter::PartialStore + Send + Sync>>,
 }
 
 impl Parser {

--- a/src/partials/eager.rs
+++ b/src/partials/eager.rs
@@ -81,7 +81,7 @@ impl<S> PartialCompiler for EagerCompiler<S>
 where
     S: PartialSource + Send + Sync + 'static,
 {
-    fn compile(self, language: sync::Arc<Language>) -> Result<Box<PartialStore + Send + Sync>> {
+    fn compile(self, language: sync::Arc<Language>) -> Result<Box<dyn PartialStore + Send + Sync>> {
         let store: HashMap<_, _> = self
             .source
             .names()
@@ -91,7 +91,7 @@ where
                     liquid_compiler::parse(s.as_ref(), &language)
                         .map(liquid_interpreter::Template::new)
                         .map(|t| {
-                            let t: sync::Arc<liquid_interpreter::Renderable> = sync::Arc::new(t);
+                            let t: sync::Arc<dyn liquid_interpreter::Renderable> = sync::Arc::new(t);
                             t
                         })
                 });
@@ -104,7 +104,7 @@ where
 }
 
 struct EagerStore {
-    store: HashMap<String, Result<sync::Arc<liquid_interpreter::Renderable>>>,
+    store: HashMap<String, Result<sync::Arc<dyn liquid_interpreter::Renderable>>>,
 }
 
 impl PartialStore for EagerStore {
@@ -116,11 +116,11 @@ impl PartialStore for EagerStore {
         self.store.keys().map(|s| s.as_str()).collect()
     }
 
-    fn try_get(&self, name: &str) -> Option<sync::Arc<Renderable>> {
+    fn try_get(&self, name: &str) -> Option<sync::Arc<dyn Renderable>> {
         self.store.get(name).and_then(|r| r.clone().ok())
     }
 
-    fn get(&self, name: &str) -> Result<sync::Arc<Renderable>> {
+    fn get(&self, name: &str) -> Result<sync::Arc<dyn Renderable>> {
         let result = self.store.get(name).ok_or_else(|| {
             let mut available: Vec<_> = self.names();
             available.sort_unstable();

--- a/src/partials/eager.rs
+++ b/src/partials/eager.rs
@@ -91,7 +91,8 @@ where
                     liquid_compiler::parse(s.as_ref(), &language)
                         .map(liquid_interpreter::Template::new)
                         .map(|t| {
-                            let t: sync::Arc<dyn liquid_interpreter::Renderable> = sync::Arc::new(t);
+                            let t: sync::Arc<dyn liquid_interpreter::Renderable> =
+                                sync::Arc::new(t);
                             t
                         })
                 });

--- a/src/partials/lazy.rs
+++ b/src/partials/lazy.rs
@@ -80,7 +80,7 @@ impl<S> PartialCompiler for LazyCompiler<S>
 where
     S: PartialSource + Send + Sync + 'static,
 {
-    fn compile(self, language: sync::Arc<Language>) -> Result<Box<PartialStore + Send + Sync>> {
+    fn compile(self, language: sync::Arc<Language>) -> Result<Box<dyn PartialStore + Send + Sync>> {
         let store = LazyStore {
             language: language,
             source: self.source,
@@ -93,14 +93,14 @@ where
 struct LazyStore<S: PartialSource> {
     language: sync::Arc<Language>,
     source: S,
-    cache: sync::Mutex<HashMap<String, Result<sync::Arc<liquid_interpreter::Renderable>>>>,
+    cache: sync::Mutex<HashMap<String, Result<sync::Arc<dyn liquid_interpreter::Renderable>>>>,
 }
 
 impl<S> LazyStore<S>
 where
     S: PartialSource,
 {
-    fn try_get_or_create(&self, name: &str) -> Option<sync::Arc<Renderable>> {
+    fn try_get_or_create(&self, name: &str) -> Option<sync::Arc<dyn Renderable>> {
         let cache = self.cache.lock().expect("not to be poisoned and reused");
         if let Some(result) = cache.get(name) {
             result.as_ref().ok().cloned()
@@ -115,7 +115,7 @@ where
         }
     }
 
-    fn get_or_create(&self, name: &str) -> Result<sync::Arc<Renderable>> {
+    fn get_or_create(&self, name: &str) -> Result<sync::Arc<dyn Renderable>> {
         let cache = self.cache.lock().expect("not to be poisoned and reused");
         if let Some(result) = cache.get(name) {
             result.clone()
@@ -142,11 +142,11 @@ where
         self.source.names()
     }
 
-    fn try_get(&self, name: &str) -> Option<sync::Arc<Renderable>> {
+    fn try_get(&self, name: &str) -> Option<sync::Arc<dyn Renderable>> {
         self.try_get_or_create(name)
     }
 
-    fn get(&self, name: &str) -> Result<sync::Arc<Renderable>> {
+    fn get(&self, name: &str) -> Result<sync::Arc<dyn Renderable>> {
         self.get_or_create(name)
     }
 }

--- a/src/partials/mod.rs
+++ b/src/partials/mod.rs
@@ -26,7 +26,7 @@ pub use self::ondemand::*;
 /// - Whether to cache the results or not.
 pub trait PartialCompiler {
     /// Convert a `PartialSource` into a `PartialStore`.
-    fn compile(self, language: sync::Arc<Language>) -> Result<Box<PartialStore + Send + Sync>>;
+    fn compile(self, language: sync::Arc<Language>) -> Result<Box<dyn PartialStore + Send + Sync>>;
 }
 
 /// Partial-template source repository.

--- a/src/partials/ondemand.rs
+++ b/src/partials/ondemand.rs
@@ -78,7 +78,7 @@ impl<S> PartialCompiler for OnDemandCompiler<S>
 where
     S: PartialSource + Send + Sync + 'static,
 {
-    fn compile(self, language: sync::Arc<Language>) -> Result<Box<PartialStore + Send + Sync>> {
+    fn compile(self, language: sync::Arc<Language>) -> Result<Box<dyn PartialStore + Send + Sync>> {
         let store = OnDemandStore {
             language,
             source: self.source,
@@ -104,7 +104,7 @@ where
         self.source.names()
     }
 
-    fn try_get(&self, name: &str) -> Option<sync::Arc<Renderable>> {
+    fn try_get(&self, name: &str) -> Option<sync::Arc<dyn Renderable>> {
         let s = self.source.try_get(name)?;
         let s = s.as_ref();
         let template = liquid_compiler::parse(s, &self.language)
@@ -114,7 +114,7 @@ where
         Some(template)
     }
 
-    fn get(&self, name: &str) -> Result<sync::Arc<Renderable>> {
+    fn get(&self, name: &str) -> Result<sync::Arc<dyn Renderable>> {
         let s = self.source.get(name)?;
         let s = s.as_ref();
         let template = liquid_compiler::parse(s, &self.language)

--- a/src/tags/assign_tag.rs
+++ b/src/tags/assign_tag.rs
@@ -24,7 +24,7 @@ impl Assign {
 }
 
 impl Renderable for Assign {
-    fn render_to(&self, _writer: &mut Write, context: &mut Context) -> Result<()> {
+    fn render_to(&self, _writer: &mut dyn Write, context: &mut Context) -> Result<()> {
         let value = self
             .src
             .evaluate(context)
@@ -54,7 +54,7 @@ impl TagReflection for AssignTag {
 }
 
 impl ParseTag for AssignTag {
-    fn parse(&self, mut arguments: TagTokenIter, options: &Language) -> Result<Box<Renderable>> {
+    fn parse(&self, mut arguments: TagTokenIter, options: &Language) -> Result<Box<dyn Renderable>> {
         let dst = arguments
             .expect_next("Identifier expected.")?
             .expect_identifier()

--- a/src/tags/assign_tag.rs
+++ b/src/tags/assign_tag.rs
@@ -54,7 +54,11 @@ impl TagReflection for AssignTag {
 }
 
 impl ParseTag for AssignTag {
-    fn parse(&self, mut arguments: TagTokenIter, options: &Language) -> Result<Box<dyn Renderable>> {
+    fn parse(
+        &self,
+        mut arguments: TagTokenIter,
+        options: &Language,
+    ) -> Result<Box<dyn Renderable>> {
         let dst = arguments
             .expect_next("Identifier expected.")?
             .expect_identifier()

--- a/src/tags/capture_block.rs
+++ b/src/tags/capture_block.rs
@@ -25,7 +25,7 @@ impl Capture {
 }
 
 impl Renderable for Capture {
-    fn render_to(&self, _writer: &mut Write, context: &mut Context) -> Result<()> {
+    fn render_to(&self, _writer: &mut dyn Write, context: &mut Context) -> Result<()> {
         let mut captured = Vec::new();
         self.template
             .render_to(&mut captured, context)
@@ -68,7 +68,7 @@ impl ParseBlock for CaptureBlock {
         mut arguments: TagTokenIter,
         mut tokens: TagBlock,
         options: &Language,
-    ) -> Result<Box<Renderable>> {
+    ) -> Result<Box<dyn Renderable>> {
         let id = arguments
             .expect_next("Identifier expected")?
             .expect_identifier()

--- a/src/tags/case_block.rs
+++ b/src/tags/case_block.rs
@@ -56,7 +56,7 @@ impl Case {
 }
 
 impl Renderable for Case {
-    fn render_to(&self, writer: &mut Write, context: &mut Context) -> Result<()> {
+    fn render_to(&self, writer: &mut dyn Write, context: &mut Context) -> Result<()> {
         let value = self.target.evaluate(context)?.to_owned();
         for case in &self.cases {
             if case.evaluate(&value, context)? {
@@ -140,7 +140,7 @@ impl ParseBlock for CaseBlock {
         mut arguments: TagTokenIter,
         mut tokens: TagBlock,
         options: &Language,
-    ) -> Result<Box<Renderable>> {
+    ) -> Result<Box<dyn Renderable>> {
         let target = arguments
             .expect_next("Value expected.")?
             .expect_value()

--- a/src/tags/comment_block.rs
+++ b/src/tags/comment_block.rs
@@ -15,7 +15,7 @@ use interpreter::Renderable;
 struct Comment;
 
 impl Renderable for Comment {
-    fn render_to(&self, _writer: &mut Write, _context: &mut Context) -> Result<()> {
+    fn render_to(&self, _writer: &mut dyn Write, _context: &mut Context) -> Result<()> {
         Ok(())
     }
 }
@@ -49,7 +49,7 @@ impl ParseBlock for CommentBlock {
         mut arguments: TagTokenIter,
         mut tokens: TagBlock,
         options: &Language,
-    ) -> Result<Box<Renderable>> {
+    ) -> Result<Box<dyn Renderable>> {
         // no arguments should be supplied, trying to supply them is an error
         arguments.expect_nothing()?;
 

--- a/src/tags/cycle_tag.rs
+++ b/src/tags/cycle_tag.rs
@@ -30,7 +30,7 @@ impl Cycle {
 }
 
 impl Renderable for Cycle {
-    fn render_to(&self, writer: &mut Write, context: &mut Context) -> Result<()> {
+    fn render_to(&self, writer: &mut dyn Write, context: &mut Context) -> Result<()> {
         let expr = context
             .get_register_mut::<State>()
             .cycle(&self.name, &self.values)
@@ -122,8 +122,8 @@ impl TagReflection for CycleTag {
 }
 
 impl ParseTag for CycleTag {
-    fn parse(&self, arguments: TagTokenIter, options: &Language) -> Result<Box<Renderable>> {
-        parse_cycle(arguments, options).map(|opt| Box::new(opt) as Box<Renderable>)
+    fn parse(&self, arguments: TagTokenIter, options: &Language) -> Result<Box<dyn Renderable>> {
+        parse_cycle(arguments, options).map(|opt| Box::new(opt) as Box<dyn Renderable>)
     }
 }
 

--- a/src/tags/for_block.rs
+++ b/src/tags/for_block.rs
@@ -151,7 +151,7 @@ fn int_argument(arg: &Expression, context: &Context, arg_name: &str) -> Result<i
 }
 
 impl Renderable for For {
-    fn render_to(&self, writer: &mut Write, context: &mut Context) -> Result<()> {
+    fn render_to(&self, writer: &mut dyn Write, context: &mut Context) -> Result<()> {
         let range = self
             .range
             .evaluate(context)
@@ -263,7 +263,7 @@ impl ParseBlock for ForBlock {
         mut arguments: TagTokenIter,
         mut tokens: TagBlock,
         options: &Language,
-    ) -> Result<Box<Renderable>> {
+    ) -> Result<Box<dyn Renderable>> {
         let var_name = arguments
             .expect_next("Identifier expected.")?
             .expect_identifier()
@@ -387,7 +387,7 @@ fn trace_tablerow_tag(
 }
 
 impl Renderable for TableRow {
-    fn render_to(&self, writer: &mut Write, context: &mut Context) -> Result<()> {
+    fn render_to(&self, writer: &mut dyn Write, context: &mut Context) -> Result<()> {
         let range = self
             .range
             .evaluate(context)
@@ -483,7 +483,7 @@ impl ParseBlock for TableRowBlock {
         mut arguments: TagTokenIter,
         mut tokens: TagBlock,
         options: &Language,
-    ) -> Result<Box<Renderable>> {
+    ) -> Result<Box<dyn Renderable>> {
         let var_name = arguments
             .expect_next("Identifier expected.")?
             .expect_identifier()

--- a/src/tags/if_block.rs
+++ b/src/tags/if_block.rs
@@ -189,7 +189,7 @@ impl Conditional {
 }
 
 impl Renderable for Conditional {
-    fn render_to(&self, writer: &mut Write, context: &mut Context) -> Result<()> {
+    fn render_to(&self, writer: &mut dyn Write, context: &mut Context) -> Result<()> {
         let condition = self.compare(context).trace_with(|| self.trace().into())?;
         if condition {
             self.if_true
@@ -328,7 +328,7 @@ impl ParseBlock for UnlessBlock {
         arguments: TagTokenIter,
         mut tokens: TagBlock,
         options: &Language,
-    ) -> Result<Box<Renderable>> {
+    ) -> Result<Box<dyn Renderable>> {
         let condition = parse_condition(arguments)?;
 
         let mut if_true = Vec::new();
@@ -366,7 +366,7 @@ fn parse_if(
     arguments: TagTokenIter,
     tokens: &mut TagBlock,
     options: &Language,
-) -> Result<Box<Renderable>> {
+) -> Result<Box<dyn Renderable>> {
     let condition = parse_condition(arguments)?;
 
     let mut if_true = Vec::new();
@@ -430,7 +430,7 @@ impl ParseBlock for IfBlock {
         arguments: TagTokenIter,
         mut tokens: TagBlock,
         options: &Language,
-    ) -> Result<Box<Renderable>> {
+    ) -> Result<Box<dyn Renderable>> {
         let conditional = parse_if(self.start_tag(), arguments, &mut tokens, options)?;
 
         tokens.assert_empty();

--- a/src/tags/ifchanged_block.rs
+++ b/src/tags/ifchanged_block.rs
@@ -23,7 +23,7 @@ impl IfChanged {
 }
 
 impl Renderable for IfChanged {
-    fn render_to(&self, writer: &mut Write, context: &mut Context) -> Result<()> {
+    fn render_to(&self, writer: &mut dyn Write, context: &mut Context) -> Result<()> {
         let mut rendered = Vec::new();
         self.if_changed
             .render_to(&mut rendered, context)
@@ -67,7 +67,7 @@ impl ParseBlock for IfChangedBlock {
         mut arguments: TagTokenIter,
         mut tokens: TagBlock,
         options: &Language,
-    ) -> Result<Box<Renderable>> {
+    ) -> Result<Box<dyn Renderable>> {
         // no arguments should be supplied, trying to supply them is an error
         arguments.expect_nothing()?;
 

--- a/src/tags/include_tag.rs
+++ b/src/tags/include_tag.rs
@@ -17,7 +17,7 @@ struct Include {
 }
 
 impl Renderable for Include {
-    fn render_to(&self, writer: &mut Write, context: &mut Context) -> Result<()> {
+    fn render_to(&self, writer: &mut dyn Write, context: &mut Context) -> Result<()> {
         let name = self.partial.evaluate(context)?.render().to_string();
         context.run_in_named_scope(name.clone(), |mut scope| -> Result<()> {
             let partial = scope
@@ -55,7 +55,7 @@ impl TagReflection for IncludeTag {
 }
 
 impl ParseTag for IncludeTag {
-    fn parse(&self, mut arguments: TagTokenIter, _options: &Language) -> Result<Box<Renderable>> {
+    fn parse(&self, mut arguments: TagTokenIter, _options: &Language) -> Result<Box<dyn Renderable>> {
         let name = arguments.expect_next("Identifier or literal expected.")?;
 
         // This may accept strange inputs such as `{% include 0 %}` or `{% include filterchain | filter:0 %}`.

--- a/src/tags/include_tag.rs
+++ b/src/tags/include_tag.rs
@@ -55,7 +55,11 @@ impl TagReflection for IncludeTag {
 }
 
 impl ParseTag for IncludeTag {
-    fn parse(&self, mut arguments: TagTokenIter, _options: &Language) -> Result<Box<dyn Renderable>> {
+    fn parse(
+        &self,
+        mut arguments: TagTokenIter,
+        _options: &Language,
+    ) -> Result<Box<dyn Renderable>> {
         let name = arguments.expect_next("Identifier or literal expected.")?;
 
         // This may accept strange inputs such as `{% include 0 %}` or `{% include filterchain | filter:0 %}`.

--- a/src/tags/increment_tags.rs
+++ b/src/tags/increment_tags.rs
@@ -16,7 +16,7 @@ struct Increment {
 }
 
 impl Renderable for Increment {
-    fn render_to(&self, writer: &mut Write, context: &mut Context) -> Result<()> {
+    fn render_to(&self, writer: &mut dyn Write, context: &mut Context) -> Result<()> {
         let mut val = context
             .stack()
             .get_index(&self.id)
@@ -53,7 +53,7 @@ impl TagReflection for IncrementTag {
 }
 
 impl ParseTag for IncrementTag {
-    fn parse(&self, mut arguments: TagTokenIter, _options: &Language) -> Result<Box<Renderable>> {
+    fn parse(&self, mut arguments: TagTokenIter, _options: &Language) -> Result<Box<dyn Renderable>> {
         let id = arguments
             .expect_next("Identifier expected.")?
             .expect_identifier()
@@ -73,7 +73,7 @@ struct Decrement {
 }
 
 impl Renderable for Decrement {
-    fn render_to(&self, writer: &mut Write, context: &mut Context) -> Result<()> {
+    fn render_to(&self, writer: &mut dyn Write, context: &mut Context) -> Result<()> {
         let mut val = context
             .stack()
             .get_index(&self.id)
@@ -110,7 +110,7 @@ impl TagReflection for DecrementTag {
 }
 
 impl ParseTag for DecrementTag {
-    fn parse(&self, mut arguments: TagTokenIter, _options: &Language) -> Result<Box<Renderable>> {
+    fn parse(&self, mut arguments: TagTokenIter, _options: &Language) -> Result<Box<dyn Renderable>> {
         let id = arguments
             .expect_next("Identifier expected.")?
             .expect_identifier()

--- a/src/tags/increment_tags.rs
+++ b/src/tags/increment_tags.rs
@@ -53,7 +53,11 @@ impl TagReflection for IncrementTag {
 }
 
 impl ParseTag for IncrementTag {
-    fn parse(&self, mut arguments: TagTokenIter, _options: &Language) -> Result<Box<dyn Renderable>> {
+    fn parse(
+        &self,
+        mut arguments: TagTokenIter,
+        _options: &Language,
+    ) -> Result<Box<dyn Renderable>> {
         let id = arguments
             .expect_next("Identifier expected.")?
             .expect_identifier()
@@ -110,7 +114,11 @@ impl TagReflection for DecrementTag {
 }
 
 impl ParseTag for DecrementTag {
-    fn parse(&self, mut arguments: TagTokenIter, _options: &Language) -> Result<Box<dyn Renderable>> {
+    fn parse(
+        &self,
+        mut arguments: TagTokenIter,
+        _options: &Language,
+    ) -> Result<Box<dyn Renderable>> {
         let id = arguments
             .expect_next("Identifier expected.")?
             .expect_identifier()

--- a/src/tags/interrupt_tags.rs
+++ b/src/tags/interrupt_tags.rs
@@ -39,7 +39,11 @@ impl TagReflection for BreakTag {
 }
 
 impl ParseTag for BreakTag {
-    fn parse(&self, mut arguments: TagTokenIter, _options: &Language) -> Result<Box<dyn Renderable>> {
+    fn parse(
+        &self,
+        mut arguments: TagTokenIter,
+        _options: &Language,
+    ) -> Result<Box<dyn Renderable>> {
         // no arguments should be supplied, trying to supply them is an error
         arguments.expect_nothing()?;
         Ok(Box::new(Break))
@@ -76,7 +80,11 @@ impl TagReflection for ContinueTag {
 }
 
 impl ParseTag for ContinueTag {
-    fn parse(&self, mut arguments: TagTokenIter, _options: &Language) -> Result<Box<dyn Renderable>> {
+    fn parse(
+        &self,
+        mut arguments: TagTokenIter,
+        _options: &Language,
+    ) -> Result<Box<dyn Renderable>> {
         // no arguments should be supplied, trying to supply them is an error
         arguments.expect_nothing()?;
         Ok(Box::new(Continue))

--- a/src/tags/interrupt_tags.rs
+++ b/src/tags/interrupt_tags.rs
@@ -13,7 +13,7 @@ use interpreter::{Context, Interrupt};
 struct Break;
 
 impl Renderable for Break {
-    fn render_to(&self, _writer: &mut Write, context: &mut Context) -> Result<()> {
+    fn render_to(&self, _writer: &mut dyn Write, context: &mut Context) -> Result<()> {
         context.interrupt_mut().set_interrupt(Interrupt::Break);
         Ok(())
     }
@@ -39,7 +39,7 @@ impl TagReflection for BreakTag {
 }
 
 impl ParseTag for BreakTag {
-    fn parse(&self, mut arguments: TagTokenIter, _options: &Language) -> Result<Box<Renderable>> {
+    fn parse(&self, mut arguments: TagTokenIter, _options: &Language) -> Result<Box<dyn Renderable>> {
         // no arguments should be supplied, trying to supply them is an error
         arguments.expect_nothing()?;
         Ok(Box::new(Break))
@@ -50,7 +50,7 @@ impl ParseTag for BreakTag {
 struct Continue;
 
 impl Renderable for Continue {
-    fn render_to(&self, _writer: &mut Write, context: &mut Context) -> Result<()> {
+    fn render_to(&self, _writer: &mut dyn Write, context: &mut Context) -> Result<()> {
         context.interrupt_mut().set_interrupt(Interrupt::Continue);
         Ok(())
     }
@@ -76,7 +76,7 @@ impl TagReflection for ContinueTag {
 }
 
 impl ParseTag for ContinueTag {
-    fn parse(&self, mut arguments: TagTokenIter, _options: &Language) -> Result<Box<Renderable>> {
+    fn parse(&self, mut arguments: TagTokenIter, _options: &Language) -> Result<Box<dyn Renderable>> {
         // no arguments should be supplied, trying to supply them is an error
         arguments.expect_nothing()?;
         Ok(Box::new(Continue))

--- a/src/tags/raw_block.rs
+++ b/src/tags/raw_block.rs
@@ -16,7 +16,7 @@ struct RawT {
 }
 
 impl Renderable for RawT {
-    fn render_to(&self, writer: &mut Write, _context: &mut Context) -> Result<()> {
+    fn render_to(&self, writer: &mut dyn Write, _context: &mut Context) -> Result<()> {
         write!(writer, "{}", self.content).replace("Failed to render")?;
         Ok(())
     }
@@ -51,7 +51,7 @@ impl ParseBlock for RawBlock {
         mut arguments: TagTokenIter,
         mut tokens: TagBlock,
         _options: &Language,
-    ) -> Result<Box<Renderable>> {
+    ) -> Result<Box<dyn Renderable>> {
         // no arguments should be supplied, trying to supply them is an error
         arguments.expect_nothing()?;
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -8,12 +8,12 @@ use liquid_interpreter::Renderable;
 
 pub struct Template {
     pub(crate) template: interpreter::Template,
-    pub(crate) partials: Option<sync::Arc<PartialStore + Send + Sync>>,
+    pub(crate) partials: Option<sync::Arc<dyn PartialStore + Send + Sync>>,
 }
 
 impl Template {
     /// Renders an instance of the Template, using the given globals.
-    pub fn render(&self, globals: &interpreter::ValueStore) -> Result<String> {
+    pub fn render(&self, globals: &dyn interpreter::ValueStore) -> Result<String> {
         const BEST_GUESS: usize = 10_000;
         let mut data = Vec::with_capacity(BEST_GUESS);
         self.render_to(&mut data, globals)?;
@@ -22,7 +22,7 @@ impl Template {
     }
 
     /// Renders an instance of the Template, using the given globals.
-    pub fn render_to(&self, writer: &mut Write, globals: &interpreter::ValueStore) -> Result<()> {
+    pub fn render_to(&self, writer: &mut dyn Write, globals: &dyn interpreter::ValueStore) -> Result<()> {
         let context = interpreter::ContextBuilder::new().set_globals(globals);
         let context = match self.partials {
             Some(ref partials) => context.set_partials(partials.as_ref()),

--- a/src/template.rs
+++ b/src/template.rs
@@ -22,7 +22,11 @@ impl Template {
     }
 
     /// Renders an instance of the Template, using the given globals.
-    pub fn render_to(&self, writer: &mut dyn Write, globals: &dyn interpreter::ValueStore) -> Result<()> {
+    pub fn render_to(
+        &self,
+        writer: &mut dyn Write,
+        globals: &dyn interpreter::ValueStore,
+    ) -> Result<()> {
         let context = interpreter::ContextBuilder::new().set_globals(globals);
         let context = match self.partials {
             Some(ref partials) => context.set_partials(partials.as_ref()),

--- a/tests/derive_macros_test_filters/stateful.rs
+++ b/tests/derive_macros_test_filters/stateful.rs
@@ -46,7 +46,7 @@ impl TestStatefulFilterParser {
 }
 
 impl ParseFilter for TestStatefulFilterParser {
-    fn parse(&self, arguments: FilterArguments) -> Result<Box<Filter>> {
+    fn parse(&self, arguments: FilterArguments) -> Result<Box<dyn Filter>> {
         let args = TestStatefulFilterParameters::from_args(arguments)?;
         let state = self.state;
 


### PR DESCRIPTION
- Remove use of deprecated functions
- Use `dyn` for traits as type arguments (inside Box or Arc).