### PR TITLE
Feat: Added 'parentloop' varaible to 'forloop' for the standard lib

### DIFF
--- a/tests/conformance_ruby/tags/for_tag_test.rs
+++ b/tests/conformance_ruby/tags/for_tag_test.rs
@@ -456,7 +456,6 @@ fn test_for_tag_string() {
 }
 
 #[test]
-#[should_panic] // liquid-rust#271
 fn test_for_parentloop_references_parent_loop() {
     assert_template_result!(
         "1.1 1.2 1.3 2.1 2.2 2.3 ",


### PR DESCRIPTION
PR for this issue: https://github.com/cobalt-org/liquid-rust/issues/271

I copied two tests from the conformance test suite and one of them I modified as it seems that `Value::Nil` works slightly different. 

- [ ] Tests created for any new feature or regression tests for bugfixes.
