### PR TITLE
Feature/standard filter conformance

### DIFF
--- a/src/filters/std/array.rs
+++ b/src/filters/std/array.rs
@@ -373,7 +373,7 @@ impl Filter for FirstFilter {
                     .unwrap_or_else(|| "".to_owned());
                 Ok(Value::scalar(c))
             }
-            Value::Array(ref x) => Ok(x.first().cloned().unwrap_or_else(|| Value::scalar(""))),
+            Value::Array(ref x) => Ok(x.first().cloned().unwrap_or_else(|| Value::Nil)),
             _ => Err(invalid_input("String or Array expected")),
         }
     }
@@ -403,7 +403,7 @@ impl Filter for LastFilter {
                     .unwrap_or_else(|| "".to_owned());
                 Ok(Value::scalar(c))
             }
-            Value::Array(ref x) => Ok(x.last().cloned().unwrap_or_else(|| Value::scalar(""))),
+            Value::Array(ref x) => Ok(x.last().cloned().unwrap_or_else(|| Value::Nil)),
             _ => Err(invalid_input("String or Array expected")),
         }
     }
@@ -540,7 +540,7 @@ mod tests {
             unit!(First, Value::Array(vec![tos!("test"), tos!("two")])),
             tos!("test")
         );
-        assert_eq!(unit!(First, Value::Array(vec![])), tos!(""));
+        assert_eq!(unit!(First, Value::Array(vec![])), Value::Nil);
     }
 
     #[test]
@@ -606,7 +606,7 @@ mod tests {
             unit!(Last, Value::Array(vec![tos!("test"), tos!("last")])),
             tos!("last")
         );
-        assert_eq!(unit!(Last, Value::Array(vec![])), tos!(""));
+        assert_eq!(unit!(Last, Value::Array(vec![])), Value::Nil);
     }
 
     #[test]

--- a/tests/conformance_ruby/filter_test.rs
+++ b/tests/conformance_ruby/filter_test.rs
@@ -135,7 +135,6 @@ fn test_sort() {
 }
 
 #[test]
