### PR TITLE
Bugfix/url filters

### DIFF
--- a/src/filters/std/url.rs
+++ b/src/filters/std/url.rs
@@ -46,6 +46,10 @@ struct UrlEncodeFilter;
 
 impl Filter for UrlEncodeFilter {
     fn evaluate(&self, input: &Value, _context: &Context) -> Result<Value> {
+        if input.is_nil() {
+            return Ok(Value::Nil);
+        }
+
         lazy_static! {
             static ref URL_ENCODE_SET: UrlEncodeSet = UrlEncodeSet("".to_owned());
         }
@@ -72,7 +76,11 @@ struct UrlDecodeFilter;
 
 impl Filter for UrlDecodeFilter {
     fn evaluate(&self, input: &Value, _context: &Context) -> Result<Value> {
-        let s = input.to_str();
+        if input.is_nil() {
+            return Ok(Value::Nil);
+        }
+
+        let s = input.to_str().replace("+", " ");
 
         let result = percent_encoding::percent_decode(s.as_bytes())
             .decode_utf8()


### PR DESCRIPTION
- [ ] Tests created for any new feature or regression tests for bugfixes.

This PR fixes #268.
It also attempts to fix #253, but I'm not sure if this is the correct fix. The behavior of the `url_{encode,decode}` filters relies on Ruby objects having a `.to_s` method.
If we want to fully emulate this for Date objects in rust, we must make `Date` a first class citizen in the `Value` enum. This would require us to rename the current `Date` object to `DateTime`, which I imagine will break all sorts of backwards compatibility.

What do you think we should do?