### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/liquid-value/src/values.rs
+++ b/liquid-value/src/values.rs
@@ -540,7 +540,7 @@ mod test {
             ("alpha".into(), Value::scalar("1")),
             ("beta".into(), Value::scalar(2f64)),
         ]
-        .into_iter()
+        .iter()
         .cloned()
         .collect();
         let a = Value::Object(a);
@@ -550,7 +550,7 @@ mod test {
             ("beta".into(), Value::scalar(2f64)),
             ("gamma".into(), Value::Array(vec![])),
         ]
-        .into_iter()
+        .iter()
         .cloned()
         .collect();
         let b = Value::Object(b);


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.