### PR TITLE
Allow borrowing string slices from ValueView (via KStringCow)

### DIFF
--- a/crates/core/src/model/scalar/mod.rs
+++ b/crates/core/src/model/scalar/mod.rs
@@ -93,6 +93,14 @@ impl<'s> ScalarCow<'s> {
         }
     }
 
+    /// Interpret as a string, if possible
+    pub fn to_string(self) -> Option<KStringCow<'s>> {
+        match self.0 {
+            ScalarCowEnum::Str(x) => Some(x),
+            _ => None,
+        }
+    }
+
     /// Interpret as an integer, if possible
     pub fn to_integer(&self) -> Option<i32> {
         match self.0 {

--- a/crates/kstring/src/cow.rs
+++ b/crates/kstring/src/cow.rs
@@ -75,6 +75,12 @@ impl<'s> KStringCow<'s> {
         self.inner.as_str()
     }
 
+    /// Returns a string slice, only if this is borrowed
+    #[inline]
+    pub fn as_borrowed(&self) -> Option<&'s str> {
+        self.inner.as_borrowed()
+    }
+
     /// Convert to a mutable string type, cloning the data if necessary.
     #[inline]
     pub fn into_string(self) -> StdString {
@@ -118,6 +124,14 @@ impl<'s> KStringCowInner<'s> {
         match self {
             Self::Owned(s) => s.into_boxed_str(),
             Self::Borrowed(s) => BoxedStr::from(s),
+        }
+    }
+
+    #[inline]
+    fn as_borrowed(&self) -> Option<&'s str> {
+        match self {
+            KStringCowInner::Owned(_) => None,
+            KStringCowInner::Borrowed(s) => Some(s),
         }
     }
 }


### PR DESCRIPTION
- [ ] Tests created for any new feature or regression tests for bugfixes.

(No tests added, I'm not sure what tests would be relevant there)

-- 

Okay so, apologies for this PR, hopefully it's small enough that this isn't a headache for you.

Here's my use case:

  * I use liquid with custom filters
  * Those take objects as "input" (not arguments)
  * I want to "deserialize" a liquid *Value* into some argument struct, by using serde and a custom Deserializer

It looks something like that:

```rust
#[derive(Deserialize, Debug)]
struct FilterInput<'a> {
    #[serde(borrow)]
    path: Cow<'a, str>,
    #[serde(borrow)]
    hash: Cow<'a, str>,
}

impl Filter for PageMarkupFilter {
    fn evaluate(
        &self,
        input: &dyn ValueView,
        _runtime: &liquid_core::Runtime,
    ) -> liquid_core::Result<liquid_core::Value> {
        // TODO: jane_eyre::Result is wrong here, color escapes in
        // the 500 page don't work
        convert_errors(|| {
            let args: FilterInput = from_value(input)?;
            println!("args = {:#?}", args);
            println!(
                "args.path is borrowed ? {}",
                matches!(args.path, Cow::Borrowed(_))
            );
            println!(
                "args.hash is borrowed ? {}",
                matches!(args.hash, Cow::Borrowed(_))
            );
```

Now, with the existing API, since `input` is a `ValueView`, I don't think there's a way to borrow from it.

`as_scalar` will take us as far as `ScalarCow` (with the correct lifetime), but then I hit a brick wall: `to_integer`, `to_float` etc. are all blissfully lifetime-free, but `into_string` consumes `self` and *always* returns an owned `KString`.

Instead, I would like to be able to get a `KStringCow` that borrows from whichever `Value` is beneath our `&dyn ValueView` - that's the **first method added**, `ScalarCow::to_string` - it returns `None` if the scalar is not actually a string. Pretty simple stuff.

The second method is in `kstring`. I'm not sure why `KStringCow` hides its implementation details with `KStringCowInner` but the result is that one may not match to find out if it's `::Borrowed` or `::Owned` (like they could with an `std::borrow::Cow`). The only way to get a `&str` out of a `KStringCow<'s>` is to use `as_str`, which returns an `&str` with a lifetime that's too short - instead of returning `&'s str`, it returns a `&str` with the same lifetime as the `&self`.

Which makes sense for the general case - if the `KStringCow` is `::Owned`, then obviously the returned `&str` can't outlive the `KStringCow` itself. But if it's borrowed, then the returned `&str` could definitely live as long as whatever the `KStringCow` borrows from.

That's the **second method added**: `KStringCow::as_borrowed` - again, returns an `Option<&str>`, simply gives `None` if it was owned.

With the power of those two methods added, I can successfully achieve the following terrible early-optimization code crime:

```rust
pub struct ValueDeserializer<'de> {
    input: &'de (dyn ValueView + 'de),
}

impl<'de, 'a> de::Deserializer<'de> for &'a mut ValueDeserializer<'de> {
    type Error = Error;

    // (cut, like, a hundred methods)

    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
    where
        V: serde::de::Visitor<'de>,
    {
        let scalar_cow: ScalarCow<'de> = self
            .input
            .as_scalar()
            .ok_or_else(|| Error::ExpectedScalar)?;
        let kstring_cow: KStringCow<'de> = scalar_cow
            .to_string()
            .ok_or_else(|| Error::ExpectedString)?;
        match kstring_cow.as_borrowed() {
            Some(s) => visitor.visit_borrowed_str(s),
            None => visitor.visit_str(kstring_cow.as_str()),
        }
    }
}
```

...and my argument structs, like this one:

```rust
#[derive(Deserialize, Debug)]
struct FilterInput<'a> {
    #[serde(borrow)]
    path: Cow<'a, str>,
    #[serde(borrow)]
    hash: Cow<'a, str>,
}
```

are *actually* borrowed from the underlying `Value` passed to `evaluate` as a `&dyn ValueView`.

One less copy, yay!

Hopefully this makes sense to you and isn't too much trouble. If not, that's okay too! Also, it's Sunday lol, sorry, I wish GitHub let me schedule pull requests for later.