### PR TITLE
fix(value)!: Use i64 rather than i32

### DIFF
--- a/crates/core/src/model/array/mod.rs
+++ b/crates/core/src/model/array/mod.rs
@@ -15,15 +15,15 @@ pub trait ArrayView: ValueView {
     fn as_value(&self) -> &dyn ValueView;
 
     /// Returns the number of elements.
-    fn size(&self) -> i32;
+    fn size(&self) -> i64;
 
     /// Returns an iterator .
     fn values<'k>(&'k self) -> Box<dyn Iterator<Item = &'k dyn ValueView> + 'k>;
 
     /// Access a contained `Value`.
-    fn contains_key(&self, index: i32) -> bool;
+    fn contains_key(&self, index: i64) -> bool;
     /// Access a contained `Value`.
-    fn get(&self, index: i32) -> Option<&dyn ValueView>;
+    fn get(&self, index: i64) -> Option<&dyn ValueView>;
     /// Returns the first element.
     fn first(&self) -> Option<&dyn ValueView> {
         self.get(0)
@@ -77,8 +77,8 @@ impl<T: ValueView> ArrayView for Vec<T> {
         self
     }
 
-    fn size(&self) -> i32 {
-        self.len() as i32
+    fn size(&self) -> i64 {
+        self.len() as i64
     }
 
     fn values<'k>(&'k self) -> Box<dyn Iterator<Item = &'k dyn ValueView> + 'k> {
@@ -86,12 +86,12 @@ impl<T: ValueView> ArrayView for Vec<T> {
         Box::new(i)
     }
 
-    fn contains_key(&self, index: i32) -> bool {
+    fn contains_key(&self, index: i64) -> bool {
         let index = convert_index(index, self.size());
         index < self.size()
     }
 
-    fn get(&self, index: i32) -> Option<&dyn ValueView> {
+    fn get(&self, index: i64) -> Option<&dyn ValueView> {
         let index = convert_index(index, self.size());
         let value = self.as_slice().get(index as usize);
         value.map(|v| convert_value(v))
@@ -102,7 +102,7 @@ fn convert_value(s: &dyn ValueView) -> &dyn ValueView {
     s
 }
 
-fn convert_index(index: i32, max_size: i32) -> i32 {
+fn convert_index(index: i64, max_size: i64) -> i64 {
     if 0 <= index {
         index
     } else {

--- a/crates/core/src/model/find.rs
+++ b/crates/core/src/model/find.rs
@@ -182,7 +182,7 @@ fn augmented_get<'o>(value: &'o dyn ValueView, index: &ScalarCow<'_>) -> Option<
         let index = index.to_kstr();
         match index.as_str() {
             "size" => Some(ValueCow::Owned(Value::scalar(
-                scalar.to_kstr().as_str().len() as i32,
+                scalar.to_kstr().as_str().len() as i64,
             ))),
             _ => None,
         }

--- a/crates/core/src/model/object/mod.rs
+++ b/crates/core/src/model/object/mod.rs
@@ -22,7 +22,7 @@ pub trait ObjectView: ValueView {
     fn as_value(&self) -> &dyn ValueView;
 
     /// Returns the number of elements.
-    fn size(&self) -> i32;
+    fn size(&self) -> i64;
 
     /// Keys available for lookup.
     fn keys<'k>(&'k self) -> Box<dyn Iterator<Item = KStringCow<'k>> + 'k>;
@@ -76,8 +76,8 @@ impl ObjectView for Object {
         self
     }
 
-    fn size(&self) -> i32 {
-        self.len() as i32
+    fn size(&self) -> i64 {
+        self.len() as i64
     }
 
     fn keys<'k>(&'k self) -> Box<dyn Iterator<Item = KStringCow<'k>> + 'k> {
@@ -167,8 +167,8 @@ impl<K: ObjectIndex, V: ValueView, S: ::std::hash::BuildHasher> ObjectView for H
         self
     }
 
-    fn size(&self) -> i32 {
-        self.len() as i32
+    fn size(&self) -> i64 {
+        self.len() as i64
     }
 
     fn keys<'k>(&'k self) -> Box<dyn Iterator<Item = KStringCow<'k>> + 'k> {
@@ -238,8 +238,8 @@ impl<K: ObjectIndex, V: ValueView> ObjectView for BTreeMap<K, V> {
         self
     }
 
-    fn size(&self) -> i32 {
-        self.len() as i32
+    fn size(&self) -> i64 {
+        self.len() as i64
     }
 
     fn keys<'k>(&'k self) -> Box<dyn Iterator<Item = KStringCow<'k>> + 'k> {

--- a/crates/core/src/model/scalar/ser.rs
+++ b/crates/core/src/model/scalar/ser.rs
@@ -46,41 +46,41 @@ impl serde::Serializer for ScalarSerializer {
 
     #[inline]
     fn serialize_i8(self, value: i8) -> Result<Scalar, SerError> {
-        serialize_as_i32(value)
+        serialize_as_i64(value)
     }
 
     #[inline]
     fn serialize_i16(self, value: i16) -> Result<Scalar, SerError> {
-        serialize_as_i32(value)
+        serialize_as_i64(value)
     }
 
     #[inline]
     fn serialize_i32(self, value: i32) -> Result<Scalar, SerError> {
-        Ok(Scalar::new(value))
+        serialize_as_i64(value)
     }
 
     fn serialize_i64(self, value: i64) -> Result<Scalar, SerError> {
-        serialize_as_i32(value)
+        Ok(Scalar::new(value))
     }
 
     #[inline]
     fn serialize_u8(self, value: u8) -> Result<Scalar, SerError> {
-        serialize_as_i32(value)
+        serialize_as_i64(value)
     }
 
     #[inline]
     fn serialize_u16(self, value: u16) -> Result<Scalar, SerError> {
-        serialize_as_i32(value)
+        serialize_as_i64(value)
     }
 
     #[inline]
     fn serialize_u32(self, value: u32) -> Result<Scalar, SerError> {
-        serialize_as_i32(value)
+        serialize_as_i64(value)
     }
 
     #[inline]
     fn serialize_u64(self, value: u64) -> Result<Scalar, SerError> {
-        serialize_as_i32(value)
+        serialize_as_i64(value)
     }
 
     #[inline]
@@ -211,8 +211,8 @@ impl serde::Serializer for ScalarSerializer {
 }
 
 #[inline]
-fn serialize_as_i32<T: num_traits::cast::NumCast>(value: T) -> Result<Scalar, SerError> {
-    let value = num_traits::cast::cast::<T, i32>(value)
+fn serialize_as_i64<T: num_traits::cast::NumCast>(value: T) -> Result<Scalar, SerError> {
+    let value = num_traits::cast::cast::<T, i64>(value)
         .ok_or_else(|| SerError::new(crate::error::Error::with_msg("Cannot fit number")))?;
     Ok(Scalar::new(value))
 }

--- a/crates/core/src/model/value/cow.rs
+++ b/crates/core/src/model/value/cow.rs
@@ -145,8 +145,8 @@ impl<'v> PartialEq<Value> for ValueCow<'v> {
     }
 }
 
-impl<'v> PartialEq<i32> for ValueCow<'v> {
-    fn eq(&self, other: &i32) -> bool {
+impl<'v> PartialEq<i64> for ValueCow<'v> {
+    fn eq(&self, other: &i64) -> bool {
         super::value_eq(self.as_view(), other)
     }
 }

--- a/crates/core/src/model/value/ser.rs
+++ b/crates/core/src/model/value/ser.rs
@@ -101,7 +101,7 @@ impl serde::Serializer for ValueSerializer {
     }
 
     fn serialize_bytes(self, value: &[u8]) -> Result<Value, SerError> {
-        let vec = value.iter().map(|&b| Value::scalar(i32::from(b))).collect();
+        let vec = value.iter().map(|&b| Value::scalar(i64::from(b))).collect();
         Ok(Value::Array(vec))
     }
 

--- a/crates/core/src/model/value/values.rs
+++ b/crates/core/src/model/value/values.rs
@@ -244,8 +244,8 @@ impl<'v> PartialEq<ValueViewCmp<'v>> for Value {
     }
 }
 
-impl PartialEq<i32> for Value {
-    fn eq(&self, other: &i32) -> bool {
+impl PartialEq<i64> for Value {
+    fn eq(&self, other: &i64) -> bool {
         super::value_eq(self.as_view(), other)
     }
 }

--- a/crates/core/src/model/value/view.rs
+++ b/crates/core/src/model/value/view.rs
@@ -144,8 +144,8 @@ impl<'v> PartialEq<ValueViewCmp<'v>> for ValueViewCmp<'v> {
     }
 }
 
-impl<'v> PartialEq<i32> for ValueViewCmp<'v> {
-    fn eq(&self, other: &i32) -> bool {
+impl<'v> PartialEq<i64> for ValueViewCmp<'v> {
+    fn eq(&self, other: &i64) -> bool {
         super::value_eq(self.0, other)
     }
 }

--- a/crates/core/src/parser/parser.rs
+++ b/crates/core/src/parser/parser.rs
@@ -103,7 +103,7 @@ fn parse_literal(literal: Pair) -> Value {
         Rule::IntegerLiteral => Value::scalar(
             literal
                 .as_str()
-                .parse::<i32>()
+                .parse::<i64>()
                 .expect("Grammar ensures matches are parseable as integers."),
         ),
         Rule::FloatLiteral => Value::scalar(

--- a/crates/derive/src/filter_parameters.rs
+++ b/crates/derive/src/filter_parameters.rs
@@ -696,7 +696,7 @@ fn generate_evaluated_struct(filter_parameters: &FilterParameters<'_>) -> TokenS
         let ty = match &field.meta.ty {
             FilterParameterType::Value => quote! { ::liquid_core::model::ValueCow<'a> },
             FilterParameterType::Scalar => quote! { ::liquid_core::model::ScalarCow<'a> },
-            FilterParameterType::Integer => quote! { i32 },
+            FilterParameterType::Integer => quote! { i64 },
             FilterParameterType::Float => quote! { f64 },
             FilterParameterType::Bool => quote! { bool },
             FilterParameterType::DateTime => quote! { ::liquid_core::model::scalar::DateTime },

--- a/crates/derive/src/lib.rs
+++ b/crates/derive/src/lib.rs
@@ -53,7 +53,7 @@ use proc_macro::TokenStream;
 ///     - "any" -> any `Value` is accepted, this is the default option and `evaluate` will
 /// only convert `Expression` to `Value`.
 ///     - "integer" -> only `Scalar(Integer)` is accepted, `evaluate` will unwrap `Value`
-/// into `i32`.
+/// into `i64`.
 ///     - "float" -> only `Scalar(Float)` is accepted, `evaluate` will unwrap `Value`
 /// into `f64`.
 ///     - "bool" -> only `Scalar(Bool)` is accepted, `evaluate` will unwrap `Value`

--- a/crates/derive/src/object_view.rs
+++ b/crates/derive/src/object_view.rs
@@ -24,8 +24,8 @@ pub fn derive(input: &DeriveInput) -> TokenStream {
                 self
             }
 
-            fn size(&self) -> i32 {
-                #num_fields as i32
+            fn size(&self) -> i64 {
+                #num_fields as i64
             }
 
             fn keys<'liquid_derive_k>(&'liquid_derive_k self) -> Box<dyn Iterator<Item = ::kstring::KStringCow<'liquid_derive_k>> + 'liquid_derive_k> {

--- a/crates/lib/src/extra/date.rs
+++ b/crates/lib/src/extra/date.rs
@@ -65,7 +65,7 @@ mod tests {
             DateInTz,
             "13 Jun 2016 12:00:00 +0000",
             "%Y-%m-%d %H:%M:%S %z",
-            3i32
+            3i64
         )
         .unwrap();
         let desired_result = liquid_core::value!("2016-06-13 15:00:00 +0300");
@@ -78,7 +78,7 @@ mod tests {
             DateInTz,
             "13 Jun 2016 12:00:00 +0000",
             "%Y-%m-%d %H:%M:%S %z",
-            -13i32
+            -13i64
         )
         .unwrap();
         let desired_result = liquid_core::value!("2016-06-12 23:00:00 -1300");
@@ -91,7 +91,7 @@ mod tests {
             DateInTz,
             "13 Jun 2016 12:00:00 +0000",
             "%Y-%m-%d %H:%M:%S %z",
-            13i32
+            13i64
         )
         .unwrap();
         let desired_result = liquid_core::value!("2016-06-14 01:00:00 +1300");
@@ -100,12 +100,12 @@ mod tests {
 
     #[test]
     fn unit_date_in_tz_input_not_a_string() {
-        liquid_core::call_filter!(DateInTz, 0f64, "%Y-%m-%d %H:%M:%S %z", 0i32).unwrap_err();
+        liquid_core::call_filter!(DateInTz, 0f64, "%Y-%m-%d %H:%M:%S %z", 0i64).unwrap_err();
     }
 
     #[test]
     fn unit_date_in_tz_input_not_a_date_string() {
-        liquid_core::call_filter!(DateInTz, "blah blah blah", "%Y-%m-%d %H:%M:%S %z", 0i32)
+        liquid_core::call_filter!(DateInTz, "blah blah blah", "%Y-%m-%d %H:%M:%S %z", 0i64)
             .unwrap_err();
     }
 

--- a/crates/lib/src/jekyll/include_tag.rs
+++ b/crates/lib/src/jekyll/include_tag.rs
@@ -143,13 +143,13 @@ mod test {
     impl Filter for SizeFilter {
         fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
             if let Some(x) = input.as_scalar() {
-                Ok(Value::scalar(x.to_kstr().len() as i32))
+                Ok(Value::scalar(x.to_kstr().len() as i64))
             } else if let Some(x) = input.as_array() {
                 Ok(Value::scalar(x.size()))
             } else if let Some(x) = input.as_object() {
                 Ok(Value::scalar(x.size()))
             } else {
-                Ok(Value::scalar(0i32))
+                Ok(Value::scalar(0i64))
             }
         }
     }

--- a/crates/lib/src/shopify/pluralize.rs
+++ b/crates/lib/src/shopify/pluralize.rs
@@ -58,22 +58,22 @@ mod tests {
     #[test]
     fn unit_pluralize() {
         assert_eq!(
-            liquid_core::call_filter!(Pluralize, 1i32, "one", "many").unwrap(),
+            liquid_core::call_filter!(Pluralize, 1i64, "one", "many").unwrap(),
             liquid_core::value!("one")
         );
 
         assert_eq!(
-            liquid_core::call_filter!(Pluralize, 0i32, "one", "many").unwrap(),
+            liquid_core::call_filter!(Pluralize, 0i64, "one", "many").unwrap(),
             liquid_core::value!("many")
         );
 
         assert_eq!(
-            liquid_core::call_filter!(Pluralize, 2i32, "one", "many").unwrap(),
+            liquid_core::call_filter!(Pluralize, 2i64, "one", "many").unwrap(),
             liquid_core::value!("many")
         );
 
         assert_eq!(
-            liquid_core::call_filter!(Pluralize, 10i32, "one", "many").unwrap(),
+            liquid_core::call_filter!(Pluralize, 10i64, "one", "many").unwrap(),
             liquid_core::value!("many")
         );
     }

--- a/crates/lib/src/stdlib/blocks/for_block.rs
+++ b/crates/lib/src/stdlib/blocks/for_block.rs
@@ -29,7 +29,7 @@ impl Range {
                 let start = int_argument(start_arg, runtime, "start")?;
                 let stop = int_argument(stop_arg, runtime, "end")?;
                 let range = start..=stop;
-                range.map(|x| Value::scalar(x as i32)).collect()
+                range.map(|x| Value::scalar(x as i64)).collect()
             }
         };
 
@@ -174,14 +174,14 @@ impl Renderable for For {
             range_len => {
                 runtime.run_in_scope(|mut scope| -> Result<()> {
                     let mut helper_vars = Object::new();
-                    helper_vars.insert("length".into(), Value::scalar(range_len as i32));
+                    helper_vars.insert("length".into(), Value::scalar(range_len as i64));
 
                     for (i, v) in range.into_iter().enumerate() {
-                        helper_vars.insert("index0".into(), Value::scalar(i as i32));
-                        helper_vars.insert("index".into(), Value::scalar((i + 1) as i32));
+                        helper_vars.insert("index0".into(), Value::scalar(i as i64));
+                        helper_vars.insert("index".into(), Value::scalar((i + 1) as i64));
                         helper_vars
-                            .insert("rindex0".into(), Value::scalar((range_len - i - 1) as i32));
-                        helper_vars.insert("rindex".into(), Value::scalar((range_len - i) as i32));
+                            .insert("rindex0".into(), Value::scalar((range_len - i - 1) as i64));
+                        helper_vars.insert("rindex".into(), Value::scalar((range_len - i) as i64));
                         helper_vars.insert("first".into(), Value::scalar(i == 0));
                         helper_vars.insert("last".into(), Value::scalar(i == (range_len - 1)));
 
@@ -406,7 +406,7 @@ impl Renderable for TableRow {
             let mut helper_vars = Object::new();
 
             let range_len = range.len();
-            helper_vars.insert("length".into(), Value::scalar(range_len as i32));
+            helper_vars.insert("length".into(), Value::scalar(range_len as i64));
 
             for (i, v) in range.into_iter().enumerate() {
                 let (col_index, row_index) = match cols {
@@ -419,14 +419,14 @@ impl Renderable for TableRow {
                 let col_first = col_index == 0;
                 let col_last = cols.filter(|&cols| col_index + 1 == cols).is_some() || last;
 
-                helper_vars.insert("index0".into(), Value::scalar(i as i32));
-                helper_vars.insert("index".into(), Value::scalar((i + 1) as i32));
-                helper_vars.insert("rindex0".into(), Value::scalar((range_len - i - 1) as i32));
-                helper_vars.insert("rindex".into(), Value::scalar((range_len - i) as i32));
+                helper_vars.insert("index0".into(), Value::scalar(i as i64));
+                helper_vars.insert("index".into(), Value::scalar((i + 1) as i64));
+                helper_vars.insert("rindex0".into(), Value::scalar((range_len - i - 1) as i64));
+                helper_vars.insert("rindex".into(), Value::scalar((range_len - i) as i64));
                 helper_vars.insert("first".into(), Value::scalar(first));
                 helper_vars.insert("last".into(), Value::scalar(last));
-                helper_vars.insert("col0".into(), Value::scalar(col_index as i32));
-                helper_vars.insert("col".into(), Value::scalar((col_index + 1) as i32));
+                helper_vars.insert("col0".into(), Value::scalar(col_index as i64));
+                helper_vars.insert("col".into(), Value::scalar((col_index + 1) as i64));
                 helper_vars.insert("col_first".into(), Value::scalar(col_first));
                 helper_vars.insert("col_last".into(), Value::scalar(col_last));
                 scope
@@ -638,10 +638,10 @@ mod test {
         let mut runtime = Runtime::new();
         runtime
             .stack_mut()
-            .set_global("alpha", Value::scalar(42i32));
+            .set_global("alpha", Value::scalar(42i64));
         runtime
             .stack_mut()
-            .set_global("omega", Value::scalar(46i32));
+            .set_global("omega", Value::scalar(46i64));
         let output = template.render(&mut runtime).unwrap();
         assert_eq!(
             output,
@@ -703,7 +703,7 @@ mod test {
 
         runtime
             .stack_mut()
-            .set_global("i", Value::Array(vec![Value::scalar(1i32)]));
+            .set_global("i", Value::Array(vec![Value::scalar(1i64)]));
         runtime.stack_mut().set_global("j", Value::Array(vec![]));
         let output = template.render(&mut runtime).unwrap();
         assert_eq!(output, "empty inner");

--- a/crates/lib/src/stdlib/filters/mod.rs
+++ b/crates/lib/src/stdlib/filters/mod.rs
@@ -45,13 +45,13 @@ struct SizeFilter;
 impl Filter for SizeFilter {
     fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
         if let Some(x) = input.as_scalar() {
-            Ok(Value::scalar(x.to_kstr().len() as i32))
+            Ok(Value::scalar(x.to_kstr().len() as i64))
         } else if let Some(x) = input.as_array() {
             Ok(Value::scalar(x.size()))
         } else if let Some(x) = input.as_object() {
             Ok(Value::scalar(x.size()))
         } else {
-            Ok(Value::scalar(0i32))
+            Ok(Value::scalar(0i64))
         }
     }
 }

--- a/crates/lib/src/stdlib/filters/string/truncate.rs
+++ b/crates/lib/src/stdlib/filters/string/truncate.rs
@@ -158,7 +158,7 @@ mod tests {
             liquid_core::call_filter!(
                 Truncate,
                 "I often quote myself.  It adds spice to my conversation.",
-                17i32
+                17i64
             )
             .unwrap(),
             liquid_core::value!("I often quote ...")
@@ -171,7 +171,7 @@ mod tests {
             liquid_core::call_filter!(
                 Truncate,
                 "I often quote myself.  It adds spice to my conversation.",
-                -17i32
+                -17i64
             )
             .unwrap(),
             liquid_core::value!("I often quote myself.  It adds spice to my conversation.")
@@ -181,7 +181,7 @@ mod tests {
     #[test]
     fn unit_truncate_non_string() {
         assert_eq!(
-            liquid_core::call_filter!(Truncate, 10000000f64, 5i32).unwrap(),
+            liquid_core::call_filter!(Truncate, 10000000f64, 5i64).unwrap(),
             liquid_core::value!("10...")
         );
     }
@@ -192,17 +192,17 @@ mod tests {
         let input = "Ground control to Major Tom.";
 
         assert_eq!(
-            liquid_core::call_filter!(Truncate, input, 20i32).unwrap(),
+            liquid_core::call_filter!(Truncate, input, 20i64).unwrap(),
             liquid_core::value!("Ground control to...")
         );
 
         assert_eq!(
-            liquid_core::call_filter!(Truncate, input, 25i32, ", and so on").unwrap(),
+            liquid_core::call_filter!(Truncate, input, 25i64, ", and so on").unwrap(),
             liquid_core::value!("Ground control, and so on")
         );
 
         assert_eq!(
-            liquid_core::call_filter!(Truncate, input, 20i32, "").unwrap(),
+            liquid_core::call_filter!(Truncate, input, 20i64, "").unwrap(),
             liquid_core::value!("Ground control to Ma")
         );
     }
@@ -212,9 +212,9 @@ mod tests {
         liquid_core::call_filter!(
             Truncate,
             "I often quote myself.  It adds spice to my conversation.",
-            17i32,
+            17i64,
             "...",
-            0i32
+            0i64
         )
         .unwrap_err();
     }
@@ -232,7 +232,7 @@ mod tests {
             liquid_core::call_filter!(
                 Truncate,
                 "Here is an a\u{310}, e\u{301}, and o\u{308}\u{332}.",
-                20i32
+                20i64
             )
             .unwrap(),
             liquid_core::value!("Here is an a\u{310}, e\u{301}, ...")
@@ -240,7 +240,7 @@ mod tests {
 
         // Note that the 🇷🇺🇸🇹 is treated as a single grapheme cluster.
         assert_eq!(
-            liquid_core::call_filter!(Truncate, "Here is a RUST: 🇷🇺🇸🇹.", 20i32).unwrap(),
+            liquid_core::call_filter!(Truncate, "Here is a RUST: 🇷🇺🇸🇹.", 20i64).unwrap(),
             liquid_core::value!("Here is a RUST: 🇷🇺...")
         );
     }
@@ -260,7 +260,7 @@ mod tests {
     #[test]
     fn unit_truncatewords_negative_length() {
         assert_eq!(
-            liquid_core::call_filter!(TruncateWords, "one two three", -1_i32).unwrap(),
+            liquid_core::call_filter!(TruncateWords, "one two three", -1_i64).unwrap(),
             liquid_core::value!("one two three")
         );
     }
@@ -268,7 +268,7 @@ mod tests {
     #[test]
     fn unit_truncatewords_zero_length() {
         assert_eq!(
-            liquid_core::call_filter!(TruncateWords, "one two three", 0_i32).unwrap(),
+            liquid_core::call_filter!(TruncateWords, "one two three", 0_i64).unwrap(),
             liquid_core::value!("...")
         );
     }
@@ -276,7 +276,7 @@ mod tests {
     #[test]
     fn unit_truncatewords_no_truncation() {
         assert_eq!(
-            liquid_core::call_filter!(TruncateWords, "one two three", 4_i32).unwrap(),
+            liquid_core::call_filter!(TruncateWords, "one two three", 4_i64).unwrap(),
             liquid_core::value!("one two three")
         );
     }
@@ -284,11 +284,11 @@ mod tests {
     #[test]
     fn unit_truncatewords_truncate() {
         assert_eq!(
-            liquid_core::call_filter!(TruncateWords, "one two three", 2_i32).unwrap(),
+            liquid_core::call_filter!(TruncateWords, "one two three", 2_i64).unwrap(),
             liquid_core::value!("one two...")
         );
         assert_eq!(
-            liquid_core::call_filter!(TruncateWords, "one two three", 2_i32, 1_i32).unwrap(),
+            liquid_core::call_filter!(TruncateWords, "one two three", 2_i64, 1_i64).unwrap(),
             liquid_core::value!("one two1")
         );
     }
@@ -296,7 +296,7 @@ mod tests {
     #[test]
     fn unit_truncatewords_empty_string() {
         assert_eq!(
-            liquid_core::call_filter!(TruncateWords, "", 1_i32).unwrap(),
+            liquid_core::call_filter!(TruncateWords, "", 1_i64).unwrap(),
             liquid_core::value!("")
         );
     }

--- a/crates/lib/src/stdlib/tags/include_tag.rs
+++ b/crates/lib/src/stdlib/tags/include_tag.rs
@@ -140,13 +140,13 @@ mod test {
     impl Filter for SizeFilter {
         fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
             if let Some(x) = input.as_scalar() {
-                Ok(Value::scalar(x.to_kstr().len() as i32))
+                Ok(Value::scalar(x.to_kstr().len() as i64))
             } else if let Some(x) = input.as_array() {
                 Ok(Value::scalar(x.size()))
             } else if let Some(x) = input.as_object() {
                 Ok(Value::scalar(x.size()))
             } else {
-                Ok(Value::scalar(0i32))
+                Ok(Value::scalar(0i64))
             }
         }
     }

--- a/tests/derive_object.rs
+++ b/tests/derive_object.rs
@@ -35,12 +35,12 @@ fn test_empty_object() {
 #[derive(ObjectView, ValueView, serde::Serialize, serde::Deserialize, Debug)]
 struct TestStatic {
     boolean: bool,
-    int: i32,
+    int: i64,
     float: f64,
     static_str: &'static str,
     string: String,
     kstring: kstring::KString,
-    array: Vec<i32>,
+    array: Vec<i64>,
 }
 
 impl TestStatic {
@@ -77,7 +77,7 @@ fn test_static_value() {
 fn test_static_object() {
     let uut = TestStatic::non_default();
 
-    assert_eq!(uut.size(), 7i32);
+    assert_eq!(uut.size(), 7i64);
     assert!(!uut.keys().collect::<Vec<_>>().is_empty());
     assert!(!uut.values().collect::<Vec<_>>().is_empty());
     assert!(!uut.iter().collect::<Vec<_>>().is_empty());
@@ -108,7 +108,7 @@ fn test_borrow_object() {
         s: fixture.as_str(),
     };
 
-    assert_eq!(uut.size(), 1i32);
+    assert_eq!(uut.size(), 1i64);
     assert!(!uut.keys().collect::<Vec<_>>().is_empty());
     assert!(!uut.values().collect::<Vec<_>>().is_empty());
     assert!(!uut.iter().collect::<Vec<_>>().is_empty());


### PR DESCRIPTION
Pros:
- More general
- Integrates better with SQL
- Doesn't increase `Scalar`size because there are larger types

Cons
- Doesn't fit within an f64.

- [ ] Tests created for any new feature or regression tests for bugfixes.
