### PR TITLE
Misc kstring improvements

### DIFF
--- a/crates/kstring/src/cow.rs
+++ b/crates/kstring/src/cow.rs
@@ -8,7 +8,7 @@ type StdString = std::string::String;
 type BoxedStr = Box<str>;
 
 /// A reference to a UTF-8 encoded, immutable string.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 #[repr(transparent)]
 pub struct KStringCow<'s> {
     pub(crate) inner: KStringCowInner<'s>,
@@ -179,6 +179,13 @@ impl<'s> std::hash::Hash for KStringCow<'s> {
     #[inline]
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.as_str().hash(state);
+    }
+}
+
+impl<'s> fmt::Debug for KStringCow<'s> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.inner, f)
     }
 }
 

--- a/crates/kstring/src/cow.rs
+++ b/crates/kstring/src/cow.rs
@@ -239,6 +239,14 @@ impl From<KString> for KStringCow<'static> {
     }
 }
 
+impl<'s> From<&'s KString> for KStringCow<'s> {
+    #[inline]
+    fn from(other: &'s KString) -> Self {
+        let other = other.as_ref();
+        other.into()
+    }
+}
+
 impl<'s> From<KStringRef<'s>> for KStringCow<'s> {
     #[inline]
     fn from(other: KStringRef<'s>) -> Self {

--- a/crates/kstring/src/cow.rs
+++ b/crates/kstring/src/cow.rs
@@ -14,7 +14,7 @@ pub struct KStringCow<'s> {
     pub(crate) inner: KStringCowInner<'s>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug)]
 pub(crate) enum KStringCowInner<'s> {
     Owned(KString),
     Borrowed(&'s str),

--- a/crates/kstring/src/cow.rs
+++ b/crates/kstring/src/cow.rs
@@ -326,13 +326,7 @@ impl<'de, 's> serde::Deserialize<'de> for KStringCow<'s> {
     where
         D: serde::Deserializer<'de>,
     {
-        use std::borrow::Cow;
-        let s: Cow<'_, str> = Cow::deserialize(deserializer)?;
-        let s = match s {
-            Cow::Owned(s) => KStringCow::from_boxed(s.into_boxed_str()),
-            Cow::Borrowed(s) => KStringCow::from_ref(s),
-        };
-        Ok(s)
+        KString::deserialize(deserializer).map(|s| s.into())
     }
 }
 

--- a/crates/kstring/src/fixed.rs
+++ b/crates/kstring/src/fixed.rs
@@ -16,7 +16,7 @@ macro_rules! fixed_string {
             }
 
             #[inline]
-            pub(crate) fn into_boxed_str(&self) -> Box<str> {
+            pub(crate) fn to_boxed_str(&self) -> Box<str> {
                 Box::from(self.as_str())
             }
 

--- a/crates/kstring/src/fixed.rs
+++ b/crates/kstring/src/fixed.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 macro_rules! fixed_string {
     ($name:ident, $len:literal) => {
-        #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[derive(Clone)]
         pub(crate) struct $name {
             array: [u8; $len],
         }

--- a/crates/kstring/src/fixed.rs
+++ b/crates/kstring/src/fixed.rs
@@ -1,6 +1,8 @@
+use std::fmt;
+
 macro_rules! fixed_string {
     ($name:ident, $len:literal) => {
-        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
         pub(crate) struct $name {
             array: [u8; $len],
         }
@@ -21,6 +23,13 @@ macro_rules! fixed_string {
             #[inline]
             pub(crate) fn as_str(&self) -> &str {
                 unsafe { std::str::from_utf8_unchecked(&self.array) }
+            }
+        }
+
+        impl fmt::Debug for $name {
+            #[inline]
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt::Debug::fmt(self.as_str(), f)
             }
         }
     };

--- a/crates/kstring/src/ref.rs
+++ b/crates/kstring/src/ref.rs
@@ -7,7 +7,7 @@ type StdString = std::string::String;
 type BoxedStr = Box<str>;
 
 /// A reference to a UTF-8 encoded, immutable string.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone)]
 #[repr(transparent)]
 pub struct KStringRef<'s> {
     pub(crate) inner: KStringRefInner<'s>,
@@ -141,6 +141,13 @@ impl<'s> std::hash::Hash for KStringRef<'s> {
     #[inline]
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.as_str().hash(state);
+    }
+}
+
+impl<'s> fmt::Debug for KStringRef<'s> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.inner, f)
     }
 }
 

--- a/crates/kstring/src/ref.rs
+++ b/crates/kstring/src/ref.rs
@@ -13,7 +13,7 @@ pub struct KStringRef<'s> {
     pub(crate) inner: KStringRefInner<'s>,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, Debug)]
 pub(crate) enum KStringRefInner<'s> {
     Borrowed(&'s str),
     Singleton(&'static str),

--- a/crates/kstring/src/string.rs
+++ b/crates/kstring/src/string.rs
@@ -15,7 +15,7 @@ type StdString = std::string::String;
 type BoxedStr = Box<str>;
 
 /// A UTF-8 encoded, immutable string.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 #[repr(transparent)]
 pub struct KString {
     pub(crate) inner: KStringInner,
@@ -214,6 +214,13 @@ impl std::hash::Hash for KString {
     #[inline]
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.as_str().hash(state);
+    }
+}
+
+impl fmt::Debug for KString {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.inner, f)
     }
 }
 

--- a/crates/kstring/src/string.rs
+++ b/crates/kstring/src/string.rs
@@ -145,14 +145,14 @@ impl KStringInner {
         match self {
             Self::Owned(s) => s,
             Self::Singleton(s) => BoxedStr::from(s),
-            Self::Fixed1(s) => s.into_boxed_str(),
-            Self::Fixed2(s) => s.into_boxed_str(),
-            Self::Fixed3(s) => s.into_boxed_str(),
-            Self::Fixed4(s) => s.into_boxed_str(),
-            Self::Fixed5(s) => s.into_boxed_str(),
-            Self::Fixed6(s) => s.into_boxed_str(),
-            Self::Fixed7(s) => s.into_boxed_str(),
-            Self::Fixed8(s) => s.into_boxed_str(),
+            Self::Fixed1(s) => s.to_boxed_str(),
+            Self::Fixed2(s) => s.to_boxed_str(),
+            Self::Fixed3(s) => s.to_boxed_str(),
+            Self::Fixed4(s) => s.to_boxed_str(),
+            Self::Fixed5(s) => s.to_boxed_str(),
+            Self::Fixed6(s) => s.to_boxed_str(),
+            Self::Fixed7(s) => s.to_boxed_str(),
+            Self::Fixed8(s) => s.to_boxed_str(),
         }
     }
 }