-#[should_panic] // liquid-rust#249
 fn test_sort_natural() {
     let assigns = v!({
         "words": ["case", "Assert", "Insensitive"],

--- a/tests/conformance_ruby/filter_test.rs
+++ b/tests/conformance_ruby/filter_test.rs
@@ -162,7 +162,7 @@ fn test_sort_natural() {
 fn test_compact() {
     let assigns = v!({
         "words": ["a", nil, "b", nil, "c"],
-        "hashes": [{ "a": "A" }, { "a": nil }, { "a": "C" }, {}],
+        "hashes": [{ "a": "A" }, { "a": nil }, { "a": "C" }],
     });
 
     // Test strings

--- a/tests/conformance_ruby/filter_test.rs
+++ b/tests/conformance_ruby/filter_test.rs
@@ -113,7 +113,6 @@ fn test_join() {
 }
 
 #[test]
-#[should_panic] // liquid-rust#250
 fn test_sort() {
     let assigns = v!({
         "value": 3,

--- a/tests/conformance_ruby/filter_test.rs
+++ b/tests/conformance_ruby/filter_test.rs
@@ -160,11 +160,10 @@ fn test_sort_natural() {
 }
 
 #[test]
-#[should_panic] // liquid-rust#246
 fn test_compact() {
     let assigns = v!({
         "words": ["a", nil, "b", nil, "c"],
-        "hashes": [{ "a": "A" }, { "a": nil }, { "a": "C" }],
+        "hashes": [{ "a": "A" }, { "a": nil }, { "a": "C" }, {}],
     });
 
     // Test strings

--- a/tests/conformance_ruby/standard_filter_test.rs
+++ b/tests/conformance_ruby/standard_filter_test.rs
@@ -224,9 +224,10 @@ fn test_sort() {
 }
 
 #[test]
-#[should_panic] // liquid-rust#262
 fn test_sort_with_nils() {
     assert_eq!(v!([1, 2, 3, 4, nil]), filters!(Sort, v!([nil, 4, 3, 2, 1])));
+    /*
+    // liquid-rust#333
     assert_eq!(
         v!([{ "a": 1 }, { "a": 2 }, { "a": 3 }, { "a": 4 }, {}]),
         filters!(
@@ -234,7 +235,7 @@ fn test_sort_with_nils() {
             v!([{ "a": 4 }, { "a": 3 }, {}, { "a": 1 }, { "a": 2 }]),
             v!("a")
         )
-    );
+    );*/
 }
 
 #[test]
@@ -275,12 +276,13 @@ fn test_sort_natural() {
 }
 
 #[test]
-#[should_panic] // liquid-rust#262
 fn test_sort_natural_with_nils() {
     assert_eq!(
         v!(["a", "B", "c", "D", nil]),
         filters!(SortNatural, v!([nil, "c", "D", "a", "B"]))
     );
+    /*
+    // liquid-rust#334
     assert_eq!(
         v!([{ "a": "a" }, { "a": "B" }, { "a": "c" }, { "a": "D" }, {}]),
         filters!(
@@ -289,6 +291,7 @@ fn test_sort_natural_with_nils() {
             v!("a")
         )
     );
+    */
 }
 
 #[test]

--- a/tests/conformance_ruby/standard_filter_test.rs
+++ b/tests/conformance_ruby/standard_filter_test.rs
@@ -365,7 +365,6 @@ fn test_sort_natural_empty_array() {
 }
 
 #[test]
-#[should_panic] // liquid-rust#257
 fn test_legacy_sort_hash() {
     assert_eq!(
         v!([{ "a": 1, "b": 2 }]),

--- a/tests/conformance_ruby/standard_filter_test.rs
+++ b/tests/conformance_ruby/standard_filter_test.rs
@@ -210,7 +210,6 @@ fn test_join() {
 }
 
 #[test]
-#[should_panic] // liquid-rust#257
 fn test_sort() {
     assert_eq!(v!([1, 2, 3, 4]), filters!(Sort, v!([4, 3, 2, 1])));
     assert_eq!(
@@ -226,8 +225,6 @@ fn test_sort() {
 #[test]
 fn test_sort_with_nils() {
     assert_eq!(v!([1, 2, 3, 4, nil]), filters!(Sort, v!([nil, 4, 3, 2, 1])));
-    /*
-    // liquid-rust#333
     assert_eq!(
         v!([{ "a": 1 }, { "a": 2 }, { "a": 3 }, { "a": 4 }, {}]),
         filters!(
@@ -235,11 +232,10 @@ fn test_sort_with_nils() {
             v!([{ "a": 4 }, { "a": 3 }, {}, { "a": 1 }, { "a": 2 }]),
             v!("a")
         )
-    );*/
+    );
 }
 
 #[test]
-#[should_panic] // liquid-rust#257
 fn test_sort_when_property_is_sometimes_missing_puts_nils_last() {
     let input = v!([
       { "price": 4, "handle": "alpha" },
@@ -248,18 +244,28 @@ fn test_sort_when_property_is_sometimes_missing_puts_nils_last() {
       { "handle": "delta" },
       { "price": 2, "handle": "epsilon" }
     ]);
-    let expectation = v!([
-      { "price": 1, "handle": "gamma" },
-      { "price": 2, "handle": "epsilon" },
-      { "price": 4, "handle": "alpha" },
-      { "handle": "delta" },
-      { "handle": "beta" }
-    ]);
-    assert_eq!(expectation, filters!(Sort, input, v!("price")));
+    let expectation_start = vec![
+        v!({ "price": 1, "handle": "gamma" }),
+        v!({ "price": 2, "handle": "epsilon" }),
+        v!({ "price": 4, "handle": "alpha" }),
+    ];
+    // Those two results are viable, since both values "map" to nil.
+    // Since the sorting is unstable, the order between the results is undefined.
+    // The original test (Ruby implementation) tests for only one of the results,
+    // which, I think, was the one produced by their specific implementation.
+    let expectation_end = (
+        vec![v!({ "handle": "delta" }), v!({ "handle": "beta" })],
+        vec![v!({ "handle": "beta" }), v!({ "handle": "delta" })],
+    );
+    let result = filters!(Sort, input, v!("price"));
+    let result = result.into_array();
+    assert!(result.is_some());
+    let result = result.unwrap();
+    assert_eq!(expectation_start, &result[..3]);
+    assert!(expectation_end.0 == &result[3..] || expectation_end.1 == &result[3..]);
 }
 
 #[test]
-#[should_panic] // liquid-rust#257
 fn test_sort_natural() {
     assert_eq!(
         v!(["a", "B", "c", "D"]),
@@ -281,8 +287,6 @@ fn test_sort_natural_with_nils() {
         v!(["a", "B", "c", "D", nil]),
         filters!(SortNatural, v!([nil, "c", "D", "a", "B"]))
     );
-    /*
-    // liquid-rust#334
     assert_eq!(
         v!([{ "a": "a" }, { "a": "B" }, { "a": "c" }, { "a": "D" }, {}]),
         filters!(
@@ -291,11 +295,9 @@ fn test_sort_natural_with_nils() {
             v!("a")
         )
     );
-    */
 }
 
 #[test]
-#[should_panic] // liquid-rust#257
 fn test_sort_natural_when_property_is_sometimes_missing_puts_nils_last() {
     let input = v!([
       { "price": "4", "handle": "alpha" },
@@ -304,18 +306,28 @@ fn test_sort_natural_when_property_is_sometimes_missing_puts_nils_last() {
       { "handle": "delta" },
       { "price": 2, "handle": "epsilon" }
     ]);
-    let expectation = v!([
-      { "price": "1", "handle": "gamma" },
-      { "price": 2, "handle": "epsilon" },
-      { "price": "4", "handle": "alpha" },
-      { "handle": "delta" },
-      { "handle": "beta" }
-    ]);
-    assert_eq!(expectation, filters!(SortNatural, input, v!("price")));
+    let expectation_start = vec![
+        v!({ "price": "1", "handle": "gamma" }),
+        v!({ "price": 2, "handle": "epsilon" }),
+        v!({ "price": "4", "handle": "alpha" }),
+    ];
+    // Those two results are viable, since both values "map" to nil.
+    // Since the sorting is unstable, the order between the results is undefined.
+    // The original test (Ruby implementation) tests for only one of the results,
+    // which, I think, was the one produced by their specific implementation.
+    let expectation_end = (
+        vec![v!({ "handle": "delta" }), v!({ "handle": "beta" })],
+        vec![v!({ "handle": "beta" }), v!({ "handle": "delta" })],
+    );
+    let result = filters!(SortNatural, input, v!("price"));
+    let result = result.into_array();
+    assert!(result.is_some());
+    let result = result.unwrap();
+    assert_eq!(expectation_start, &result[..3]);
+    assert!(expectation_end.0 == &result[3..] || expectation_end.1 == &result[3..]);
 }
 
 #[test]
-#[should_panic] // liquid-rust#257
 fn test_sort_natural_case_check() {
     let input = v!([
       { "key": "X" },
@@ -343,13 +355,11 @@ fn test_sort_natural_case_check() {
 }
 
 #[test]
-#[should_panic] // liquid-rust#257
 fn test_sort_empty_array() {
     assert_eq!(v!([]), filters!(Sort, v!([]), v!("a")));
 }
 
 #[test]
-#[should_panic] // liquid-rust#257
 fn test_sort_natural_empty_array() {
     assert_eq!(v!([]), filters!(SortNatural, v!([]), v!("a")));
 }
@@ -364,7 +374,6 @@ fn test_legacy_sort_hash() {
 }
 
 #[test]
-#[should_panic] // liquid-rust#257
 fn test_numerical_vs_lexicographical_sort() {
     assert_eq!(v!([2, 10]), filters!(Sort, v!([10, 2])));
     assert_eq!(

--- a/tests/conformance_ruby/standard_filter_test.rs
+++ b/tests/conformance_ruby/standard_filter_test.rs
@@ -413,9 +413,15 @@ fn test_uniq_empty_array() {
 }
 
 #[test]
-#[should_panic] // liquid-rust#335
 fn test_compact_empty_array() {
     assert_eq!(v!([]), filters!(Compact, v!([]), v!("a")));
+}
+
+#[test]
+fn test_compact_invalid_property() {
+    let input = v!([[1], [2], [3]]);
+
+    filters_fail!(Compact, input, v!("bar"));
 }
 
 #[test]

--- a/tests/conformance_ruby/standard_filter_test.rs
+++ b/tests/conformance_ruby/standard_filter_test.rs
@@ -593,7 +593,6 @@ fn test_date() {
 }
 
 #[test]
-#[should_panic] // liquid-rust#254
 fn test_first_last() {
     assert_eq!(v!(1), filters!(First, v!([1, 2, 3])));
     assert_eq!(v!(3), filters!(Last, v!([1, 2, 3])));

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -675,3 +675,23 @@ text: foo
     let output = template.render(&globals).unwrap();
     assert_eq!(output, "foo".to_string());
 }
+
+#[test]
+fn test_compact() {
+    let text = "{{hashes | compact: 'a' | map: 'a' | join}}";
+    let globals: liquid::value::Object = serde_yaml::from_str(
+        r#"
+words: ["a", null, "b", null, "c"]
+hashes: [{"a": "A"}, {"a": null}, {"a": "C"}, {}]
+"#,
+    )
+    .unwrap();
+
+    let template = liquid::ParserBuilder::with_liquid()
+        .build()
+        .unwrap()
+        .parse(text)
+        .unwrap();
+    let output = template.render(&globals).unwrap();
+    assert_eq!(output, "A C".to_string());
+}


### PR DESCRIPTION
- [ ] Tests created for any new feature or regression tests for bugfixes.

* This PR should fix issues #262, #333, #334, #335, #257, #250.
* It also partially fixes issue #246. 
* The macro introduced here (`as_sequence`) should help fixing #246, #255, #256, #266 (and maybe others). It helps writing filters that take a value and "coerce" it into an array the same way Ruby's [InputIterator](https://github.com/Shopify/liquid/blob/98dfe198e168eef580345842ff49c4f2549e238b/lib/liquid/standardfilters.rb#L457) does.

I know this is a heavy PR, but the issues fixed here are very closely related.
