### PR TITLE
feat(lib): support for variable passing for `include`

### DIFF
--- a/crates/lib/src/stdlib/tags/include_tag.rs
+++ b/crates/lib/src/stdlib/tags/include_tag.rs
@@ -151,6 +151,7 @@ mod test {
         fn try_get<'a>(&'a self, name: &str) -> Option<borrow::Cow<'a, str>> {
             match name {
                 "example.txt" => Some(r#"{{'whooo' | size}}{%comment%}What happens{%endcomment%} {%if num < numTwo%}wat{%else%}wot{%endif%} {%if num > numTwo%}wat{%else%}wot{%endif%}"#.into()),
+                "example_var.txt" => Some(r#"{{inlcude.example_var}}"#.into()),
                 _ => None
             }
         }
@@ -215,6 +216,24 @@ mod test {
             .set_global("numTwo", Value::scalar(10f64));
         let output = template.render(&mut runtime).unwrap();
         assert_eq!(output, "5 wat wot");
+    }
+
+    #[test]
+    fn include_varaible() {
+        let text = "{% include 'example_var.txt' example_var=\"hello\" %}";
+        let options = options();
+        let template = parser::parse(text, &options)
+            .map(runtime::Template::new)
+            .unwrap();
+
+        let partials = partials::OnDemandCompiler::<TestSource>::empty()
+            .compile(::std::sync::Arc::new(options))
+            .unwrap();
+        let mut runtime = RuntimeBuilder::new()
+            .set_partials(partials.as_ref())
+            .build();
+        let output = template.render(&mut runtime).unwrap();
+        assert_eq!(output, "hello");
     }
 
     #[test]

--- a/crates/lib/src/stdlib/tags/include_tag.rs
+++ b/crates/lib/src/stdlib/tags/include_tag.rs
@@ -1,5 +1,6 @@
 use std::io::Write;
 
+use kstring::KString;
 use liquid_core::Expression;
 use liquid_core::Language;
 use liquid_core::Renderable;
@@ -12,7 +13,7 @@ use liquid_core::{ParseTag, TagReflection, TagTokenIter};
 #[derive(Debug)]
 struct Include {
     partial: Expression,
-    vars: Vec<(String, Expression)>,
+    vars: Vec<(KString, Expression)>,
 }
 
 impl Renderable for Include {
@@ -25,25 +26,20 @@ impl Renderable for Include {
         }
         let name = value.to_kstr().into_owned();
 
-        let mut varaibles_evaluated = Vec::new();
-        for (id, expr) in &self.vars {
-            varaibles_evaluated.push((
-                id.to_owned(),
-                expr.try_evaluate(runtime)
-                    .ok_or_else(|| Error::with_msg("failed to evaluate value"))?
-                    .into_owned(),
-            ));
-        }
-
         runtime.run_in_named_scope(name.clone(), |mut scope| -> Result<()> {
             // if there our additional varaibles creates a include object to access all the varaibles
             // from e.g. { include 'image.html' path="foo.png" }
             // then in image.html you could have <img src="{{include.path}}" />
-            if !varaibles_evaluated.is_empty() {
+            if !self.vars.is_empty() {
                 let mut helper_vars = Object::new();
 
-                for (id, val) in varaibles_evaluated {
-                    helper_vars.insert(id.into(), val);
+                for (id, val) in &self.vars {
+                    helper_vars.insert(
+                        id.to_owned().into(),
+                        val.try_evaluate(scope)
+                            .ok_or_else(|| Error::with_msg("failed to evaluate value"))?
+                            .into_owned(),
+                    );
                 }
 
                 scope.stack_mut().set("include", Value::Object(helper_vars));
@@ -94,19 +90,19 @@ impl ParseTag for IncludeTag {
 
         let partial = partial.expect_value().into_result()?;
 
-        let mut vars = Vec::new();
+        let mut vars: Vec<(KString, Expression)> = Vec::new();
         while let Ok(next) = arguments.expect_next("") {
-            let id = next.expect_value().into_result()?.to_string();
+            let id = next.expect_identifier().into_result()?.to_string();
 
             arguments
-                .expect_next("expected string")?
-                .expect_str("=")
-                .into_result_custom_msg("expected '=' to be used for the assignment")?;
+                .expect_next("\":\" expected.")?
+                .expect_str(":")
+                .into_result_custom_msg("expected \":\" to be used for the assignment")?;
 
             vars.push((
-                id,
+                id.into(),
                 arguments
-                    .expect_next("expected expression/value")?
+                    .expect_next("expected value")?
                     .expect_value()
                     .into_result()?,
             ));
@@ -151,7 +147,7 @@ mod test {
         fn try_get<'a>(&'a self, name: &str) -> Option<borrow::Cow<'a, str>> {
             match name {
                 "example.txt" => Some(r#"{{'whooo' | size}}{%comment%}What happens{%endcomment%} {%if num < numTwo%}wat{%else%}wot{%endif%} {%if num > numTwo%}wat{%else%}wot{%endif%}"#.into()),
-                "example_var.txt" => Some(r#"{{inlcude.example_var}}"#.into()),
+                "example_var.txt" => Some(r#"{{include.example_var}}"#.into()),
                 _ => None
             }
         }
@@ -220,7 +216,7 @@ mod test {
 
     #[test]
     fn include_varaible() {
-        let text = "{% include 'example_var.txt' example_var=\"hello\" %}";
+        let text = "{% include 'example_var.txt' example_var:\"hello\" %}";
         let options = options();
         let template = parser::parse(text, &options)
             .map(runtime::Template::new)

--- a/tests/conformance_ruby/tags/include_tag_test.rs
+++ b/tests/conformance_ruby/tags/include_tag_test.rs
@@ -17,7 +17,8 @@ impl liquid::partials::PartialSource for TestFileSystem {
     fn try_get<'a>(&'a self, name: &str) -> Option<borrow::Cow<'a, str>> {
         let template = match name {
             "product" => "Product: {{ product.title }} ".into(),
-            "locale_variables" => "Locale: {{echo1}} {{echo2}}".into(),
+            "locale_variables" => "Locale: {{include.echo1}} {{include.echo2}}".into(),
+            "single_locale_variable" => "Single Locale: {{include.echo1}}".into(),
             "variant" => "Variant: {{ variant.title }}".into(),
             "nested_template" => {
                 "{% include 'header' %} {% include 'body' %} {% include 'footer' %}".into()
@@ -81,33 +82,41 @@ fn test_include_tag_for() {
 }
 
 #[test]
-#[should_panic] // liquid-rust#237
-fn test_include_tag_with_local_variables() {
+fn test_include_tag_with_single_local_variable() {
     assert_template_result!(
-        "Locale: test123 ",
-        "{% include 'locale_variables' echo1: 'test123' %}",
+        "Single Locale: test123",
+        "{% include 'single_locale_variable' echo1='test123' %}",
         o!({}),
         liquid()
     );
 }
 
 #[test]
-#[should_panic] // liquid-rust#237
+#[should_panic]
+fn test_include_tag_with_local_variables() {
+    assert_template_result!(
+        "Locale: test123",
+        "{% include 'locale_variables' echo1='test123' %}",
+        o!({}),
+        liquid()
+    );
+}
+
+#[test]
 fn test_include_tag_with_multiple_local_variables() {
     assert_template_result!(
         "Locale: test123 test321",
-        "{% include 'locale_variables' echo1: 'test123', echo2: 'test321' %}",
+        "{% include 'locale_variables' echo1='test123' echo2='test321' %}",
         o!({}),
         liquid()
     );
 }
 
 #[test]
-#[should_panic] // liquid-rust#237
 fn test_include_tag_with_multiple_local_variables_from_runtime() {
     assert_template_result!(
         "Locale: test123 test321",
-        "{% include 'locale_variables' echo1: echo1, echo2: more_echos.echo2 %}",
+        "{% include 'locale_variables' echo1=echo1 echo2=more_echos.echo2 %}",
         o!({"echo1": "test123", "more_echos": { "echo2": "test321" }}),
         liquid()
     );

--- a/tests/conformance_ruby/tags/include_tag_test.rs
+++ b/tests/conformance_ruby/tags/include_tag_test.rs
@@ -17,8 +17,8 @@ impl liquid::partials::PartialSource for TestFileSystem {
     fn try_get<'a>(&'a self, name: &str) -> Option<borrow::Cow<'a, str>> {
         let template = match name {
             "product" => "Product: {{ product.title }} ".into(),
-            "locale_variables" => "Locale: {{include.echo1}} {{include.echo2}}".into(),
-            "single_locale_variable" => "Single Locale: {{include.echo1}}".into(),
+            "locale_variables" => "Locale: {{echo1}} {{echo2}}".into(),
+            "single_locale_variable" => "Single Locale: {{echo1}}".into(),
             "variant" => "Variant: {{ variant.title }}".into(),
             "nested_template" => {
                 "{% include 'header' %} {% include 'body' %} {% include 'footer' %}".into()
@@ -82,7 +82,7 @@ fn test_include_tag_for() {
 }
 
 #[test]
-fn test_include_tag_with_single_local_variable() {
+fn test_include_tag_with_local_variable() {
     assert_template_result!(
         "Single Locale: test123",
         "{% include 'single_locale_variable' echo1:'test123' %}",
@@ -106,7 +106,7 @@ fn test_include_tag_with_local_variables() {
 fn test_include_tag_with_multiple_local_variables() {
     assert_template_result!(
         "Locale: test123 test321",
-        "{% include 'locale_variables' echo1:'test123' echo2:'test321' %}",
+        "{% include 'locale_variables' echo1:'test123', echo2:'test321' %}",
         o!({}),
         liquid()
     );
@@ -116,7 +116,7 @@ fn test_include_tag_with_multiple_local_variables() {
 fn test_include_tag_with_multiple_local_variables_from_runtime() {
     assert_template_result!(
         "Locale: test123 test321",
-        "{% include 'locale_variables' echo1:echo1 echo2:more_echos.echo2 %}",
+        "{% include 'locale_variables' echo1:echo1, echo2:more_echos.echo2 %}",
         o!({"echo1": "test123", "more_echos": { "echo2": "test321" }}),
         liquid()
     );

--- a/tests/conformance_ruby/tags/include_tag_test.rs
+++ b/tests/conformance_ruby/tags/include_tag_test.rs
@@ -18,14 +18,13 @@ impl liquid::partials::PartialSource for TestFileSystem {
         let template = match name {
             "product" => "Product: {{ product.title }} ".into(),
             "locale_variables" => "Locale: {{echo1}} {{echo2}}".into(),
-            "single_locale_variable" => "Single Locale: {{echo1}}".into(),
             "variant" => "Variant: {{ variant.title }}".into(),
             "nested_template" => {
                 "{% include 'header' %} {% include 'body' %} {% include 'footer' %}".into()
             }
             "body" => "body {% include 'body_detail' %}".into(),
             "nested_product_template" => {
-                "Product= {{ nested_product_template.title }} {%include 'details'%} ".into()
+                "Product: {{ nested_product_template.title }} {%include 'details'%} ".into()
             }
             "recursively_nested_template" => "-{% include 'recursively_nested_template' %}".into(),
             "pick_a_source" => "from TestFileSystem".into(),
@@ -82,21 +81,11 @@ fn test_include_tag_for() {
 }
 
 #[test]
-fn test_include_tag_with_local_variable() {
-    assert_template_result!(
-        "Single Locale: test123",
-        "{% include 'single_locale_variable' echo1:'test123' %}",
-        o!({}),
-        liquid()
-    );
-}
-
-#[test]
-#[should_panic]
+#[should_panic] // fails due to strict_varaibles
 fn test_include_tag_with_local_variables() {
     assert_template_result!(
-        "Locale: test123",
-        "{% include 'locale_variables' echo1:'test123' %}",
+        "Locale: test123 ",
+        "{% include 'locale_variables' echo1: 'test123' %}",
         o!({}),
         liquid()
     );
@@ -106,7 +95,7 @@ fn test_include_tag_with_local_variables() {
 fn test_include_tag_with_multiple_local_variables() {
     assert_template_result!(
         "Locale: test123 test321",
-        "{% include 'locale_variables' echo1:'test123', echo2:'test321' %}",
+        "{% include 'locale_variables' echo1: 'test123', echo2: 'test321' %}",
         o!({}),
         liquid()
     );
@@ -116,7 +105,7 @@ fn test_include_tag_with_multiple_local_variables() {
 fn test_include_tag_with_multiple_local_variables_from_runtime() {
     assert_template_result!(
         "Locale: test123 test321",
-        "{% include 'locale_variables' echo1:echo1, echo2:more_echos.echo2 %}",
+        "{% include 'locale_variables' echo1: echo1, echo2: more_echos.echo2 %}",
         o!({"echo1": "test123", "more_echos": { "echo2": "test321" }}),
         liquid()
     );

--- a/tests/conformance_ruby/tags/include_tag_test.rs
+++ b/tests/conformance_ruby/tags/include_tag_test.rs
@@ -25,7 +25,7 @@ impl liquid::partials::PartialSource for TestFileSystem {
             }
             "body" => "body {% include 'body_detail' %}".into(),
             "nested_product_template" => {
-                "Product: {{ nested_product_template.title }} {%include 'details'%} ".into()
+                "Product= {{ nested_product_template.title }} {%include 'details'%} ".into()
             }
             "recursively_nested_template" => "-{% include 'recursively_nested_template' %}".into(),
             "pick_a_source" => "from TestFileSystem".into(),
@@ -85,7 +85,7 @@ fn test_include_tag_for() {
 fn test_include_tag_with_single_local_variable() {
     assert_template_result!(
         "Single Locale: test123",
-        "{% include 'single_locale_variable' echo1='test123' %}",
+        "{% include 'single_locale_variable' echo1:'test123' %}",
         o!({}),
         liquid()
     );
@@ -96,7 +96,7 @@ fn test_include_tag_with_single_local_variable() {
 fn test_include_tag_with_local_variables() {
     assert_template_result!(
         "Locale: test123",
-        "{% include 'locale_variables' echo1='test123' %}",
+        "{% include 'locale_variables' echo1:'test123' %}",
         o!({}),
         liquid()
     );
@@ -106,7 +106,7 @@ fn test_include_tag_with_local_variables() {
 fn test_include_tag_with_multiple_local_variables() {
     assert_template_result!(
         "Locale: test123 test321",
-        "{% include 'locale_variables' echo1='test123' echo2='test321' %}",
+        "{% include 'locale_variables' echo1:'test123' echo2:'test321' %}",
         o!({}),
         liquid()
     );
@@ -116,7 +116,7 @@ fn test_include_tag_with_multiple_local_variables() {
 fn test_include_tag_with_multiple_local_variables_from_runtime() {
     assert_template_result!(
         "Locale: test123 test321",
-        "{% include 'locale_variables' echo1=echo1 echo2=more_echos.echo2 %}",
+        "{% include 'locale_variables' echo1:echo1 echo2:more_echos.echo2 %}",
         o!({"echo1": "test123", "more_echos": { "echo2": "test321" }}),
         liquid()
     );


### PR DESCRIPTION
This adds it both for Jekyll and Liquid versions of include which have different syntaxes.

Fixes #310