--- a/crates/kstring/src/string.rs
+++ b/crates/kstring/src/string.rs
@@ -21,7 +21,7 @@ pub struct KString {
     pub(crate) inner: KStringInner,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug)]
 pub(crate) enum KStringInner {
     Owned(BoxedStr),
     Singleton(&'static str),

--- a/crates/kstring/src/string.rs
+++ b/crates/kstring/src/string.rs
@@ -346,13 +346,57 @@ impl<'de> serde::Deserialize<'de> for KString {
     where
         D: serde::Deserializer<'de>,
     {
-        use std::borrow::Cow;
-        let s: Cow<'_, str> = Cow::deserialize(deserializer)?;
-        let s = match s {
-            Cow::Owned(s) => KString::from_boxed(s.into_boxed_str()),
-            Cow::Borrowed(s) => KString::from_ref(s),
-        };
-        Ok(s)
+        deserializer.deserialize_string(StringVisitor)
+    }
+}
+
+struct StringVisitor;
+
+impl<'de> serde::de::Visitor<'de> for StringVisitor {
+    type Value = KString;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a string")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(KString::from_ref(v))
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(KString::from_string(v))
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        match std::str::from_utf8(v) {
+            Ok(s) => Ok(KString::from_ref(s)),
+            Err(_) => Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Bytes(v),
+                &self,
+            )),
+        }
+    }
+
+    fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        match String::from_utf8(v) {
+            Ok(s) => Ok(KString::from_string(s)),
+            Err(e) => Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Bytes(&e.into_bytes()),
+                &self,
+            )),
+        }
     }
 }
 


### PR DESCRIPTION
The main ones
- Shortened the debug reprs.  We don't make it the same as a `str` because we want enough info to know what optimizations are being applied
- Add a `From` that I found useful
- Ensure fixed strings are used with serde