### PR TITLE
fix(model): DateTime serialization was off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="0.21.3"></a>
+## 0.21.3 (2020-08-03)
+
+### Highlights
+
+- Fix date serialization
+
 <a name="0.21.2"></a>
 ## 0.21.2 (2020-07-15)
 

--- a/crates/core/src/model/scalar/date.rs
+++ b/crates/core/src/model/scalar/date.rs
@@ -135,7 +135,7 @@ mod friendly_date {
     where
         S: Serializer,
     {
-        let s = date.to_string();
+        let s = date.format(DATE_FORMAT).to_string();
         serializer.serialize_str(&s)
     }
 
@@ -169,16 +169,22 @@ mod test {
     use super::*;
     #[test]
     fn parse_date_time_empty_is_bad() {
-        assert!(parse_date("").is_none());
+        let input = "";
+        let actual = parse_date(input);
+        assert!(actual.is_none());
     }
 
     #[test]
     fn parse_date_time_bad() {
-        assert!(parse_date("aaaaa").is_none());
+        let input = "aaaaa";
+        let actual = parse_date(input);
+        assert!(actual.is_none());
     }
 
     #[test]
     fn parse_date_today() {
-        assert!(parse_date("today").is_some());
+        let input = "today";
+        let actual = parse_date(input);
+        assert!(actual.is_some());
     }
 }

--- a/crates/core/src/model/scalar/datetime.rs
+++ b/crates/core/src/model/scalar/datetime.rs
@@ -216,7 +216,7 @@ mod friendly_date_time {
     where
         S: Serializer,
     {
-        let s = date.to_string();
+        let s = date.format(DATE_TIME_FORMAT).to_string();
         serializer.serialize_str(&s)
     }
 
@@ -251,18 +251,40 @@ fn parse_date_time(s: &str) -> Option<DateTimeImpl> {
 #[cfg(test)]
 mod test {
     use super::*;
+
     #[test]
     fn parse_date_time_empty_is_bad() {
-        assert!(parse_date_time("").is_none());
+        let input = "";
+        let actual = parse_date_time(input);
+        assert!(actual.is_none());
     }
 
     #[test]
     fn parse_date_time_bad() {
-        assert!(parse_date_time("aaaaa").is_none());
+        let input = "aaaaa";
+        let actual = parse_date_time(input);
+        assert!(actual.is_none());
     }
 
     #[test]
     fn parse_date_time_now() {
-        assert!(parse_date_time("now").is_some());
+        let input = "now";
+        let actual = parse_date_time(input);
+        assert!(actual.is_some());
+    }
+
+    #[test]
+    fn parse_date_time_serialized_format() {
+        let input = "2016-02-16 10:00:00 +0100";
+        let actual = parse_date_time(input);
+        assert!(actual.is_some());
+    }
+
+    #[test]
+    fn parse_date_time_to_string() {
+        let date = DateTime::now();
+        let input = date.to_string();
+        let actual = parse_date_time(&input);
+        assert!(actual.is_some());
     }
 }


### PR DESCRIPTION
When I ported this code from cobalt to liquid, I missed that I was using
serialziation methods on the underlying type rather than our own.

- [ ] Tests created for any new feature or regression tests for bugfixes.
