### PR TITLE
perf(runtime): Allow stack frames to contain references to other stack frames #337 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Features
+
+API
+- Allow `#[derive(liquid_core::ObjectView, liquid_core::ValueView)]` (previously only worked from `liquid`, making it unusable for the `lib` crate)
+
 ### Breaking Changes
 
 - `core::runtime` went through significant changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Breaking Changes
+
+- `core::runtime` went through significant changes
+  - `Renderable::render_to` now takes `&dyn Runtime` instead of `&Runtime<'_>`
+  - Adding a new stack frame is now a `StackFrame::new` instead of `Runtime.run_in_scope`
+    - This opens up taking references to layers lower in the stack.
+    - `runtime.` to access stack functions instead of `runtime.stack_mut()`
+- `InterruptState` is now `InterruptRegister` and accessed via `runtime.registers()`
+  - Functions were renamed while at it.
+
 ## [0.21.5] - 2021-02-03
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ API
 
 ### Performance
 
+- Reduce allocations for for-loop variables
 - Reduce overhead from `derive(ValueView)` generating `to_value`
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     - `runtime.` to access stack functions instead of `runtime.stack_mut()`
 - `InterruptState` is now `InterruptRegister` and accessed via `runtime.registers()`
   - Functions were renamed while at it.
+- `core::model` has been flattened
 
 ## [0.21.5] - 2021-02-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 API
 - Allow `#[derive(liquid_core::ObjectView, liquid_core::ValueView)]` (previously only worked from `liquid`, making it unusable for the `lib` crate)
 
+### Fixes
+
+- Remove `serde` requirement for `derive(ValueView)`, making it work with more types (like `field: &dyn ValueView`).
+
+### Performance
+
+- Reduce overhead from `derive(ValueView)` generating `to_value`
+
 ### Breaking Changes
 
 - `core::runtime` went through significant changes
@@ -22,6 +30,7 @@ API
 - `InterruptState` is now `InterruptRegister` and accessed via `runtime.registers()`
   - Functions were renamed while at it.
 - `core::model` has been flattened
+- `derive(ValueView)` now requires being used with `impl ObjectView`
 
 ## [0.21.5] - 2021-02-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ API
   - Functions were renamed while at it.
 - `core::model` has been flattened
 - `derive(ValueView)` now requires being used with `impl ObjectView`
+- `liquid-core` users now need to opt-in to the `derive` feature for derive macros
 
 ## [0.21.5] - 2021-02-03
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,14 @@ stages:
         rust: stable
     - script: cargo check --workspace --all-targets
       displayName: Default features
+    - script: cargo check --all-targets --all-features
+      displayName: All features (core)
+      workingDirectory: crates/core
+    - script: cargo check --all-targets --all-features
+      displayName: All features (lib)
+      workingDirectory: crates/lib
+    - script: cargo doc --workspace --no-deps
+      displayName: Docs
 - stage: test
   displayName: Test
   jobs:
@@ -85,9 +93,13 @@ stages:
         rust: $(channel)
         targets: ["$(TARGET)"]
     - script: cargo test --target $(TARGET) --workspace
-      displayName: cargo test
-    - script: cargo doc --target $(TARGET) --workspace --no-deps
-      displayName: cargo doc
+      displayName: Default features
+    - script: cargo test --target $(TARGET) --all-features
+      displayName: All features (core)
+      workingDirectory: crates/lib
+    - script: cargo test --target $(TARGET) --all-features
+      displayName: All features (lib)
+      workingDirectory: crates/lib
   - job: msrv
     displayName: "${{ format('Minimum supported Rust version: {0}', variables.minrust) }}"
     dependsOn: []

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -22,8 +22,12 @@ pest_derive = "2.0"
 chrono = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 kstring = "1.0"
-liquid-derive = { version = "^0.21.0", path = "../derive" }
+liquid-derive = { version = "^0.21.0", path = "../derive", optional = true }
 
 [dev-dependencies]
 difference = "2.0"
 serde_yaml = "0.8"
+
+[features]
+default = []
+derive = ["liquid-derive"]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod partials;
 pub mod runtime;
 
 pub use error::{Error, Result};
+#[cfg(feature = "derive")]
 #[doc(hidden)]
 pub use liquid_derive::{
     Display_filter, FilterParameters, FilterReflection, FromFilterParameters, ParseFilter,

--- a/crates/core/src/macros.rs
+++ b/crates/core/src/macros.rs
@@ -388,7 +388,7 @@ macro_rules! call_filter {
         let keyword = Box::new(Vec::new().into_iter());
         let args = $crate::parser::FilterArguments { positional, keyword };
 
-        let runtime = $crate::Runtime::default();
+        let runtime = $crate::runtime::RuntimeBuilder::new().build();
 
         let input = $crate::value!($input);
 

--- a/crates/core/src/model/array/mod.rs
+++ b/crates/core/src/model/array/mod.rs
@@ -98,6 +98,28 @@ impl<T: ValueView> ArrayView for Vec<T> {
     }
 }
 
+impl<'a, A: ArrayView + ?Sized> ArrayView for &'a A {
+    fn as_value(&self) -> &dyn ValueView {
+        <A as ArrayView>::as_value(self)
+    }
+
+    fn size(&self) -> i64 {
+        <A as ArrayView>::size(self)
+    }
+
+    fn values<'k>(&'k self) -> Box<dyn Iterator<Item = &'k dyn ValueView> + 'k> {
+        <A as ArrayView>::values(self)
+    }
+
+    fn contains_key(&self, index: i64) -> bool {
+        <A as ArrayView>::contains_key(self, index)
+    }
+
+    fn get(&self, index: i64) -> Option<&dyn ValueView> {
+        <A as ArrayView>::get(self, index)
+    }
+}
+
 fn convert_value(s: &dyn ValueView) -> &dyn ValueView {
     s
 }

--- a/crates/core/src/model/mod.rs
+++ b/crates/core/src/model/mod.rs
@@ -18,8 +18,10 @@ pub use object::*;
 pub use scalar::*;
 pub use value::*;
 
+#[cfg(feature = "derive")]
 #[doc(hidden)]
 pub use liquid_derive::CoreObjectView as ObjectView;
+#[cfg(feature = "derive")]
 #[doc(hidden)]
 pub use liquid_derive::CoreValueView as ValueView;
 #[doc(hidden)]

--- a/crates/core/src/model/mod.rs
+++ b/crates/core/src/model/mod.rs
@@ -17,3 +17,12 @@ pub use find::*;
 pub use object::*;
 pub use scalar::*;
 pub use value::*;
+
+#[doc(hidden)]
+pub use liquid_derive::CoreObjectView as ObjectView;
+#[doc(hidden)]
+pub use liquid_derive::CoreValueView as ValueView;
+#[doc(hidden)]
+pub use object::ObjectView as _ObjectView;
+#[doc(hidden)]
+pub use value::ValueView as _ValueView;

--- a/crates/core/src/model/mod.rs
+++ b/crates/core/src/model/mod.rs
@@ -4,15 +4,16 @@
 #![warn(missing_debug_implementations)]
 #![warn(unused_extern_crates)]
 
-pub mod array;
-pub mod find;
-pub mod object;
-pub mod scalar;
-pub mod value;
+mod array;
+mod find;
+mod object;
+mod scalar;
+mod value;
 
 mod ser;
 
-pub use array::{Array, ArrayView};
-pub use object::{to_object, Object, ObjectView};
-pub use scalar::{Scalar, ScalarCow};
-pub use value::{to_value, State, Value, ValueCow, ValueView};
+pub use array::*;
+pub use find::*;
+pub use object::*;
+pub use scalar::*;
+pub use value::*;

--- a/crates/core/src/model/object/map.rs
+++ b/crates/core/src/model/object/map.rs
@@ -1,3 +1,5 @@
+//! Type representing a Liquid object, payload of the `Value::Object` variant
+
 use std::borrow::Borrow;
 use std::collections::hash_map;
 use std::fmt::{self, Debug};
@@ -446,7 +448,7 @@ impl<'a> VacantEntry<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// use liquid_core::model::object::Entry;
+    /// use liquid_core::model::map::Entry;
     ///
     /// let mut map = liquid_core::model::Object::new();
     ///
@@ -468,7 +470,7 @@ impl<'a> VacantEntry<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// use liquid_core::model::object::Entry;
+    /// use liquid_core::model::map::Entry;
     ///
     /// let mut map = liquid_core::model::Object::new();
     ///
@@ -491,7 +493,7 @@ impl<'a> OccupiedEntry<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// use liquid_core::model::object::Entry;
+    /// use liquid_core::model::map::Entry;
     ///
     /// let mut map = liquid_core::model::Object::new();
     /// map.insert("liquid".into(), liquid_core::value!(12));
@@ -513,7 +515,7 @@ impl<'a> OccupiedEntry<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// use liquid_core::model::object::Entry;
+    /// use liquid_core::model::map::Entry;
     ///
     /// let mut map = liquid_core::model::Object::new();
     /// map.insert("liquid".into(), liquid_core::value!(12));
@@ -537,7 +539,7 @@ impl<'a> OccupiedEntry<'a> {
     /// ```rust
     /// # use liquid_core::model::ValueView;
     /// #
-    /// use liquid_core::model::object::Entry;
+    /// use liquid_core::model::map::Entry;
     ///
     /// let mut map = liquid_core::model::Object::new();
     /// map.insert("liquid".into(), liquid_core::value!([1, 2, 3]));
@@ -561,7 +563,7 @@ impl<'a> OccupiedEntry<'a> {
     /// ```rust
     /// # use liquid_core::model::ValueView;
     /// #
-    /// use liquid_core::model::object::Entry;
+    /// use liquid_core::model::map::Entry;
     ///
     /// let mut map = liquid_core::model::Object::new();
     /// map.insert("liquid".into(), liquid_core::value!([1, 2, 3]));
@@ -584,7 +586,7 @@ impl<'a> OccupiedEntry<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// use liquid_core::model::object::Entry;
+    /// use liquid_core::model::map::Entry;
     ///
     /// let mut map = liquid_core::model::Object::new();
     /// map.insert("liquid".into(), liquid_core::value!(12));
@@ -607,7 +609,7 @@ impl<'a> OccupiedEntry<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// use liquid_core::model::object::Entry;
+    /// use liquid_core::model::map::Entry;
     ///
     /// let mut map = liquid_core::model::Object::new();
     /// map.insert("liquid".into(), liquid_core::value!(12));

--- a/crates/core/src/model/object/mod.rs
+++ b/crates/core/src/model/object/mod.rs
@@ -154,6 +154,18 @@ impl ObjectIndex for kstring::KString {
     }
 }
 
+impl<'s> ObjectIndex for kstring::KStringRef<'s> {
+    fn as_index(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl<'s> ObjectIndex for kstring::KStringCow<'s> {
+    fn as_index(&self) -> &str {
+        self.as_str()
+    }
+}
+
 impl<K: ObjectIndex, V: ValueView, S: ::std::hash::BuildHasher> ValueView for HashMap<K, V, S> {
     fn as_debug(&self) -> &dyn fmt::Debug {
         self

--- a/crates/core/src/model/object/mod.rs
+++ b/crates/core/src/model/object/mod.rs
@@ -1,6 +1,6 @@
 //! Type representing a Liquid object, payload of the `Value::Object` variant
 
-mod map;
+pub mod map;
 mod ser;
 
 use std::collections::BTreeMap;
@@ -13,7 +13,7 @@ use crate::model::value::DisplayCow;
 use crate::model::State;
 use crate::model::{Value, ValueView};
 
-pub use map::*;
+pub use map::Object;
 pub use ser::to_object;
 
 /// Accessor for objects.

--- a/crates/core/src/model/object/mod.rs
+++ b/crates/core/src/model/object/mod.rs
@@ -104,6 +104,36 @@ impl ObjectView for Object {
     }
 }
 
+impl<'o, O: ObjectView + ?Sized> ObjectView for &'o O {
+    fn as_value(&self) -> &dyn ValueView {
+        <O as ObjectView>::as_value(self)
+    }
+
+    fn size(&self) -> i64 {
+        <O as ObjectView>::size(self)
+    }
+
+    fn keys<'k>(&'k self) -> Box<dyn Iterator<Item = KStringCow<'k>> + 'k> {
+        <O as ObjectView>::keys(self)
+    }
+
+    fn values<'k>(&'k self) -> Box<dyn Iterator<Item = &'k dyn ValueView> + 'k> {
+        <O as ObjectView>::values(self)
+    }
+
+    fn iter<'k>(&'k self) -> Box<dyn Iterator<Item = (KStringCow<'k>, &'k dyn ValueView)> + 'k> {
+        <O as ObjectView>::iter(self)
+    }
+
+    fn contains_key(&self, index: &str) -> bool {
+        <O as ObjectView>::contains_key(self, index)
+    }
+
+    fn get<'s>(&'s self, index: &str) -> Option<&'s dyn ValueView> {
+        <O as ObjectView>::get(self, index)
+    }
+}
+
 /// Owned object index
 pub trait ObjectIndex:
     fmt::Debug + fmt::Display + Ord + std::hash::Hash + Eq + std::borrow::Borrow<str>

--- a/crates/core/src/model/scalar/ser.rs
+++ b/crates/core/src/model/scalar/ser.rs
@@ -11,7 +11,7 @@ use crate::model::Scalar;
 ///
 /// ```rust
 /// let s = "foo";
-/// let value = liquid_core::model::scalar::to_scalar(&s).unwrap();
+/// let value = liquid_core::model::to_scalar(&s).unwrap();
 /// assert_eq!(value, liquid_core::model::Scalar::new(s));
 /// ```
 pub fn to_scalar<T>(value: &T) -> Result<Scalar, crate::error::Error>

--- a/crates/core/src/model/value/view.rs
+++ b/crates/core/src/model/value/view.rs
@@ -73,6 +73,52 @@ pub trait ValueView: fmt::Debug {
     }
 }
 
+impl<'v, V: ValueView + ?Sized> ValueView for &'v V {
+    fn as_debug(&self) -> &dyn fmt::Debug {
+        <V as ValueView>::as_debug(self)
+    }
+
+    fn render(&self) -> DisplayCow<'_> {
+        <V as ValueView>::render(self)
+    }
+    fn source(&self) -> DisplayCow<'_> {
+        <V as ValueView>::source(self)
+    }
+    fn type_name(&self) -> &'static str {
+        <V as ValueView>::type_name(self)
+    }
+    fn query_state(&self, state: State) -> bool {
+        <V as ValueView>::query_state(self, state)
+    }
+
+    fn to_kstr(&self) -> KStringCow<'_> {
+        <V as ValueView>::to_kstr(self)
+    }
+    fn to_value(&self) -> Value {
+        <V as ValueView>::to_value(self)
+    }
+
+    fn as_scalar(&self) -> Option<ScalarCow<'_>> {
+        <V as ValueView>::as_scalar(self)
+    }
+
+    fn as_array(&self) -> Option<&dyn ArrayView> {
+        <V as ValueView>::as_array(self)
+    }
+
+    fn as_object(&self) -> Option<&dyn ObjectView> {
+        <V as ValueView>::as_object(self)
+    }
+
+    fn as_state(&self) -> Option<State> {
+        <V as ValueView>::as_state(self)
+    }
+
+    fn is_nil(&self) -> bool {
+        <V as ValueView>::is_nil(self)
+    }
+}
+
 static NIL: Value = Value::Nil;
 
 impl<T: ValueView> ValueView for Option<T> {

--- a/crates/core/src/parser/filter.rs
+++ b/crates/core/src/parser/filter.rs
@@ -58,7 +58,7 @@ pub trait FilterReflection {
 pub trait FilterParameters<'a>: Sized + FilterParametersReflection + Debug + Display {
     type EvaluatedFilterParameters;
     fn from_args(args: FilterArguments) -> Result<Self>;
-    fn evaluate(&'a self, runtime: &'a Runtime) -> Result<Self::EvaluatedFilterParameters>;
+    fn evaluate(&'a self, runtime: &'a dyn Runtime) -> Result<Self::EvaluatedFilterParameters>;
 }
 
 /// Structure that holds the unparsed arguments of a filter, both positional and keyword.
@@ -94,7 +94,7 @@ pub struct FilterArguments<'a> {
 /// struct AbsFilter; // There are no parameters, so implements `Default`.
 ///
 /// impl Filter for AbsFilter {
-///     fn evaluate(&self, input: &dyn  ValueView, _runtime: &Runtime) -> Result<Value> {
+///     fn evaluate(&self, input: &dyn  ValueView, _runtime: &dyn Runtime) -> Result<Value> {
 ///         // Implementation of the filter here
 ///     }
 /// }
@@ -110,7 +110,7 @@ pub struct FilterArguments<'a> {
 /// }
 ///
 /// impl Filter for AtLeastFilter {
-///     fn evaluate(&self, input: &ValueViwe, runtime: &Runtime) -> Result<Value> {
+///     fn evaluate(&self, input: &ValueViwe, runtime: &dyn Runtime) -> Result<Value> {
 ///         // Evaluate the `FilterParameters`
 ///         let args = self.args.evaluate(runtime)?;
 ///
@@ -132,7 +132,7 @@ pub struct FilterArguments<'a> {
 /// }
 ///
 /// impl Filter for AtLeastFilter {
-///     fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime) -> Result<Value> {
+///     fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
 ///         // Evaluate the `FilterParameters`
 ///         let args = self.args.evaluate(runtime)?;
 ///
@@ -142,7 +142,7 @@ pub struct FilterArguments<'a> {
 /// ```
 pub trait Filter: Send + Sync + Debug + Display {
     // This will evaluate the expressions and evaluate the filter.
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime) -> Result<Value>;
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value>;
 }
 
 /// A trait to register a new filter in the `liquid::Parser`.

--- a/crates/core/src/parser/filter_chain.rs
+++ b/crates/core/src/parser/filter_chain.rs
@@ -22,7 +22,7 @@ impl FilterChain {
     }
 
     /// Process `Value` expression within `runtime`'s stack.
-    pub fn evaluate<'s>(&'s self, runtime: &'s Runtime) -> Result<ValueCow<'s>> {
+    pub fn evaluate<'s>(&'s self, runtime: &'s dyn Runtime) -> Result<ValueCow<'s>> {
         // take either the provided value or the value from the provided variable
         let mut entry = self.entry.evaluate(runtime)?;
 
@@ -55,7 +55,7 @@ impl fmt::Display for FilterChain {
 }
 
 impl Renderable for FilterChain {
-    fn render_to(&self, writer: &mut dyn Write, runtime: &mut Runtime) -> Result<()> {
+    fn render_to(&self, writer: &mut dyn Write, runtime: &dyn Runtime) -> Result<()> {
         let entry = self.evaluate(runtime)?;
         write!(writer, "{}", entry.render()).replace("Failed to render")?;
         Ok(())

--- a/crates/core/src/parser/parser.rs
+++ b/crates/core/src/parser/parser.rs
@@ -1032,7 +1032,7 @@ impl<'a> TagToken<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::runtime::{Runtime, Template};
+    use crate::runtime::{Runtime, RuntimeBuilder, Template};
 
     #[test]
     fn test_parse_literal() {
@@ -1135,30 +1135,30 @@ mod test {
     fn test_whitespace_control() {
         let options = Language::default();
 
-        let mut runtime = Runtime::new();
-        runtime.stack_mut().set_global("exp", Value::scalar(5));
+        let runtime = RuntimeBuilder::new().build();
+        runtime.set_global("exp".into(), Value::scalar(5));
 
         let text = "    \n    {{ exp }}    \n    ";
         let template = parse(text, &options).map(Template::new).unwrap();
-        let output = template.render(&mut runtime).unwrap();
+        let output = template.render(&runtime).unwrap();
 
         assert_eq!(output, "    \n    5    \n    ");
 
         let text = "    \n    {{- exp }}    \n    ";
         let template = parse(text, &options).map(Template::new).unwrap();
-        let output = template.render(&mut runtime).unwrap();
+        let output = template.render(&runtime).unwrap();
 
         assert_eq!(output, "5    \n    ");
 
         let text = "    \n    {{ exp -}}    \n    ";
         let template = parse(text, &options).map(Template::new).unwrap();
-        let output = template.render(&mut runtime).unwrap();
+        let output = template.render(&runtime).unwrap();
 
         assert_eq!(output, "    \n    5");
 
         let text = "    \n    {{- exp -}}    \n    ";
         let template = parse(text, &options).map(Template::new).unwrap();
-        let output = template.render(&mut runtime).unwrap();
+        let output = template.render(&runtime).unwrap();
 
         assert_eq!(output, "5");
     }

--- a/crates/core/src/parser/text.rs
+++ b/crates/core/src/parser/text.rs
@@ -18,7 +18,7 @@ impl Text {
 }
 
 impl Renderable for Text {
-    fn render_to(&self, writer: &mut dyn Write, _runtime: &mut Runtime) -> Result<()> {
+    fn render_to(&self, writer: &mut dyn Write, _runtime: &dyn Runtime) -> Result<()> {
         write!(writer, "{}", &self.text).replace("Failed to render")?;
         Ok(())
     }

--- a/crates/core/src/runtime/expression.rs
+++ b/crates/core/src/runtime/expression.rs
@@ -41,23 +41,23 @@ impl Expression {
     }
 
     /// Convert to a `Value`.
-    pub fn try_evaluate<'c>(&'c self, runtime: &'c Runtime<'_>) -> Option<ValueCow<'c>> {
+    pub fn try_evaluate<'c>(&'c self, runtime: &'c dyn Runtime) -> Option<ValueCow<'c>> {
         match self {
             Expression::Literal(ref x) => Some(ValueCow::Borrowed(x)),
             Expression::Variable(ref x) => {
                 let path = x.try_evaluate(runtime)?;
-                runtime.stack().try_get(&path)
+                runtime.try_get(&path)
             }
         }
     }
 
     /// Convert to a `Value`.
-    pub fn evaluate<'c>(&'c self, runtime: &'c Runtime<'_>) -> Result<ValueCow<'c>> {
+    pub fn evaluate<'c>(&'c self, runtime: &'c dyn Runtime) -> Result<ValueCow<'c>> {
         let val = match self {
             Expression::Literal(ref x) => ValueCow::Borrowed(x),
             Expression::Variable(ref x) => {
                 let path = x.evaluate(runtime)?;
-                runtime.stack().get(&path)?
+                runtime.get(&path)?
             }
         };
         Ok(val)

--- a/crates/core/src/runtime/renderable.rs
+++ b/crates/core/src/runtime/renderable.rs
@@ -8,12 +8,12 @@ use super::Runtime;
 /// Any object (tag/block) that can be rendered by liquid must implement this trait.
 pub trait Renderable: Send + Sync + Debug {
     /// Renders the Renderable instance given a Liquid runtime.
-    fn render(&self, runtime: &mut Runtime<'_>) -> Result<String> {
+    fn render(&self, runtime: &dyn Runtime) -> Result<String> {
         let mut data = Vec::new();
         self.render_to(&mut data, runtime)?;
         Ok(String::from_utf8(data).expect("render only writes UTF-8"))
     }
 
     /// Renders the Renderable instance given a Liquid runtime.
-    fn render_to(&self, writer: &mut dyn Write, runtime: &mut Runtime<'_>) -> Result<()>;
+    fn render_to(&self, writer: &mut dyn Write, runtime: &dyn Runtime) -> Result<()>;
 }

--- a/crates/core/src/runtime/runtime.rs
+++ b/crates/core/src/runtime/runtime.rs
@@ -131,10 +131,10 @@ impl ValueView for NullObject {
         self
     }
 
-    fn render(&self) -> crate::model::value::DisplayCow<'_> {
+    fn render(&self) -> crate::model::DisplayCow<'_> {
         Value::Nil.render()
     }
-    fn source(&self) -> crate::model::value::DisplayCow<'_> {
+    fn source(&self) -> crate::model::DisplayCow<'_> {
         Value::Nil.source()
     }
     fn type_name(&self) -> &'static str {
@@ -366,9 +366,9 @@ impl PartialStore for NullPartials {
 mod test {
     use super::*;
 
-    use crate::model::value::ValueViewCmp;
     use crate::model::Scalar;
     use crate::model::Value;
+    use crate::model::ValueViewCmp;
 
     #[test]
     fn mask_variables() {

--- a/crates/core/src/runtime/runtime.rs
+++ b/crates/core/src/runtime/runtime.rs
@@ -2,19 +2,234 @@ use std::sync;
 
 use crate::error::Error;
 use crate::error::Result;
-use crate::model::ObjectView;
+use crate::model::{ObjectView, Scalar, ScalarCow, Value, ValueCow, ValueView};
 
 use super::PartialStore;
 use super::Renderable;
-use super::Stack;
 
-/// Block processing interrupt state.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Interrupt {
-    /// Restart processing the current block.
-    Continue,
-    /// Stop processing the current block.
-    Break,
+/// State for rendering a template
+pub trait Runtime {
+    /// Partial templates for inclusion.
+    fn partials(&self) -> &dyn PartialStore;
+
+    /// The name of the currently active template.
+    fn name(&self) -> Option<kstring::KStringRef<'_>>;
+
+    /// All available values
+    fn roots<'r>(&'r self) -> std::collections::BTreeSet<kstring::KStringCow<'r>>;
+    /// Recursively index into the stack.
+    fn try_get(&self, path: &[ScalarCow<'_>]) -> Option<ValueCow<'_>>;
+    /// Recursively index into the stack.
+    fn get(&self, path: &[ScalarCow<'_>]) -> Result<ValueCow<'_>>;
+
+    /// Sets a value in the global runtime.
+    fn set_global(
+        &self,
+        name: kstring::KString,
+        val: crate::model::Value,
+    ) -> Option<crate::model::Value>;
+
+    /// Used by increment and decrement tags
+    fn set_index(&self, name: kstring::KString, val: Value) -> Option<Value>;
+    /// Used by increment and decrement tags
+    fn get_index<'a>(&'a self, name: &str) -> Option<ValueCow<'a>>;
+
+    /// Unnamed state for plugins during rendering
+    fn registers(&self) -> &Registers;
+}
+
+impl Runtime for Box<dyn Runtime> {
+    fn partials(&self) -> &dyn super::PartialStore {
+        self.as_ref().partials()
+    }
+
+    fn name(&self) -> Option<kstring::KStringRef<'_>> {
+        self.as_ref().name()
+    }
+
+    fn roots<'r>(&'r self) -> std::collections::BTreeSet<kstring::KStringCow<'r>> {
+        self.as_ref().roots()
+    }
+
+    fn try_get(&self, path: &[ScalarCow<'_>]) -> Option<ValueCow<'_>> {
+        self.as_ref().try_get(path)
+    }
+
+    fn get(&self, path: &[ScalarCow<'_>]) -> Result<ValueCow<'_>> {
+        self.as_ref().get(path)
+    }
+
+    fn set_global(
+        &self,
+        name: kstring::KString,
+        val: crate::model::Value,
+    ) -> Option<crate::model::Value> {
+        self.as_ref().set_global(name, val)
+    }
+
+    fn set_index(&self, name: kstring::KString, val: Value) -> Option<Value> {
+        self.as_ref().set_index(name, val)
+    }
+
+    fn get_index<'a>(&'a self, name: &str) -> Option<ValueCow<'a>> {
+        self.as_ref().get_index(name)
+    }
+
+    fn registers(&self) -> &super::Registers {
+        self.as_ref().registers()
+    }
+}
+
+/// Create processing runtime for a template.
+pub struct RuntimeBuilder<'g, 'p> {
+    globals: Option<&'g dyn ObjectView>,
+    partials: Option<&'p dyn PartialStore>,
+}
+
+impl<'c, 'g: 'c, 'p: 'c> RuntimeBuilder<'g, 'p> {
+    /// Creates a new, empty rendering runtime.
+    pub fn new() -> Self {
+        Self {
+            globals: None,
+            partials: None,
+        }
+    }
+
+    /// Initialize the stack with the given globals.
+    pub fn set_globals<'n>(self, values: &'n dyn ObjectView) -> RuntimeBuilder<'n, 'p> {
+        RuntimeBuilder {
+            globals: Some(values),
+            partials: self.partials,
+        }
+    }
+
+    /// Initialize partial-templates availible for including.
+    pub fn set_partials<'n>(self, values: &'n dyn PartialStore) -> RuntimeBuilder<'g, 'n> {
+        RuntimeBuilder {
+            globals: self.globals,
+            partials: Some(values),
+        }
+    }
+
+    /// Create the `Runtime`.
+    pub fn build(self) -> impl Runtime + 'c {
+        let partials = self.partials.unwrap_or(&NullPartials);
+        let mut runtime = RuntimeCore::default();
+        runtime.partials = partials;
+        let runtime = super::IndexFrame::new(runtime);
+        let runtime = super::ConstantFrame::new(runtime, self.globals);
+        let runtime = super::GlobalFrame::new(runtime);
+        runtime
+    }
+}
+
+impl Default for RuntimeBuilder<'static, 'static> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Processing runtime for a template.
+pub struct RuntimeCore<'g> {
+    partials: &'g dyn PartialStore,
+
+    registers: Registers,
+}
+
+impl<'g> RuntimeCore<'g> {
+    /// Create a default `RuntimeCore`.
+    ///
+    /// See `RuntimeBuilder` for more control.
+    pub fn new() -> Self {
+        RuntimeCore::default()
+    }
+
+    /// Partial templates for inclusion.
+    pub fn partials(&self) -> &dyn PartialStore {
+        self.partials
+    }
+}
+
+impl<'g> Runtime for RuntimeCore<'g> {
+    fn partials(&self) -> &dyn PartialStore {
+        self.partials
+    }
+
+    fn name(&self) -> Option<kstring::KStringRef<'_>> {
+        None
+    }
+
+    fn roots<'r>(&'r self) -> std::collections::BTreeSet<kstring::KStringCow<'r>> {
+        // Indexes don't count
+        std::collections::BTreeSet::new()
+    }
+
+    fn try_get(&self, _path: &[ScalarCow<'_>]) -> Option<ValueCow<'_>> {
+        None
+    }
+
+    fn get(&self, path: &[ScalarCow<'_>]) -> Result<ValueCow<'_>> {
+        let key = path.first().cloned().unwrap_or_else(|| Scalar::new("nil"));
+        Error::with_msg("Unknown variable")
+            .context("requested variable", key.to_kstr())
+            .into_err()
+    }
+
+    fn set_global(
+        &self,
+        _name: kstring::KString,
+        _val: crate::model::Value,
+    ) -> Option<crate::model::Value> {
+        unreachable!("Must be masked by a global frame");
+    }
+
+    fn set_index(&self, _name: kstring::KString, _val: Value) -> Option<Value> {
+        unreachable!("Must be masked by a global frame");
+    }
+
+    fn get_index<'a>(&'a self, _name: &str) -> Option<ValueCow<'a>> {
+        None
+    }
+
+    fn registers(&self) -> &Registers {
+        &self.registers
+    }
+}
+
+impl<'g> Default for RuntimeCore<'g> {
+    fn default() -> Self {
+        Self {
+            partials: &NullPartials,
+            registers: Default::default(),
+        }
+    }
+}
+
+/// Unnamed state for plugins during rendering
+pub struct Registers {
+    registers: std::cell::RefCell<anymap::AnyMap>,
+}
+
+impl Registers {
+    /// Data store for stateful tags/blocks.
+    ///
+    /// If a plugin needs state, it creates a `struct Register : Default` and accesses it via
+    /// `get_mut`.
+    pub fn get_mut<T: anymap::any::IntoBox<dyn anymap::any::Any> + Default>(
+        &self,
+    ) -> std::cell::RefMut<'_, T> {
+        std::cell::RefMut::map(self.registers.borrow_mut(), |registers| {
+            registers.entry::<T>().or_insert_with(Default::default)
+        })
+    }
+}
+
+impl Default for Registers {
+    fn default() -> Self {
+        Self {
+            registers: std::cell::RefCell::new(anymap::AnyMap::new()),
+        }
+    }
 }
 
 /// The current interrupt state. The interrupt state is used by
@@ -23,27 +238,34 @@ pub enum Interrupt {
 /// it reaches an enclosing `for_loop`. At that point the interrupt
 /// is cleared, and the `for_loop` carries on processing as directed.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct InterruptState {
+pub struct InterruptRegister {
     interrupt: Option<Interrupt>,
 }
 
-impl InterruptState {
+impl InterruptRegister {
     /// An interrupt state is active.
     pub fn interrupted(&self) -> bool {
         self.interrupt.is_some()
     }
 
     /// Sets the interrupt state. Any previous state is obliterated.
-    pub fn set_interrupt(&mut self, interrupt: Interrupt) {
-        self.interrupt = Some(interrupt);
+    pub fn set(&mut self, interrupt: Interrupt) {
+        self.interrupt.replace(interrupt);
     }
 
     /// Fetches and clears the interrupt state.
-    pub fn pop_interrupt(&mut self) -> Option<Interrupt> {
-        let rval = self.interrupt;
-        self.interrupt = None;
-        rval
+    pub fn reset(&mut self) -> Option<Interrupt> {
+        self.interrupt.take()
     }
+}
+
+/// Block processing interrupt state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Interrupt {
+    /// Restart processing the current block.
+    Continue,
+    /// Stop processing the current block.
+    Break,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -67,152 +289,6 @@ impl PartialStore for NullPartials {
     }
 }
 
-/// Create processing runtime for a template.
-pub struct RuntimeBuilder<'g> {
-    globals: Option<&'g dyn ObjectView>,
-    partials: Option<&'g dyn PartialStore>,
-}
-
-impl<'g> RuntimeBuilder<'g> {
-    /// Creates a new, empty rendering runtime.
-    pub fn new() -> Self {
-        Self {
-            globals: None,
-            partials: None,
-        }
-    }
-
-    /// Initialize the stack with the given globals.
-    pub fn set_globals(mut self, values: &'g dyn ObjectView) -> Self {
-        self.globals = Some(values);
-        self
-    }
-
-    /// Initialize partial-templates availible for including.
-    pub fn set_partials(mut self, values: &'g dyn PartialStore) -> Self {
-        self.partials = Some(values);
-        self
-    }
-
-    /// Create the `Runtime`.
-    pub fn build(self) -> Runtime<'g> {
-        let stack = match self.globals {
-            Some(globals) => Stack::with_globals(globals),
-            None => Stack::empty(),
-        };
-        let partials = self.partials.unwrap_or(&NullPartials);
-        Runtime {
-            stack,
-            partials,
-            registers: anymap::AnyMap::new(),
-            interrupt: InterruptState::default(),
-        }
-    }
-}
-
-impl<'g> Default for RuntimeBuilder<'g> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-/// Processing runtime for a template.
-pub struct Runtime<'g> {
-    stack: Stack<'g>,
-    partials: &'g dyn PartialStore,
-
-    registers: anymap::AnyMap,
-    interrupt: InterruptState,
-}
-
-impl<'g> Runtime<'g> {
-    /// Create a default `Runtime`.
-    ///
-    /// See `RuntimeBuilder` for more control.
-    pub fn new() -> Self {
-        Runtime::default()
-    }
-
-    /// Access the block's `InterruptState`.
-    pub fn interrupt(&self) -> &InterruptState {
-        &self.interrupt
-    }
-
-    /// Access the block's `InterruptState`.
-    pub fn interrupt_mut(&mut self) -> &mut InterruptState {
-        &mut self.interrupt
-    }
-
-    /// Partial templates for inclusion.
-    pub fn partials(&self) -> &dyn PartialStore {
-        self.partials
-    }
-
-    /// Data store for stateful tags/blocks.
-    ///
-    /// If a plugin needs state, it creates a `struct State : Default` and accesses it via
-    /// `get_register_mut`.
-    pub fn get_register_mut<T: anymap::any::IntoBox<dyn anymap::any::Any> + Default>(
-        &mut self,
-    ) -> &mut T {
-        self.registers.entry::<T>().or_insert_with(Default::default)
-    }
-
-    /// Access the current `Stack`.
-    pub fn stack(&self) -> &Stack<'_> {
-        &self.stack
-    }
-
-    /// Access the current `Stack`.
-    pub fn stack_mut<'a>(&'a mut self) -> &'a mut Stack<'g>
-    where
-        'g: 'a,
-    {
-        &mut self.stack
-    }
-
-    /// Sets up a new stack frame, executes the supplied function and then
-    /// tears the stack frame down before returning the function's result
-    /// to the caller.
-    pub fn run_in_scope<RvalT, FnT>(&mut self, f: FnT) -> RvalT
-    where
-        FnT: FnOnce(&mut Runtime<'_>) -> RvalT,
-    {
-        self.stack.push_frame();
-        let result = f(self);
-        self.stack.pop_frame();
-        result
-    }
-
-    /// Sets up a new stack frame, executes the supplied function and then
-    /// tears the stack frame down before returning the function's result
-    /// to the caller.
-    pub fn run_in_named_scope<RvalT, S: Into<kstring::KString>, FnT>(
-        &mut self,
-        name: S,
-        f: FnT,
-    ) -> RvalT
-    where
-        FnT: FnOnce(&mut Runtime<'_>) -> RvalT,
-    {
-        self.stack.push_named_frame(name);
-        let result = f(self);
-        self.stack.pop_frame();
-        result
-    }
-}
-
-impl<'g> Default for Runtime<'g> {
-    fn default() -> Self {
-        Self {
-            stack: Stack::empty(),
-            partials: &NullPartials,
-            registers: anymap::AnyMap::new(),
-            interrupt: InterruptState::default(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -222,44 +298,40 @@ mod test {
     use crate::model::Value;
 
     #[test]
-    fn scoped_variables() {
+    fn mask_variables() {
         let test_path = [Scalar::new("test")];
-        let global_path = [Scalar::new("global")];
 
-        let mut rt = Runtime::new();
-        rt.stack_mut().set_global("test", Value::scalar(42f64));
-        assert_eq!(
-            &rt.stack().get(&test_path).unwrap(),
-            &ValueViewCmp::new(&42f64)
-        );
+        let rt = RuntimeBuilder::new().build();
+        rt.set_global("test".into(), Value::scalar(42f64));
+        assert_eq!(&rt.get(&test_path).unwrap(), &ValueViewCmp::new(&42f64));
 
-        rt.run_in_scope(|new_scope| {
+        {
+            let data = crate::object!({"test": 3});
+            let new_scope = super::super::StackFrame::new(&rt, &data);
+
             // assert that values are chained to the parent scope
-            assert_eq!(
-                &new_scope.stack().get(&test_path).unwrap(),
-                &ValueViewCmp::new(&42)
-            );
-
-            // set a new local value, and assert that it overrides the previous value
-            new_scope.stack_mut().set("test", Value::scalar(3));
-            assert_eq!(
-                &new_scope.stack().get(&test_path).unwrap(),
-                &ValueViewCmp::new(&3)
-            );
-
-            // sat a new val that we will pick up outside the scope
-            new_scope
-                .stack_mut()
-                .set_global("global", Value::scalar("some value"));
-        });
+            assert_eq!(&new_scope.get(&test_path).unwrap(), &ValueViewCmp::new(&3));
+        }
 
         // assert that the value has reverted to the old one
+        assert_eq!(&rt.get(&test_path).unwrap(), &ValueViewCmp::new(&42));
+    }
+
+    #[test]
+    fn global_variables() {
+        let global_path = [Scalar::new("global")];
+
+        let rt = RuntimeBuilder::new().build();
+
+        {
+            let data = crate::object!({"test": 3});
+            let new_scope = super::super::StackFrame::new(&rt, &data);
+
+            // sat a new val that we will pick up outside the scope
+            new_scope.set_global("global".into(), Value::scalar("some value"));
+        }
         assert_eq!(
-            &rt.stack().get(&test_path).unwrap(),
-            &ValueViewCmp::new(&42)
-        );
-        assert_eq!(
-            &rt.stack().get(&global_path).unwrap(),
+            &rt.get(&global_path).unwrap(),
             &ValueViewCmp::new(&"some value")
         );
     }

--- a/crates/core/src/runtime/stack.rs
+++ b/crates/core/src/runtime/stack.rs
@@ -38,7 +38,7 @@ impl<P: super::Runtime, O: ObjectView> super::Runtime for StackFrame<P, O> {
             .or_else(|| self.parent.name())
     }
 
-    fn roots<'r>(&'r self) -> std::collections::BTreeSet<kstring::KStringCow<'r>> {
+    fn roots(&self) -> std::collections::BTreeSet<kstring::KStringCow<'_>> {
         let mut roots = self.parent.roots();
         roots.extend(self.data.keys());
         roots
@@ -112,7 +112,7 @@ impl<P: super::Runtime> super::Runtime for GlobalFrame<P> {
         self.parent.name()
     }
 
-    fn roots<'r>(&'r self) -> std::collections::BTreeSet<kstring::KStringCow<'r>> {
+    fn roots(&self) -> std::collections::BTreeSet<kstring::KStringCow<'_>> {
         let mut roots = self.parent.roots();
         roots.extend(self.data.borrow().keys().map(|k| k.clone().into()));
         roots
@@ -187,7 +187,7 @@ impl<P: super::Runtime> super::Runtime for IndexFrame<P> {
         self.parent.name()
     }
 
-    fn roots<'r>(&'r self) -> std::collections::BTreeSet<kstring::KStringCow<'r>> {
+    fn roots(&self) -> std::collections::BTreeSet<kstring::KStringCow<'_>> {
         let mut roots = self.parent.roots();
         roots.extend(self.data.borrow().keys().map(|k| k.clone().into()));
         roots

--- a/crates/core/src/runtime/stack.rs
+++ b/crates/core/src/runtime/stack.rs
@@ -49,7 +49,7 @@ impl<P: super::Runtime, O: ObjectView> super::Runtime for StackFrame<P, O> {
         let key = key.to_kstr();
         let data = &self.data;
         if data.contains_key(key.as_str()) {
-            crate::model::find::try_find(data.as_value(), path)
+            crate::model::try_find(data.as_value(), path)
         } else {
             self.parent.try_get(path)
         }
@@ -62,7 +62,7 @@ impl<P: super::Runtime, O: ObjectView> super::Runtime for StackFrame<P, O> {
         let key = key.to_kstr();
         let data = &self.data;
         if data.contains_key(key.as_str()) {
-            crate::model::find::find(data.as_value(), path).map(|v| v.into_owned().into())
+            crate::model::find(data.as_value(), path).map(|v| v.into_owned().into())
         } else {
             self.parent.get(path)
         }
@@ -123,7 +123,7 @@ impl<P: super::Runtime> super::Runtime for GlobalFrame<P> {
         let key = key.to_kstr();
         let data = self.data.borrow();
         if data.contains_key(key.as_str()) {
-            crate::model::find::try_find(data.as_value(), path).map(|v| v.into_owned().into())
+            crate::model::try_find(data.as_value(), path).map(|v| v.into_owned().into())
         } else {
             self.parent.try_get(path)
         }
@@ -136,7 +136,7 @@ impl<P: super::Runtime> super::Runtime for GlobalFrame<P> {
         let key = key.to_kstr();
         let data = self.data.borrow();
         if data.contains_key(key.as_str()) {
-            crate::model::find::find(data.as_value(), path).map(|v| v.into_owned().into())
+            crate::model::find(data.as_value(), path).map(|v| v.into_owned().into())
         } else {
             self.parent.get(path)
         }
@@ -198,7 +198,7 @@ impl<P: super::Runtime> super::Runtime for IndexFrame<P> {
         let key = key.to_kstr();
         let data = self.data.borrow();
         if data.contains_key(key.as_str()) {
-            crate::model::find::try_find(data.as_value(), path).map(|v| v.into_owned().into())
+            crate::model::try_find(data.as_value(), path).map(|v| v.into_owned().into())
         } else {
             self.parent.try_get(path)
         }
@@ -211,7 +211,7 @@ impl<P: super::Runtime> super::Runtime for IndexFrame<P> {
         let key = key.to_kstr();
         let data = self.data.borrow();
         if data.contains_key(key.as_str()) {
-            crate::model::find::find(data.as_value(), path).map(|v| v.into_owned().into())
+            crate::model::find(data.as_value(), path).map(|v| v.into_owned().into())
         } else {
             self.parent.get(path)
         }

--- a/crates/core/src/runtime/stack.rs
+++ b/crates/core/src/runtime/stack.rs
@@ -1,232 +1,314 @@
-use crate::error::{Error, Result};
-use crate::model::{Object, ObjectView, Scalar, ScalarCow, Value, ValueCow, ValueView};
+use crate::error::Error;
+use crate::error::Result;
+use crate::model::{Object, ObjectView, ScalarCow, Value, ValueCow, ValueView};
 
-#[derive(Clone, Default, Debug)]
-struct Frame {
+/// Layer variables on top of the existing runtime
+pub struct StackFrame<'p, 'o> {
+    parent: &'p dyn super::Runtime,
     name: Option<kstring::KString>,
-    data: Object,
+    data: &'o dyn ObjectView,
 }
 
-impl Frame {
-    fn new() -> Self {
-        Default::default()
-    }
-
-    fn with_name<S: Into<kstring::KString>>(name: S) -> Self {
+impl<'p, 'o> StackFrame<'p, 'o> {
+    /// Layer variables on top of the existing runtime
+    pub fn new(parent: &'p dyn super::Runtime, data: &'o dyn ObjectView) -> Self {
         Self {
-            name: Some(name.into()),
-            data: Object::new(),
+            parent,
+            name: None,
+            data,
         }
+    }
+
+    /// Name the current context
+    pub fn with_name<S: Into<kstring::KString>>(mut self, name: S) -> Self {
+        self.name = Some(name.into());
+        self
     }
 }
 
-/// Stack of variables.
-#[derive(Debug, Clone)]
-pub struct Stack<'g> {
-    globals: Option<&'g dyn ObjectView>,
-    stack: Vec<Frame>,
-    // State of variables created through increment or decrement tags.
-    indexes: Object,
-}
-
-impl<'g> Stack<'g> {
-    /// Create an empty stack
-    pub fn empty() -> Self {
-        Self {
-            globals: None,
-            indexes: Object::new(),
-            // Mutable frame for globals.
-            stack: vec![Frame::new()],
-        }
+impl<'p, 'o> super::Runtime for StackFrame<'p, 'o> {
+    fn partials(&self) -> &dyn super::PartialStore {
+        self.parent.partials()
     }
 
-    /// Create a stack initialized with read-only `ObjectView`.
-    pub fn with_globals(globals: &'g dyn ObjectView) -> Self {
-        let mut stack = Self::empty();
-        stack.globals = Some(globals);
-        stack
+    fn name(&self) -> Option<kstring::KStringRef<'_>> {
+        self.name
+            .as_ref()
+            .map(|n| n.as_ref())
+            .or_else(|| self.parent.name())
     }
 
-    /// Creates a new variable scope chained to a parent scope.
-    pub(crate) fn push_frame(&mut self) {
-        self.stack.push(Frame::new());
-    }
-
-    /// Creates a new variable scope chained to a parent scope.
-    pub(crate) fn push_named_frame<S: Into<kstring::KString>>(&mut self, name: S) {
-        self.stack.push(Frame::with_name(name));
-    }
-
-    /// Removes the topmost stack frame from the local variable stack.
-    ///
-    /// # Panics
-    ///
-    /// This method will panic if popping the topmost frame results in an
-    /// empty stack. Given that a runtime is created with a top-level stack
-    /// frame already in place, emptying the stack should never happen in a
-    /// well-formed program.
-    pub(crate) fn pop_frame(&mut self) {
-        if self.stack.pop().is_none() {
-            panic!("Unbalanced push/pop, leaving the stack empty.")
-        };
-    }
-
-    /// The name of the currently active template.
-    pub fn frame_name(&self) -> Option<kstring::KStringRef<'_>> {
-        self.stack
-            .iter()
-            .rev()
-            .find_map(|f| f.name.as_ref().map(|s| s.as_ref()))
-    }
-
-    /// Recursively index into the stack.
-    pub fn try_get(&self, path: &[ScalarCow<'_>]) -> Option<ValueCow<'_>> {
-        let frame = self.find_path_frame(path)?;
-
-        crate::model::find::try_find(frame.as_value(), path)
-    }
-
-    /// Recursively index into the stack.
-    pub fn get(&self, path: &[ScalarCow<'_>]) -> Result<ValueCow<'_>> {
-        let frame = self.find_path_frame(path).ok_or_else(|| {
-            let key = path
-                .iter()
-                .next()
-                .cloned()
-                .unwrap_or_else(|| Scalar::new("nil"));
-            let globals = itertools::join(self.roots().iter(), ", ");
-            Error::with_msg("Unknown variable")
-                .context("requested variable", key.to_kstr())
-                .context("available variables", globals)
-        })?;
-
-        crate::model::find::find(frame.as_value(), path)
-    }
-
-    fn roots(&self) -> Vec<kstring::KStringCow<'_>> {
-        let mut roots = Vec::new();
-        if let Some(globals) = self.globals {
-            roots.extend(globals.keys());
-        }
-        for frame in self.stack.iter() {
-            roots.extend(frame.data.keys().map(kstring::KStringCow::from));
-        }
-        roots.sort();
-        roots.dedup();
+    fn roots<'r>(&'r self) -> std::collections::BTreeSet<kstring::KStringCow<'r>> {
+        let mut roots = self.parent.roots();
+        roots.extend(self.data.keys());
         roots
     }
 
-    fn find_path_frame<'a>(&'a self, path: &[ScalarCow<'_>]) -> Option<&'a dyn ObjectView> {
-        let key = path.iter().next()?;
+    fn try_get(&self, path: &[ScalarCow<'_>]) -> Option<ValueCow<'_>> {
+        let key = path.first()?;
         let key = key.to_kstr();
-        self.find_frame(key.as_str())
-    }
-
-    fn find_frame<'a>(&'a self, name: &str) -> Option<&'a dyn ObjectView> {
-        for frame in self.stack.iter().rev() {
-            if frame.data.contains_key(name) {
-                return Some(&frame.data);
-            }
-        }
-
-        if self.globals.map(|g| g.contains_key(name)).unwrap_or(false) {
-            return self.globals;
-        }
-
-        if self.indexes.contains_key(name) {
-            return Some(&self.indexes);
-        }
-
-        None
-    }
-
-    /// Used by increment and decrement tags
-    pub fn set_index<S>(&mut self, name: S, val: Value) -> Option<Value>
-    where
-        S: Into<kstring::KString>,
-    {
-        self.indexes.insert(name.into(), val)
-    }
-
-    /// Used by increment and decrement tags
-    pub fn get_index<'a>(&'a self, name: &str) -> Option<&'a Value> {
-        self.indexes.get(name)
-    }
-
-    /// Sets a value in the global runtime.
-    pub fn set_global<S>(&mut self, name: S, val: Value) -> Option<Value>
-    where
-        S: Into<kstring::KString>,
-    {
-        let name = name.into();
-        self.global_frame().insert(name, val)
-    }
-
-    /// Sets a value to the rendering runtime.
-    /// Note that it needs to be wrapped in a liquid::Value.
-    ///
-    /// # Panics
-    ///
-    /// Panics if there is no frame on the local values stack. Runtime
-    /// instances are created with a top-level stack frame in place, so
-    /// this should never happen in a well-formed program.
-    pub fn set<S>(&mut self, name: S, val: Value) -> Option<Value>
-    where
-        S: Into<kstring::KString>,
-    {
-        self.current_frame().insert(name.into(), val)
-    }
-
-    fn current_frame(&mut self) -> &mut Object {
-        match self.stack.last_mut() {
-            Some(frame) => &mut frame.data,
-            None => panic!("Global frame removed."),
+        let data = self.data;
+        if data.contains_key(key.as_str()) {
+            crate::model::find::try_find(data.as_value(), path)
+        } else {
+            self.parent.try_get(path)
         }
     }
 
-    fn global_frame(&mut self) -> &mut Object {
-        match self.stack.first_mut() {
-            Some(frame) => &mut frame.data,
-            None => panic!("Global frame removed."),
+    fn get(&self, path: &[ScalarCow<'_>]) -> Result<ValueCow<'_>> {
+        let key = path.first().ok_or_else(|| {
+            Error::with_msg("Unknown variable").context("requested variable", "nil")
+        })?;
+        let key = key.to_kstr();
+        let data = self.data;
+        if data.contains_key(key.as_str()) {
+            crate::model::find::find(data.as_value(), path).map(|v| v.into_owned().into())
+        } else {
+            self.parent.get(path)
+        }
+    }
+
+    fn set_global(
+        &self,
+        name: kstring::KString,
+        val: crate::model::Value,
+    ) -> Option<crate::model::Value> {
+        self.parent.set_global(name, val)
+    }
+
+    fn set_index(&self, name: kstring::KString, val: Value) -> Option<Value> {
+        self.parent.set_index(name, val)
+    }
+
+    fn get_index<'a>(&'a self, name: &str) -> Option<ValueCow<'a>> {
+        self.parent.get_index(name)
+    }
+
+    fn registers(&self) -> &super::Registers {
+        self.parent.registers()
+    }
+}
+
+pub(crate) struct ConstantFrame<'o, P> {
+    parent: P,
+    data: Option<&'o dyn ObjectView>,
+}
+
+impl<'o, P: super::Runtime> ConstantFrame<'o, P> {
+    /// Layer variables on top of the existing runtime
+    pub fn new(parent: P, data: Option<&'o dyn ObjectView>) -> Self {
+        Self { parent, data }
+    }
+}
+
+impl<'o, P: super::Runtime> super::Runtime for ConstantFrame<'o, P> {
+    fn partials(&self) -> &dyn super::PartialStore {
+        self.parent.partials()
+    }
+
+    fn name(&self) -> Option<kstring::KStringRef<'_>> {
+        self.parent.name()
+    }
+
+    fn roots<'r>(&'r self) -> std::collections::BTreeSet<kstring::KStringCow<'r>> {
+        let mut roots = self.parent.roots();
+        if let Some(data) = self.data {
+            roots.extend(data.keys());
+        }
+        roots
+    }
+
+    fn try_get(&self, path: &[ScalarCow<'_>]) -> Option<ValueCow<'_>> {
+        let key = path.first()?;
+        let key = key.to_kstr();
+        let data = self.data;
+        if data.map(|d| d.contains_key(key.as_str())).unwrap_or(false) {
+            crate::model::find::try_find(data.unwrap().as_value(), path)
+        } else {
+            self.parent.try_get(path)
+        }
+    }
+
+    fn get(&self, path: &[ScalarCow<'_>]) -> Result<ValueCow<'_>> {
+        let key = path.first().ok_or_else(|| {
+            Error::with_msg("Unknown variable").context("requested variable", "nil")
+        })?;
+        let key = key.to_kstr();
+        let data = self.data;
+        if data.map(|d| d.contains_key(key.as_str())).unwrap_or(false) {
+            crate::model::find::find(data.unwrap().as_value(), path).map(|v| v.into_owned().into())
+        } else {
+            self.parent.get(path)
+        }
+    }
+
+    fn set_global(
+        &self,
+        name: kstring::KString,
+        val: crate::model::Value,
+    ) -> Option<crate::model::Value> {
+        self.parent.set_global(name, val)
+    }
+
+    fn set_index(&self, name: kstring::KString, val: Value) -> Option<Value> {
+        self.parent.set_index(name, val)
+    }
+
+    fn get_index<'a>(&'a self, name: &str) -> Option<ValueCow<'a>> {
+        self.parent.get_index(name)
+    }
+
+    fn registers(&self) -> &super::Registers {
+        self.parent.registers()
+    }
+}
+
+pub(crate) struct GlobalFrame<P> {
+    parent: P,
+    data: std::cell::RefCell<Object>,
+}
+
+impl<P: super::Runtime> GlobalFrame<P> {
+    pub fn new(parent: P) -> Self {
+        Self {
+            parent,
+            data: Default::default(),
         }
     }
 }
 
-impl<'g> Default for Stack<'g> {
-    fn default() -> Self {
-        Self::empty()
+impl<P: super::Runtime> super::Runtime for GlobalFrame<P> {
+    fn partials(&self) -> &dyn super::PartialStore {
+        self.parent.partials()
+    }
+
+    fn name(&self) -> Option<kstring::KStringRef<'_>> {
+        self.parent.name()
+    }
+
+    fn roots<'r>(&'r self) -> std::collections::BTreeSet<kstring::KStringCow<'r>> {
+        let mut roots = self.parent.roots();
+        roots.extend(self.data.borrow().keys().map(|k| k.clone().into()));
+        roots
+    }
+
+    fn try_get(&self, path: &[ScalarCow<'_>]) -> Option<ValueCow<'_>> {
+        let key = path.first()?;
+        let key = key.to_kstr();
+        let data = self.data.borrow();
+        if data.contains_key(key.as_str()) {
+            crate::model::find::try_find(data.as_value(), path).map(|v| v.into_owned().into())
+        } else {
+            self.parent.try_get(path)
+        }
+    }
+
+    fn get(&self, path: &[ScalarCow<'_>]) -> Result<ValueCow<'_>> {
+        let key = path.first().ok_or_else(|| {
+            Error::with_msg("Unknown variable").context("requested variable", "nil")
+        })?;
+        let key = key.to_kstr();
+        let data = self.data.borrow();
+        if data.contains_key(key.as_str()) {
+            crate::model::find::find(data.as_value(), path).map(|v| v.into_owned().into())
+        } else {
+            self.parent.get(path)
+        }
+    }
+
+    fn set_global(
+        &self,
+        name: kstring::KString,
+        val: crate::model::Value,
+    ) -> Option<crate::model::Value> {
+        let mut data = self.data.borrow_mut();
+        data.insert(name, val)
+    }
+
+    fn set_index(&self, name: kstring::KString, val: Value) -> Option<Value> {
+        self.parent.set_index(name, val)
+    }
+
+    fn get_index<'a>(&'a self, name: &str) -> Option<ValueCow<'a>> {
+        self.parent.get_index(name)
+    }
+
+    fn registers(&self) -> &super::Registers {
+        self.parent.registers()
     }
 }
 
-#[cfg(test)]
-mod test {
-    use super::*;
+pub(crate) struct IndexFrame<P> {
+    parent: P,
+    data: std::cell::RefCell<Object>,
+}
 
-    use crate::model::value::ValueViewCmp;
+impl<P: super::Runtime> IndexFrame<P> {
+    pub fn new(parent: P) -> Self {
+        Self {
+            parent,
+            data: Default::default(),
+        }
+    }
+}
 
-    #[test]
-    fn stack_find_frame() {
-        let mut stack = Stack::empty();
-        stack.set_global("number", Value::scalar(42f64));
-        assert!(stack.find_frame("number").is_some(),);
+impl<P: super::Runtime> super::Runtime for IndexFrame<P> {
+    fn partials(&self) -> &dyn super::PartialStore {
+        self.parent.partials()
     }
 
-    #[test]
-    fn stack_find_frame_failure() {
-        let mut stack = Stack::empty();
-        let mut post = Object::new();
-        post.insert("number".into(), Value::scalar(42f64));
-        stack.set_global("post", Value::Object(post));
-        assert!(stack.find_frame("post.number").is_none());
+    fn name(&self) -> Option<kstring::KStringRef<'_>> {
+        self.parent.name()
     }
 
-    #[test]
-    fn stack_get() {
-        let mut stack = Stack::empty();
-        let mut post = Object::new();
-        post.insert("number".into(), Value::scalar(42f64));
-        stack.set_global("post", Value::Object(post));
-        let indexes = [Scalar::new("post"), Scalar::new("number")];
-        assert_eq!(&stack.get(&indexes).unwrap(), &ValueViewCmp::new(&42f64));
+    fn roots<'r>(&'r self) -> std::collections::BTreeSet<kstring::KStringCow<'r>> {
+        let mut roots = self.parent.roots();
+        roots.extend(self.data.borrow().keys().map(|k| k.clone().into()));
+        roots
+    }
+
+    fn try_get(&self, path: &[ScalarCow<'_>]) -> Option<ValueCow<'_>> {
+        let key = path.first()?;
+        let key = key.to_kstr();
+        let data = self.data.borrow();
+        if data.contains_key(key.as_str()) {
+            crate::model::find::try_find(data.as_value(), path).map(|v| v.into_owned().into())
+        } else {
+            self.parent.try_get(path)
+        }
+    }
+
+    fn get(&self, path: &[ScalarCow<'_>]) -> Result<ValueCow<'_>> {
+        let key = path.first().ok_or_else(|| {
+            Error::with_msg("Unknown variable").context("requested variable", "nil")
+        })?;
+        let key = key.to_kstr();
+        let data = self.data.borrow();
+        if data.contains_key(key.as_str()) {
+            crate::model::find::find(data.as_value(), path).map(|v| v.into_owned().into())
+        } else {
+            self.parent.get(path)
+        }
+    }
+
+    fn set_global(
+        &self,
+        name: kstring::KString,
+        val: crate::model::Value,
+    ) -> Option<crate::model::Value> {
+        self.parent.set_global(name, val)
+    }
+
+    fn set_index(&self, name: kstring::KString, val: Value) -> Option<Value> {
+        let mut data = self.data.borrow_mut();
+        data.insert(name, val)
+    }
+
+    fn get_index<'a>(&'a self, name: &str) -> Option<ValueCow<'a>> {
+        self.data.borrow().get(name).map(|v| v.to_value().into())
+    }
+
+    fn registers(&self) -> &super::Registers {
+        self.parent.registers()
     }
 }

--- a/crates/core/src/runtime/template.rs
+++ b/crates/core/src/runtime/template.rs
@@ -19,7 +19,7 @@ impl Template {
 }
 
 impl Renderable for Template {
-    fn render_to(&self, writer: &mut dyn Write, runtime: &mut Runtime<'_>) -> Result<()> {
+    fn render_to(&self, writer: &mut dyn Write, runtime: &dyn Runtime) -> Result<()> {
         for el in &self.elements {
             el.render_to(writer, runtime)?;
 
@@ -27,7 +27,11 @@ impl Renderable for Template {
             // need to abandon the rest of our child elements and just
             // return what we've got. This is usually in response to a
             // `break` or `continue` tag being rendered.
-            if runtime.interrupt().interrupted() {
+            if runtime
+                .registers()
+                .get_mut::<super::InterruptRegister>()
+                .interrupted()
+            {
                 break;
             }
         }

--- a/crates/core/src/runtime/variable.rs
+++ b/crates/core/src/runtime/variable.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use crate::error::{Error, Result};
-use crate::model::find::Path;
+use crate::model::Path;
 use crate::model::Scalar;
 use crate::model::{ValueCow, ValueView};
 
@@ -95,8 +95,8 @@ impl fmt::Display for Variable {
 mod test {
     use super::*;
 
-    use crate::model::value::ValueViewCmp;
     use crate::model::Object;
+    use crate::model::ValueViewCmp;
 
     use super::super::RuntimeBuilder;
     use super::super::StackFrame;

--- a/crates/core/src/runtime/variable.rs
+++ b/crates/core/src/runtime/variable.rs
@@ -31,7 +31,7 @@ impl Variable {
     }
 
     /// Convert to a `Path`.
-    pub fn try_evaluate<'c>(&'c self, runtime: &'c Runtime<'_>) -> Option<Path<'c>> {
+    pub fn try_evaluate<'c>(&'c self, runtime: &'c dyn Runtime) -> Option<Path<'c>> {
         let mut path = Path::with_index(self.variable.as_ref());
         path.reserve(self.indexes.len());
         for expr in &self.indexes {
@@ -46,7 +46,7 @@ impl Variable {
     }
 
     /// Convert to a `Path`.
-    pub fn evaluate<'c>(&'c self, runtime: &'c Runtime<'_>) -> Result<Path<'c>> {
+    pub fn evaluate<'c>(&'c self, runtime: &'c dyn Runtime) -> Result<Path<'c>> {
         let mut path = Path::with_index(self.variable.as_ref());
         path.reserve(self.indexes.len());
         for expr in &self.indexes {
@@ -99,6 +99,7 @@ mod test {
     use crate::model::Object;
 
     use super::super::RuntimeBuilder;
+    use super::super::StackFrame;
 
     #[test]
     fn identifier_path_array_index() {
@@ -112,9 +113,10 @@ test_a: ["test"]
         let index = vec![Scalar::new(0)];
         var.extend(index);
 
-        let runtime = RuntimeBuilder::new().set_globals(&globals).build();
+        let runtime = RuntimeBuilder::new().build();
+        let runtime = StackFrame::new(&runtime, &globals);
         let actual = var.evaluate(&runtime).unwrap();
-        let actual = runtime.stack().get(&actual).unwrap();
+        let actual = runtime.get(&actual).unwrap();
         assert_eq!(actual, ValueViewCmp::new(&"test"));
     }
 
@@ -130,9 +132,10 @@ test_a: ["test1", "test2"]
         let index = vec![Scalar::new(-1)];
         var.extend(index);
 
-        let runtime = RuntimeBuilder::new().set_globals(&globals).build();
+        let runtime = RuntimeBuilder::new().build();
+        let runtime = StackFrame::new(&runtime, &globals);
         let actual = var.evaluate(&runtime).unwrap();
-        let actual = runtime.stack().get(&actual).unwrap();
+        let actual = runtime.get(&actual).unwrap();
         assert_eq!(actual, ValueViewCmp::new(&"test2"));
     }
 
@@ -149,9 +152,10 @@ test_a:
         let index = vec![Scalar::new(0), Scalar::new("test_h")];
         var.extend(index);
 
-        let runtime = RuntimeBuilder::new().set_globals(&globals).build();
+        let runtime = RuntimeBuilder::new().build();
+        let runtime = StackFrame::new(&runtime, &globals);
         let actual = var.evaluate(&runtime).unwrap();
-        let actual = runtime.stack().get(&actual).unwrap();
+        let actual = runtime.get(&actual).unwrap();
         assert_eq!(actual, ValueViewCmp::new(&5));
     }
 }

--- a/crates/derive/src/filter_parameters.rs
+++ b/crates/derive/src/filter_parameters.rs
@@ -674,7 +674,7 @@ fn generate_impl_filter_parameters(filter_parameters: &FilterParameters<'_>) -> 
                 Ok( #name { #comma_separated_field_names } )
             }
 
-            fn evaluate(&'a self, runtime: &'a ::liquid_core::runtime::Runtime) -> ::liquid_core::error::Result<Self::EvaluatedFilterParameters> {
+            fn evaluate(&'a self, runtime: &'a dyn ::liquid_core::runtime::Runtime) -> ::liquid_core::error::Result<Self::EvaluatedFilterParameters> {
                #(#evaluate_fields)*
 
                 Ok( #evaluated_name { #comma_separated_field_names __phantom_data: ::std::marker::PhantomData } )

--- a/crates/derive/src/filter_parameters.rs
+++ b/crates/derive/src/filter_parameters.rs
@@ -699,8 +699,8 @@ fn generate_evaluated_struct(filter_parameters: &FilterParameters<'_>) -> TokenS
             FilterParameterType::Integer => quote! { i64 },
             FilterParameterType::Float => quote! { f64 },
             FilterParameterType::Bool => quote! { bool },
-            FilterParameterType::DateTime => quote! { ::liquid_core::model::scalar::DateTime },
-            FilterParameterType::Date => quote! { ::liquid_core::model::scalar::Date },
+            FilterParameterType::DateTime => quote! { ::liquid_core::model::DateTime },
+            FilterParameterType::Date => quote! { ::liquid_core::model::Date },
             FilterParameterType::Str => quote! { ::kstring::KStringCow<'a> },
         };
 

--- a/crates/derive/src/lib.rs
+++ b/crates/derive/src/lib.rs
@@ -250,6 +250,18 @@ pub fn derive_display_filter(item: TokenStream) -> TokenStream {
     filter::display::derive(&input).into()
 }
 
+#[proc_macro_derive(CoreValueView)]
+pub fn derive_core_value_view(item: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(item as syn::DeriveInput);
+    value_view::core_derive(&input).into()
+}
+
+#[proc_macro_derive(CoreObjectView)]
+pub fn derive_core_object_view(item: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(item as syn::DeriveInput);
+    object_view::core_derive(&input).into()
+}
+
 #[proc_macro_derive(ValueView)]
 pub fn derive_value_view(item: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(item as syn::DeriveInput);

--- a/crates/derive/src/object_view.rs
+++ b/crates/derive/src/object_view.rs
@@ -76,6 +76,80 @@ pub fn derive(input: &DeriveInput) -> TokenStream {
     }
 }
 
+pub fn core_derive(input: &DeriveInput) -> TokenStream {
+    let DeriveInput {
+        ident,
+        data,
+        generics,
+        ..
+    } = input;
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let fields = match get_fields(data) {
+        Ok(fields) => fields,
+        Err(err) => return err.to_compile_error(),
+    };
+    let num_fields = fields.len();
+
+    quote! {
+        impl #impl_generics ::liquid_core::ObjectView for #ident #ty_generics #where_clause {
+            fn as_value(&self) -> &dyn ::liquid_core::ValueView {
+                self
+            }
+
+            fn size(&self) -> i64 {
+                #num_fields as i64
+            }
+
+            fn keys<'liquid_derive_k>(&'liquid_derive_k self) -> Box<dyn Iterator<Item = ::kstring::KStringCow<'liquid_derive_k>> + 'liquid_derive_k> {
+                let mut keys = Vec::with_capacity(#num_fields);
+                #(
+                    keys.push(::kstring::KStringCow::from_static(stringify!(#fields)));
+                )*
+                Box::new(keys.into_iter())
+            }
+
+            fn values<'liquid_derive_k>(&'liquid_derive_k self) -> Box<dyn Iterator<Item = &'liquid_derive_k dyn ::liquid_core::ValueView> + 'liquid_derive_k> {
+                let mut values = Vec::<&dyn ::liquid_core::ValueView>::with_capacity(#num_fields);
+                #(
+                    values.push(&self.#fields);
+                )*
+                Box::new(values.into_iter())
+            }
+
+            fn iter<'liquid_derive_k>(&'liquid_derive_k self) -> Box<dyn Iterator<Item = (::kstring::KStringCow<'liquid_derive_k>, &'liquid_derive_k dyn ::liquid_core::ValueView)> + 'liquid_derive_k> {
+                let mut values = Vec::<(::kstring::KStringCow<'liquid_derive_k>, &'liquid_derive_k dyn ::liquid_core::ValueView)>::with_capacity(#num_fields);
+                #(
+                    values.push((
+                        ::kstring::KStringCow::from_static(stringify!(#fields)),
+                        &self.#fields,
+                    ));
+                )*
+                Box::new(values.into_iter())
+            }
+
+            fn contains_key(&self, index: &str) -> bool {
+                match index {
+                    #(
+                        stringify!(#fields) => true,
+                    )*
+                    _ => false,
+                }
+            }
+
+            fn get<'liquid_derive_s>(&'liquid_derive_s self, index: &str) -> Option<&'liquid_derive_s dyn ::liquid_core::ValueView> {
+                match index {
+                    #(
+                        stringify!(#fields) => Some(&self.#fields),
+                    )*
+                    _ => None,
+                }
+            }
+        }
+    }
+}
+
 fn get_fields(data: &Data) -> Result<Vec<&Ident>> {
     let fields = match data {
         Data::Struct(data) => &data.fields,

--- a/crates/derive/src/object_view.rs
+++ b/crates/derive/src/object_view.rs
@@ -150,7 +150,7 @@ pub fn core_derive(input: &DeriveInput) -> TokenStream {
     }
 }
 
-fn get_fields(data: &Data) -> Result<Vec<&Ident>> {
+pub(crate) fn get_fields(data: &Data) -> Result<Vec<&Ident>> {
     let fields = match data {
         Data::Struct(data) => &data.fields,
         Data::Enum(data) => {

--- a/crates/derive/src/value_view.rs
+++ b/crates/derive/src/value_view.rs
@@ -15,11 +15,11 @@ pub fn derive(input: &DeriveInput) -> TokenStream {
                 self
             }
 
-            fn render(&self) -> ::liquid::model::value::DisplayCow<'_> {
-                ::liquid::model::value::DisplayCow::Owned(Box::new(::liquid::model::object::ObjectRender::new(self)))
+            fn render(&self) -> ::liquid::model::DisplayCow<'_> {
+                ::liquid::model::DisplayCow::Owned(Box::new(::liquid::model::ObjectRender::new(self)))
             }
-            fn source(&self) -> ::liquid::model::value::DisplayCow<'_> {
-                ::liquid::model::value::DisplayCow::Owned(Box::new(::liquid::model::object::ObjectSource::new(self)))
+            fn source(&self) -> ::liquid::model::DisplayCow<'_> {
+                ::liquid::model::DisplayCow::Owned(Box::new(::liquid::model::ObjectSource::new(self)))
             }
             fn type_name(&self) -> &'static str {
                 "object"
@@ -34,7 +34,7 @@ pub fn derive(input: &DeriveInput) -> TokenStream {
             }
 
             fn to_kstr(&self) -> ::kstring::KStringCow<'_> {
-                let s = ::liquid::model::object::ObjectRender::new(self).to_string();
+                let s = ::liquid::model::ObjectRender::new(self).to_string();
                 ::kstring::KStringCow::from_string(s)
             }
             fn to_value(&self) -> ::liquid::model::Value {

--- a/crates/derive/src/value_view.rs
+++ b/crates/derive/src/value_view.rs
@@ -47,3 +47,49 @@ pub fn derive(input: &DeriveInput) -> TokenStream {
         }
     }
 }
+
+pub fn core_derive(input: &DeriveInput) -> TokenStream {
+    let DeriveInput {
+        ident, generics, ..
+    } = input;
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics ::liquid_core::ValueView for #ident #ty_generics #where_clause {
+            fn as_debug(&self) -> &dyn ::std::fmt::Debug {
+                self
+            }
+
+            fn render(&self) -> ::liquid_core::model::DisplayCow<'_> {
+                ::liquid_core::model::DisplayCow::Owned(Box::new(::liquid_core::model::ObjectRender::new(self)))
+            }
+            fn source(&self) -> ::liquid_core::model::DisplayCow<'_> {
+                ::liquid_core::model::DisplayCow::Owned(Box::new(::liquid_core::model::ObjectSource::new(self)))
+            }
+            fn type_name(&self) -> &'static str {
+                "object"
+            }
+            fn query_state(&self, state: ::liquid_core::model::State) -> bool {
+                match state {
+                    ::liquid_core::model::State::Truthy => true,
+                    ::liquid_core::model::State::DefaultValue |
+                    ::liquid_core::model::State::Empty |
+                    ::liquid_core::model::State::Blank => self.size() == 0,
+                }
+            }
+
+            fn to_kstr(&self) -> ::kstring::KStringCow<'_> {
+                let s = ::liquid_core::model::ObjectRender::new(self).to_string();
+                ::kstring::KStringCow::from_string(s)
+            }
+            fn to_value(&self) -> ::liquid_core::model::Value {
+                ::liquid_core::model::to_value(self).unwrap()
+            }
+
+            fn as_object(&self) -> Option<&dyn ::liquid_core::ObjectView> {
+                Some(self)
+            }
+        }
+    }
+}

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -18,7 +18,7 @@ features = [ "default", "jekyll", "all" ]
 azure-devops = { project = "cobalt-org", pipeline = "liquid-rust" }
 
 [dependencies]
-liquid-core = { version = "^0.21.0", path = "../core" }
+liquid-core = { version = "^0.21.0", path = "../core", features = ["derive"] }
 kstring = "1.0"
 itertools = "0.10.0"
 regex = "1.0"

--- a/crates/lib/src/extra/date.rs
+++ b/crates/lib/src/extra/date.rs
@@ -41,7 +41,7 @@ struct DateInTzFilter {
 }
 
 impl Filter for DateInTzFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let date = input

--- a/crates/lib/src/jekyll/array.rs
+++ b/crates/lib/src/jekyll/array.rs
@@ -33,7 +33,7 @@ struct PushFilter {
 }
 
 impl Filter for PushFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let element = args.element.to_value();
@@ -60,7 +60,7 @@ pub struct Pop;
 struct PopFilter;
 
 impl Filter for PopFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         let mut array = input
             .to_value()
             .into_array()
@@ -94,7 +94,7 @@ struct UnshiftFilter {
 }
 
 impl Filter for UnshiftFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let element = args.element.to_value();
@@ -121,7 +121,7 @@ pub struct Shift;
 struct ShiftFilter;
 
 impl Filter for ShiftFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         let mut array = input
             .to_value()
             .into_array()
@@ -161,7 +161,7 @@ struct ArrayToSentenceStringFilter {
 }
 
 impl Filter for ArrayToSentenceStringFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let connector = args.connector.unwrap_or_else(|| "and".into());

--- a/crates/lib/src/jekyll/include_tag.rs
+++ b/crates/lib/src/jekyll/include_tag.rs
@@ -208,12 +208,12 @@ mod test {
         let partials = partials::OnDemandCompiler::<TestSource>::empty()
             .compile(::std::sync::Arc::new(options))
             .unwrap();
-        let mut runtime = RuntimeBuilder::new()
+        let runtime = RuntimeBuilder::new()
             .set_partials(partials.as_ref())
             .build();
         runtime.set_global("num".into(), Value::scalar(5f64));
         runtime.set_global("numTwo".into(), Value::scalar(10f64));
-        let output = template.render(&mut runtime).unwrap();
+        let output = template.render(&runtime).unwrap();
         assert_eq!(output, "5 wat wot");
     }
 
@@ -228,10 +228,10 @@ mod test {
         let partials = partials::OnDemandCompiler::<TestSource>::empty()
             .compile(::std::sync::Arc::new(options))
             .unwrap();
-        let mut runtime = RuntimeBuilder::new()
+        let runtime = RuntimeBuilder::new()
             .set_partials(partials.as_ref())
             .build();
-        let output = template.render(&mut runtime).unwrap();
+        let output = template.render(&runtime).unwrap();
         assert_eq!(output, "hello");
     }
 
@@ -246,10 +246,10 @@ mod test {
         let partials = partials::OnDemandCompiler::<TestSource>::empty()
             .compile(::std::sync::Arc::new(options))
             .unwrap();
-        let mut runtime = RuntimeBuilder::new()
+        let runtime = RuntimeBuilder::new()
             .set_partials(partials.as_ref())
             .build();
-        let output = template.render(&mut runtime).unwrap();
+        let output = template.render(&runtime).unwrap();
         assert_eq!(output, "hello world");
     }
 
@@ -267,12 +267,12 @@ mod test {
         let partials = partials::OnDemandCompiler::<TestSource>::empty()
             .compile(::std::sync::Arc::new(options))
             .unwrap();
-        let mut runtime = RuntimeBuilder::new()
+        let runtime = RuntimeBuilder::new()
             .set_partials(partials.as_ref())
             .build();
         runtime.set_global("num".into(), Value::scalar(5f64));
         runtime.set_global("numTwo".into(), Value::scalar(10f64));
-        let output = template.render(&mut runtime);
+        let output = template.render(&runtime);
         assert!(output.is_err());
     }
 }

--- a/crates/lib/src/jekyll/include_tag.rs
+++ b/crates/lib/src/jekyll/include_tag.rs
@@ -5,9 +5,9 @@ use liquid_core::parser::TryMatchToken;
 use liquid_core::Expression;
 use liquid_core::Language;
 use liquid_core::Renderable;
-use liquid_core::Runtime;
 use liquid_core::ValueView;
 use liquid_core::{error::ResultLiquidExt, Object, Value};
+use liquid_core::{runtime::StackFrame, Runtime};
 use liquid_core::{Error, Result};
 use liquid_core::{ParseTag, TagReflection, TagTokenIter};
 
@@ -18,36 +18,38 @@ struct Include {
 }
 
 impl Renderable for Include {
-    fn render_to(&self, writer: &mut dyn Write, runtime: &mut Runtime<'_>) -> Result<()> {
+    fn render_to(&self, writer: &mut dyn Write, runtime: &dyn Runtime) -> Result<()> {
         let name = self.partial.evaluate(runtime)?.render().to_string();
 
-        runtime.run_in_named_scope(name.clone(), |mut scope| -> Result<()> {
+        {
+            let mut pass_through = Object::new();
             if !self.vars.is_empty() {
                 let mut helper_vars = Object::new();
 
                 for (id, val) in &self.vars {
                     helper_vars.insert(
                         id.clone(),
-                        val.try_evaluate(scope)
+                        val.try_evaluate(runtime)
                             .ok_or_else(|| Error::with_msg("failed to evaluate value"))?
                             .into_owned(),
                     );
                 }
 
-                scope.stack_mut().set("include", Value::Object(helper_vars));
+                pass_through.insert("include".into(), Value::Object(helper_vars));
             }
 
+            let scope = StackFrame::new(runtime, &pass_through);
             let partial = scope
                 .partials()
                 .get(&name)
                 .trace_with(|| format!("{{% include {} %}}", self.partial).into())?;
 
             partial
-                .render_to(writer, &mut scope)
+                .render_to(writer, &scope)
                 .trace_with(|| format!("{{% include {} %}}", self.partial).into())
                 .context_key_with(|| self.partial.to_string().into())
-                .value_with(|| name.to_string().into())
-        })?;
+                .value_with(|| name.to_string().into())?;
+        }
 
         Ok(())
     }
@@ -179,7 +181,7 @@ mod test {
     pub struct SizeFilter;
 
     impl Filter for SizeFilter {
-        fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+        fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
             if let Some(x) = input.as_scalar() {
                 Ok(Value::scalar(x.to_kstr().len() as i64))
             } else if let Some(x) = input.as_array() {
@@ -209,10 +211,8 @@ mod test {
         let mut runtime = RuntimeBuilder::new()
             .set_partials(partials.as_ref())
             .build();
-        runtime.stack_mut().set_global("num", Value::scalar(5f64));
-        runtime
-            .stack_mut()
-            .set_global("numTwo", Value::scalar(10f64));
+        runtime.set_global("num".into(), Value::scalar(5f64));
+        runtime.set_global("numTwo".into(), Value::scalar(10f64));
         let output = template.render(&mut runtime).unwrap();
         assert_eq!(output, "5 wat wot");
     }
@@ -270,10 +270,8 @@ mod test {
         let mut runtime = RuntimeBuilder::new()
             .set_partials(partials.as_ref())
             .build();
-        runtime.stack_mut().set_global("num", Value::scalar(5f64));
-        runtime
-            .stack_mut()
-            .set_global("numTwo", Value::scalar(10f64));
+        runtime.set_global("num".into(), Value::scalar(5f64));
+        runtime.set_global("numTwo".into(), Value::scalar(10f64));
         let output = template.render(&mut runtime);
         assert!(output.is_err());
     }

--- a/crates/lib/src/jekyll/slugify.rs
+++ b/crates/lib/src/jekyll/slugify.rs
@@ -66,7 +66,7 @@ struct SlugifyFilter {
 }
 
 impl Filter for SlugifyFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let s = input.to_kstr();

--- a/crates/lib/src/shopify/pluralize.rs
+++ b/crates/lib/src/shopify/pluralize.rs
@@ -35,7 +35,7 @@ struct PluralizeFilter {
 }
 
 impl Filter for PluralizeFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let n = input

--- a/crates/lib/src/stdlib/blocks/capture_block.rs
+++ b/crates/lib/src/stdlib/blocks/capture_block.rs
@@ -9,31 +9,6 @@ use liquid_core::Runtime;
 use liquid_core::Template;
 use liquid_core::{BlockReflection, ParseBlock, TagBlock, TagTokenIter};
 
-#[derive(Debug)]
-struct Capture {
-    id: kstring::KString,
-    template: Template,
-}
-
-impl Capture {
-    fn trace(&self) -> String {
-        format!("{{% capture {} %}}", self.id)
-    }
-}
-
-impl Renderable for Capture {
-    fn render_to(&self, _writer: &mut dyn Write, runtime: &dyn Runtime) -> Result<()> {
-        let mut captured = Vec::new();
-        self.template
-            .render_to(&mut captured, runtime)
-            .trace_with(|| self.trace().into())?;
-
-        let output = String::from_utf8(captured).expect("render only writes UTF-8");
-        runtime.set_global(self.id.clone(), Value::scalar(output));
-        Ok(())
-    }
-}
-
 #[derive(Copy, Clone, Debug, Default)]
 pub struct CaptureBlock;
 
@@ -86,6 +61,31 @@ impl ParseBlock for CaptureBlock {
 
     fn reflection(&self) -> &dyn BlockReflection {
         self
+    }
+}
+
+#[derive(Debug)]
+struct Capture {
+    id: kstring::KString,
+    template: Template,
+}
+
+impl Capture {
+    fn trace(&self) -> String {
+        format!("{{% capture {} %}}", self.id)
+    }
+}
+
+impl Renderable for Capture {
+    fn render_to(&self, _writer: &mut dyn Write, runtime: &dyn Runtime) -> Result<()> {
+        let mut captured = Vec::new();
+        self.template
+            .render_to(&mut captured, runtime)
+            .trace_with(|| self.trace().into())?;
+
+        let output = String::from_utf8(captured).expect("render only writes UTF-8");
+        runtime.set_global(self.id.clone(), Value::scalar(output));
+        Ok(())
     }
 }
 

--- a/crates/lib/src/stdlib/blocks/case_block.rs
+++ b/crates/lib/src/stdlib/blocks/case_block.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use liquid_core::error::ResultLiquidExt;
-use liquid_core::model::{value::ValueViewCmp, ValueView};
+use liquid_core::model::{ValueView, ValueViewCmp};
 use liquid_core::parser::BlockElement;
 use liquid_core::parser::TryMatchToken;
 use liquid_core::Expression;

--- a/crates/lib/src/stdlib/blocks/case_block.rs
+++ b/crates/lib/src/stdlib/blocks/case_block.rs
@@ -12,101 +12,6 @@ use liquid_core::Runtime;
 use liquid_core::Template;
 use liquid_core::{BlockReflection, ParseBlock, TagBlock, TagTokenIter};
 
-#[derive(Debug)]
-struct CaseOption {
-    args: Vec<Expression>,
-    template: Template,
-}
-
-impl CaseOption {
-    fn new(args: Vec<Expression>, template: Template) -> CaseOption {
-        CaseOption { args, template }
-    }
-
-    fn evaluate(&self, value: &dyn ValueView, runtime: &dyn Runtime) -> Result<bool> {
-        for a in &self.args {
-            let v = a.evaluate(runtime)?;
-            if v == ValueViewCmp::new(value) {
-                return Ok(true);
-            }
-        }
-        Ok(false)
-    }
-
-    fn trace(&self) -> String {
-        format!("{{% when {} %}}", itertools::join(self.args.iter(), " or "))
-    }
-}
-
-#[derive(Debug)]
-struct Case {
-    target: Expression,
-    cases: Vec<CaseOption>,
-    else_block: Option<Template>,
-}
-
-impl Case {
-    fn trace(&self) -> String {
-        format!("{{% case {} %}}", self.target)
-    }
-}
-
-impl Renderable for Case {
-    fn render_to(&self, writer: &mut dyn Write, runtime: &dyn Runtime) -> Result<()> {
-        let value = self.target.evaluate(runtime)?.to_value();
-        for case in &self.cases {
-            if case.evaluate(&value, runtime)? {
-                return case
-                    .template
-                    .render_to(writer, runtime)
-                    .trace_with(|| case.trace().into())
-                    .trace_with(|| self.trace().into())
-                    .context_key_with(|| self.target.to_string().into())
-                    .value_with(|| value.to_kstr().into_owned());
-            }
-        }
-
-        if let Some(ref t) = self.else_block {
-            return t
-                .render_to(writer, runtime)
-                .trace("{{% else %}}")
-                .trace_with(|| self.trace().into())
-                .context_key_with(|| self.target.to_string().into())
-                .value_with(|| value.to_kstr().into_owned());
-        }
-
-        Ok(())
-    }
-}
-
-fn parse_condition(arguments: &mut TagTokenIter<'_>) -> Result<Vec<Expression>> {
-    let mut values = Vec::new();
-
-    let first_value = arguments
-        .expect_next("Value expected")?
-        .expect_value()
-        .into_result()?;
-    values.push(first_value);
-
-    while let Some(token) = arguments.next() {
-        if let TryMatchToken::Fails(token) = token.expect_str("or") {
-            token
-                .expect_str(",")
-                .into_result_custom_msg("\"or\" or \",\" expected.")?;
-        }
-
-        let value = arguments
-            .expect_next("Value expected")?
-            .expect_value()
-            .into_result()?;
-        values.push(value);
-    }
-
-    // no more arguments should be supplied, trying to supply them is an error
-    arguments.expect_nothing()?;
-    Ok(values)
-}
-
 #[derive(Copy, Clone, Debug, Default)]
 pub struct CaseBlock;
 
@@ -188,6 +93,101 @@ impl ParseBlock for CaseBlock {
 
     fn reflection(&self) -> &dyn BlockReflection {
         self
+    }
+}
+
+fn parse_condition(arguments: &mut TagTokenIter<'_>) -> Result<Vec<Expression>> {
+    let mut values = Vec::new();
+
+    let first_value = arguments
+        .expect_next("Value expected")?
+        .expect_value()
+        .into_result()?;
+    values.push(first_value);
+
+    while let Some(token) = arguments.next() {
+        if let TryMatchToken::Fails(token) = token.expect_str("or") {
+            token
+                .expect_str(",")
+                .into_result_custom_msg("\"or\" or \",\" expected.")?;
+        }
+
+        let value = arguments
+            .expect_next("Value expected")?
+            .expect_value()
+            .into_result()?;
+        values.push(value);
+    }
+
+    // no more arguments should be supplied, trying to supply them is an error
+    arguments.expect_nothing()?;
+    Ok(values)
+}
+
+#[derive(Debug)]
+struct Case {
+    target: Expression,
+    cases: Vec<CaseOption>,
+    else_block: Option<Template>,
+}
+
+impl Case {
+    fn trace(&self) -> String {
+        format!("{{% case {} %}}", self.target)
+    }
+}
+
+impl Renderable for Case {
+    fn render_to(&self, writer: &mut dyn Write, runtime: &dyn Runtime) -> Result<()> {
+        let value = self.target.evaluate(runtime)?.to_value();
+        for case in &self.cases {
+            if case.evaluate(&value, runtime)? {
+                return case
+                    .template
+                    .render_to(writer, runtime)
+                    .trace_with(|| case.trace().into())
+                    .trace_with(|| self.trace().into())
+                    .context_key_with(|| self.target.to_string().into())
+                    .value_with(|| value.to_kstr().into_owned());
+            }
+        }
+
+        if let Some(ref t) = self.else_block {
+            return t
+                .render_to(writer, runtime)
+                .trace("{{% else %}}")
+                .trace_with(|| self.trace().into())
+                .context_key_with(|| self.target.to_string().into())
+                .value_with(|| value.to_kstr().into_owned());
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct CaseOption {
+    args: Vec<Expression>,
+    template: Template,
+}
+
+impl CaseOption {
+    fn new(args: Vec<Expression>, template: Template) -> CaseOption {
+        CaseOption { args, template }
+    }
+
+    fn evaluate(&self, value: &dyn ValueView, runtime: &dyn Runtime) -> Result<bool> {
+        for a in &self.args {
+            let v = a.evaluate(runtime)?;
+            if v == ValueViewCmp::new(value) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    fn trace(&self) -> String {
+        format!("{{% when {} %}}", itertools::join(self.args.iter(), " or "))
     }
 }
 

--- a/crates/lib/src/stdlib/blocks/comment_block.rs
+++ b/crates/lib/src/stdlib/blocks/comment_block.rs
@@ -7,15 +7,6 @@ use liquid_core::Result;
 use liquid_core::Runtime;
 use liquid_core::{BlockReflection, ParseBlock, TagBlock, TagTokenIter};
 
-#[derive(Copy, Clone, Debug)]
-struct Comment;
-
-impl Renderable for Comment {
-    fn render_to(&self, _writer: &mut dyn Write, _runtime: &dyn Runtime) -> Result<()> {
-        Ok(())
-    }
-}
-
 #[derive(Copy, Clone, Debug, Default)]
 pub struct CommentBlock;
 
@@ -69,6 +60,15 @@ impl ParseBlock for CommentBlock {
 
     fn reflection(&self) -> &dyn BlockReflection {
         self
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+struct Comment;
+
+impl Renderable for Comment {
+    fn render_to(&self, _writer: &mut dyn Write, _runtime: &dyn Runtime) -> Result<()> {
+        Ok(())
     }
 }
 

--- a/crates/lib/src/stdlib/blocks/comment_block.rs
+++ b/crates/lib/src/stdlib/blocks/comment_block.rs
@@ -11,7 +11,7 @@ use liquid_core::{BlockReflection, ParseBlock, TagBlock, TagTokenIter};
 struct Comment;
 
 impl Renderable for Comment {
-    fn render_to(&self, _writer: &mut dyn Write, _runtime: &mut Runtime<'_>) -> Result<()> {
+    fn render_to(&self, _writer: &mut dyn Write, _runtime: &dyn Runtime) -> Result<()> {
         Ok(())
     }
 }
@@ -78,6 +78,7 @@ mod test {
 
     use liquid_core::parser;
     use liquid_core::runtime;
+    use liquid_core::runtime::RuntimeBuilder;
 
     fn options() -> Language {
         let mut options = Language::default();
@@ -93,9 +94,9 @@ mod test {
             .map(runtime::Template::new)
             .unwrap();
 
-        let mut runtime = Runtime::new();
+        let runtime = RuntimeBuilder::new().build();
 
-        template.render(&mut runtime).unwrap()
+        template.render(&runtime).unwrap()
     }
 
     #[test]

--- a/crates/lib/src/stdlib/blocks/if_block.rs
+++ b/crates/lib/src/stdlib/blocks/if_block.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::io::Write;
 
 use liquid_core::error::ResultLiquidExt;
-use liquid_core::model::{value::ValueViewCmp, ValueView};
+use liquid_core::model::{ValueView, ValueViewCmp};
 use liquid_core::parser::BlockElement;
 use liquid_core::parser::TagToken;
 use liquid_core::Expression;

--- a/crates/lib/src/stdlib/blocks/if_block.rs
+++ b/crates/lib/src/stdlib/blocks/if_block.rs
@@ -13,6 +13,285 @@ use liquid_core::Template;
 use liquid_core::{BlockReflection, ParseBlock, TagBlock, TagTokenIter};
 use liquid_core::{Error, Result};
 
+#[derive(Copy, Clone, Debug, Default)]
+pub struct IfBlock;
+
+impl IfBlock {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl BlockReflection for IfBlock {
+    fn start_tag(&self) -> &str {
+        "if"
+    }
+
+    fn end_tag(&self) -> &str {
+        "endif"
+    }
+
+    fn description(&self) -> &str {
+        ""
+    }
+}
+
+impl ParseBlock for IfBlock {
+    fn parse(
+        &self,
+        arguments: TagTokenIter<'_>,
+        mut tokens: TagBlock<'_, '_>,
+        options: &Language,
+    ) -> Result<Box<dyn Renderable>> {
+        let conditional = parse_if(self.start_tag(), arguments, &mut tokens, options)?;
+
+        tokens.assert_empty();
+        Ok(conditional)
+    }
+
+    fn reflection(&self) -> &dyn BlockReflection {
+        self
+    }
+}
+
+fn parse_if(
+    tag_name: &str,
+    arguments: TagTokenIter<'_>,
+    tokens: &mut TagBlock<'_, '_>,
+    options: &Language,
+) -> Result<Box<dyn Renderable>> {
+    let condition = parse_condition(arguments)?;
+
+    let mut if_true = Vec::new();
+    let mut if_false = None;
+
+    while let Some(element) = tokens.next()? {
+        match element {
+            BlockElement::Tag(tag) => match tag.name() {
+                "else" => {
+                    if_false = Some(tokens.parse_all(options)?);
+                    break;
+                }
+                "elsif" => {
+                    if_false = Some(vec![parse_if("elsif", tag.into_tokens(), tokens, options)?]);
+                    break;
+                }
+                _ => if_true.push(tag.parse(tokens, options)?),
+            },
+            element => if_true.push(element.parse(tokens, options)?),
+        }
+    }
+
+    let if_true = Template::new(if_true);
+    let if_false = if_false.map(Template::new);
+
+    Ok(Box::new(Conditional {
+        tag_name: tag_name.to_string(),
+        condition,
+        mode: true,
+        if_true,
+        if_false,
+    }))
+}
+
+#[derive(Copy, Clone, Debug, Default)]
+pub struct UnlessBlock;
+
+impl UnlessBlock {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl BlockReflection for UnlessBlock {
+    fn start_tag(&self) -> &str {
+        "unless"
+    }
+
+    fn end_tag(&self) -> &str {
+        "endunless"
+    }
+
+    fn description(&self) -> &str {
+        ""
+    }
+}
+
+impl ParseBlock for UnlessBlock {
+    fn parse(
+        &self,
+        arguments: TagTokenIter<'_>,
+        mut tokens: TagBlock<'_, '_>,
+        options: &Language,
+    ) -> Result<Box<dyn Renderable>> {
+        let condition = parse_condition(arguments)?;
+
+        let mut if_true = Vec::new();
+        let mut if_false = None;
+
+        while let Some(element) = tokens.next()? {
+            match element {
+                BlockElement::Tag(tag) => match tag.name() {
+                    "else" => {
+                        if_false = Some(tokens.parse_all(options)?);
+                        break;
+                    }
+                    _ => if_true.push(tag.parse(&mut tokens, options)?),
+                },
+                element => if_true.push(element.parse(&mut tokens, options)?),
+            }
+        }
+
+        let if_true = Template::new(if_true);
+        let if_false = if_false.map(Template::new);
+
+        tokens.assert_empty();
+        Ok(Box::new(Conditional {
+            tag_name: self.start_tag().to_string(),
+            condition,
+            mode: false,
+            if_true,
+            if_false,
+        }))
+    }
+
+    fn reflection(&self) -> &dyn BlockReflection {
+        self
+    }
+}
+
+#[derive(Debug)]
+struct Conditional {
+    tag_name: String,
+    condition: Condition,
+    mode: bool,
+    if_true: Template,
+    if_false: Option<Template>,
+}
+
+impl Conditional {
+    fn compare(&self, runtime: &dyn Runtime) -> Result<bool> {
+        let result = self.condition.evaluate(runtime)?;
+
+        Ok(result == self.mode)
+    }
+
+    fn trace(&self) -> String {
+        format!("{{% if {} %}}", self.condition)
+    }
+}
+
+impl Renderable for Conditional {
+    fn render_to(&self, writer: &mut dyn Write, runtime: &dyn Runtime) -> Result<()> {
+        let condition = self.compare(runtime).trace_with(|| self.trace().into())?;
+        if condition {
+            self.if_true
+                .render_to(writer, runtime)
+                .trace_with(|| self.trace().into())?;
+        } else if let Some(ref template) = self.if_false {
+            template
+                .render_to(writer, runtime)
+                .trace("{{% else %}}")
+                .trace_with(|| self.trace().into())?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+enum Condition {
+    Binary(BinaryCondition),
+    Existence(ExistenceCondition),
+    Conjunction(Box<Condition>, Box<Condition>),
+    Disjunction(Box<Condition>, Box<Condition>),
+}
+
+impl Condition {
+    pub fn evaluate(&self, runtime: &dyn Runtime) -> Result<bool> {
+        match *self {
+            Condition::Binary(ref c) => c.evaluate(runtime),
+            Condition::Existence(ref c) => c.evaluate(runtime),
+            Condition::Conjunction(ref left, ref right) => {
+                Ok(left.evaluate(runtime)? && right.evaluate(runtime)?)
+            }
+            Condition::Disjunction(ref left, ref right) => {
+                Ok(left.evaluate(runtime)? || right.evaluate(runtime)?)
+            }
+        }
+    }
+}
+
+impl fmt::Display for Condition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Condition::Binary(ref c) => write!(f, "{}", c),
+            Condition::Existence(ref c) => write!(f, "{}", c),
+            Condition::Conjunction(ref left, ref right) => write!(f, "{} and {}", left, right),
+            Condition::Disjunction(ref left, ref right) => write!(f, "{} or {}", left, right),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct BinaryCondition {
+    lh: Expression,
+    comparison: ComparisonOperator,
+    rh: Expression,
+}
+
+impl BinaryCondition {
+    pub fn evaluate(&self, runtime: &dyn Runtime) -> Result<bool> {
+        let a = self.lh.evaluate(runtime)?;
+        let ca = ValueViewCmp::new(a.as_view());
+        let b = self.rh.evaluate(runtime)?;
+        let cb = ValueViewCmp::new(b.as_view());
+
+        let result = match self.comparison {
+            ComparisonOperator::Equals => ca == cb,
+            ComparisonOperator::NotEquals => ca != cb,
+            ComparisonOperator::LessThan => ca < cb,
+            ComparisonOperator::GreaterThan => ca > cb,
+            ComparisonOperator::LessThanEquals => ca <= cb,
+            ComparisonOperator::GreaterThanEquals => ca >= cb,
+            ComparisonOperator::Contains => contains_check(a.as_view(), b.as_view())?,
+        };
+
+        Ok(result)
+    }
+}
+
+impl fmt::Display for BinaryCondition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} {} {}", self.lh, self.comparison, self.rh)
+    }
+}
+
+fn contains_check(a: &dyn ValueView, b: &dyn ValueView) -> Result<bool> {
+    if let Some(a) = a.as_scalar() {
+        let b = b.to_kstr();
+        Ok(a.to_kstr().contains(b.as_str()))
+    } else if let Some(a) = a.as_object() {
+        let b = b.as_scalar();
+        let check = b
+            .map(|b| a.contains_key(b.to_kstr().as_str()))
+            .unwrap_or(false);
+        Ok(check)
+    } else if let Some(a) = a.as_array() {
+        for elem in a.values() {
+            if ValueViewCmp::new(elem) == ValueViewCmp::new(b) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    } else {
+        Err(unexpected_value_error(
+            "string | array | object",
+            Some(a.type_name()),
+        ))
+    }
+}
+
 #[derive(Clone, Debug)]
 enum ComparisonOperator {
     Equals,
@@ -55,40 +334,6 @@ impl ComparisonOperator {
 }
 
 #[derive(Clone, Debug)]
-struct BinaryCondition {
-    lh: Expression,
-    comparison: ComparisonOperator,
-    rh: Expression,
-}
-
-impl BinaryCondition {
-    pub fn evaluate(&self, runtime: &dyn Runtime) -> Result<bool> {
-        let a = self.lh.evaluate(runtime)?;
-        let ca = ValueViewCmp::new(a.as_view());
-        let b = self.rh.evaluate(runtime)?;
-        let cb = ValueViewCmp::new(b.as_view());
-
-        let result = match self.comparison {
-            ComparisonOperator::Equals => ca == cb,
-            ComparisonOperator::NotEquals => ca != cb,
-            ComparisonOperator::LessThan => ca < cb,
-            ComparisonOperator::GreaterThan => ca > cb,
-            ComparisonOperator::LessThanEquals => ca <= cb,
-            ComparisonOperator::GreaterThanEquals => ca >= cb,
-            ComparisonOperator::Contains => contains_check(a.as_view(), b.as_view())?,
-        };
-
-        Ok(result)
-    }
-}
-
-impl fmt::Display for BinaryCondition {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {} {}", self.lh, self.comparison, self.rh)
-    }
-}
-
-#[derive(Clone, Debug)]
 struct ExistenceCondition {
     lh: Expression,
 }
@@ -105,104 +350,6 @@ impl ExistenceCondition {
 impl fmt::Display for ExistenceCondition {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.lh)
-    }
-}
-
-#[derive(Clone, Debug)]
-enum Condition {
-    Binary(BinaryCondition),
-    Existence(ExistenceCondition),
-    Conjunction(Box<Condition>, Box<Condition>),
-    Disjunction(Box<Condition>, Box<Condition>),
-}
-
-impl Condition {
-    pub fn evaluate(&self, runtime: &dyn Runtime) -> Result<bool> {
-        match *self {
-            Condition::Binary(ref c) => c.evaluate(runtime),
-            Condition::Existence(ref c) => c.evaluate(runtime),
-            Condition::Conjunction(ref left, ref right) => {
-                Ok(left.evaluate(runtime)? && right.evaluate(runtime)?)
-            }
-            Condition::Disjunction(ref left, ref right) => {
-                Ok(left.evaluate(runtime)? || right.evaluate(runtime)?)
-            }
-        }
-    }
-}
-
-impl fmt::Display for Condition {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            Condition::Binary(ref c) => write!(f, "{}", c),
-            Condition::Existence(ref c) => write!(f, "{}", c),
-            Condition::Conjunction(ref left, ref right) => write!(f, "{} and {}", left, right),
-            Condition::Disjunction(ref left, ref right) => write!(f, "{} or {}", left, right),
-        }
-    }
-}
-
-#[derive(Debug)]
-struct Conditional {
-    tag_name: String,
-    condition: Condition,
-    mode: bool,
-    if_true: Template,
-    if_false: Option<Template>,
-}
-
-fn contains_check(a: &dyn ValueView, b: &dyn ValueView) -> Result<bool> {
-    if let Some(a) = a.as_scalar() {
-        let b = b.to_kstr();
-        Ok(a.to_kstr().contains(b.as_str()))
-    } else if let Some(a) = a.as_object() {
-        let b = b.as_scalar();
-        let check = b
-            .map(|b| a.contains_key(b.to_kstr().as_str()))
-            .unwrap_or(false);
-        Ok(check)
-    } else if let Some(a) = a.as_array() {
-        for elem in a.values() {
-            if ValueViewCmp::new(elem) == ValueViewCmp::new(b) {
-                return Ok(true);
-            }
-        }
-        Ok(false)
-    } else {
-        Err(unexpected_value_error(
-            "string | array | object",
-            Some(a.type_name()),
-        ))
-    }
-}
-
-impl Conditional {
-    fn compare(&self, runtime: &dyn Runtime) -> Result<bool> {
-        let result = self.condition.evaluate(runtime)?;
-
-        Ok(result == self.mode)
-    }
-
-    fn trace(&self) -> String {
-        format!("{{% if {} %}}", self.condition)
-    }
-}
-
-impl Renderable for Conditional {
-    fn render_to(&self, writer: &mut dyn Write, runtime: &dyn Runtime) -> Result<()> {
-        let condition = self.compare(runtime).trace_with(|| self.trace().into())?;
-        if condition {
-            self.if_true
-                .render_to(writer, runtime)
-                .trace_with(|| self.trace().into())?;
-        } else if let Some(ref template) = self.if_false {
-            template
-                .render_to(writer, runtime)
-                .trace("{{% else %}}")
-                .trace_with(|| self.trace().into())?;
-        }
-
-        Ok(())
     }
 }
 
@@ -299,155 +446,8 @@ fn parse_condition(arguments: TagTokenIter<'_>) -> Result<Condition> {
     Ok(lh)
 }
 
-#[derive(Copy, Clone, Debug, Default)]
-pub struct UnlessBlock;
-
-impl UnlessBlock {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-impl BlockReflection for UnlessBlock {
-    fn start_tag(&self) -> &str {
-        "unless"
-    }
-
-    fn end_tag(&self) -> &str {
-        "endunless"
-    }
-
-    fn description(&self) -> &str {
-        ""
-    }
-}
-
-impl ParseBlock for UnlessBlock {
-    fn parse(
-        &self,
-        arguments: TagTokenIter<'_>,
-        mut tokens: TagBlock<'_, '_>,
-        options: &Language,
-    ) -> Result<Box<dyn Renderable>> {
-        let condition = parse_condition(arguments)?;
-
-        let mut if_true = Vec::new();
-        let mut if_false = None;
-
-        while let Some(element) = tokens.next()? {
-            match element {
-                BlockElement::Tag(tag) => match tag.name() {
-                    "else" => {
-                        if_false = Some(tokens.parse_all(options)?);
-                        break;
-                    }
-                    _ => if_true.push(tag.parse(&mut tokens, options)?),
-                },
-                element => if_true.push(element.parse(&mut tokens, options)?),
-            }
-        }
-
-        let if_true = Template::new(if_true);
-        let if_false = if_false.map(Template::new);
-
-        tokens.assert_empty();
-        Ok(Box::new(Conditional {
-            tag_name: self.start_tag().to_string(),
-            condition,
-            mode: false,
-            if_true,
-            if_false,
-        }))
-    }
-
-    fn reflection(&self) -> &dyn BlockReflection {
-        self
-    }
-}
-
-fn parse_if(
-    tag_name: &str,
-    arguments: TagTokenIter<'_>,
-    tokens: &mut TagBlock<'_, '_>,
-    options: &Language,
-) -> Result<Box<dyn Renderable>> {
-    let condition = parse_condition(arguments)?;
-
-    let mut if_true = Vec::new();
-    let mut if_false = None;
-
-    while let Some(element) = tokens.next()? {
-        match element {
-            BlockElement::Tag(tag) => match tag.name() {
-                "else" => {
-                    if_false = Some(tokens.parse_all(options)?);
-                    break;
-                }
-                "elsif" => {
-                    if_false = Some(vec![parse_if("elsif", tag.into_tokens(), tokens, options)?]);
-                    break;
-                }
-                _ => if_true.push(tag.parse(tokens, options)?),
-            },
-            element => if_true.push(element.parse(tokens, options)?),
-        }
-    }
-
-    let if_true = Template::new(if_true);
-    let if_false = if_false.map(Template::new);
-
-    Ok(Box::new(Conditional {
-        tag_name: tag_name.to_string(),
-        condition,
-        mode: true,
-        if_true,
-        if_false,
-    }))
-}
-
-#[derive(Copy, Clone, Debug, Default)]
-pub struct IfBlock;
-
-impl IfBlock {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-impl BlockReflection for IfBlock {
-    fn start_tag(&self) -> &str {
-        "if"
-    }
-
-    fn end_tag(&self) -> &str {
-        "endif"
-    }
-
-    fn description(&self) -> &str {
-        ""
-    }
-}
-
-impl ParseBlock for IfBlock {
-    fn parse(
-        &self,
-        arguments: TagTokenIter<'_>,
-        mut tokens: TagBlock<'_, '_>,
-        options: &Language,
-    ) -> Result<Box<dyn Renderable>> {
-        let conditional = parse_if(self.start_tag(), arguments, &mut tokens, options)?;
-
-        tokens.assert_empty();
-        Ok(conditional)
-    }
-
-    fn reflection(&self) -> &dyn BlockReflection {
-        self
-    }
-}
-
 /// Format an error for an unexpected value.
-pub fn unexpected_value_error<S: ToString>(expected: &str, actual: Option<S>) -> Error {
+fn unexpected_value_error<S: ToString>(expected: &str, actual: Option<S>) -> Error {
     let actual = actual.map(|x| x.to_string());
     unexpected_value_error_string(expected, actual)
 }

--- a/crates/lib/src/stdlib/blocks/raw_block.rs
+++ b/crates/lib/src/stdlib/blocks/raw_block.rs
@@ -7,18 +7,6 @@ use liquid_core::Result;
 use liquid_core::Runtime;
 use liquid_core::{BlockReflection, ParseBlock, TagBlock, TagTokenIter};
 
-#[derive(Clone, Debug)]
-struct RawT {
-    content: String,
-}
-
-impl Renderable for RawT {
-    fn render_to(&self, writer: &mut dyn Write, _runtime: &dyn Runtime) -> Result<()> {
-        write!(writer, "{}", self.content).replace("Failed to render")?;
-        Ok(())
-    }
-}
-
 #[derive(Copy, Clone, Debug, Default)]
 pub struct RawBlock;
 
@@ -60,6 +48,18 @@ impl ParseBlock for RawBlock {
 
     fn reflection(&self) -> &dyn BlockReflection {
         self
+    }
+}
+
+#[derive(Clone, Debug)]
+struct RawT {
+    content: String,
+}
+
+impl Renderable for RawT {
+    fn render_to(&self, writer: &mut dyn Write, _runtime: &dyn Runtime) -> Result<()> {
+        write!(writer, "{}", self.content).replace("Failed to render")?;
+        Ok(())
     }
 }
 

--- a/crates/lib/src/stdlib/blocks/raw_block.rs
+++ b/crates/lib/src/stdlib/blocks/raw_block.rs
@@ -13,7 +13,7 @@ struct RawT {
 }
 
 impl Renderable for RawT {
-    fn render_to(&self, writer: &mut dyn Write, _runtime: &mut Runtime<'_>) -> Result<()> {
+    fn render_to(&self, writer: &mut dyn Write, _runtime: &dyn Runtime) -> Result<()> {
         write!(writer, "{}", self.content).replace("Failed to render")?;
         Ok(())
     }
@@ -69,6 +69,7 @@ mod test {
 
     use liquid_core::parser;
     use liquid_core::runtime;
+    use liquid_core::runtime::RuntimeBuilder;
 
     fn options() -> Language {
         let mut options = Language::default();
@@ -82,9 +83,9 @@ mod test {
             .map(runtime::Template::new)
             .unwrap();
 
-        let mut runtime = Runtime::new();
+        let runtime = RuntimeBuilder::new().build();
 
-        template.render(&mut runtime).unwrap()
+        template.render(&runtime).unwrap()
     }
 
     #[test]

--- a/crates/lib/src/stdlib/filters/array.rs
+++ b/crates/lib/src/stdlib/filters/array.rs
@@ -47,7 +47,7 @@ struct JoinFilter {
 }
 
 impl Filter for JoinFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let separator = args.separator.unwrap_or_else(|| " ".into());
@@ -120,7 +120,7 @@ fn safe_property_getter<'a>(value: &'a Value, property: &str) -> &'a dyn ValueVi
 }
 
 impl Filter for SortFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let input: Vec<_> = as_sequence(input).collect();
@@ -162,7 +162,7 @@ struct SortNaturalFilter {
 }
 
 impl Filter for SortNaturalFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let input: Vec<_> = as_sequence(input).collect();
@@ -223,7 +223,7 @@ struct WhereFilter {
 }
 
 impl Filter for WhereFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
         let property: &str = &args.property;
         let target_value: Option<ValueCow<'_>> = args.target_value;
@@ -280,7 +280,7 @@ pub struct Uniq;
 struct UniqFilter;
 
 impl Filter for UniqFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         // TODO(#267) optional property parameter
 
         let array = input
@@ -313,7 +313,7 @@ pub struct Reverse;
 struct ReverseFilter;
 
 impl Filter for ReverseFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         let mut array: Vec<_> = input
             .as_array()
             .ok_or_else(|| invalid_input("Array expected"))?
@@ -351,7 +351,7 @@ struct MapFilter {
 }
 
 impl Filter for MapFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let array = input
@@ -387,7 +387,7 @@ struct CompactFilter {
 }
 
 impl Filter for CompactFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let array = input
@@ -443,7 +443,7 @@ struct ConcatFilter {
 }
 
 impl Filter for ConcatFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let input = input
@@ -476,7 +476,7 @@ pub struct First;
 struct FirstFilter;
 
 impl Filter for FirstFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         if let Some(x) = input.as_scalar() {
             let c = x
                 .to_kstr()
@@ -508,7 +508,7 @@ pub struct Last;
 struct LastFilter;
 
 impl Filter for LastFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         if let Some(x) = input.as_scalar() {
             let c = x
                 .to_kstr()

--- a/crates/lib/src/stdlib/filters/array.rs
+++ b/crates/lib/src/stdlib/filters/array.rs
@@ -1,6 +1,6 @@
 use std::cmp;
 
-use liquid_core::model::value::ValueViewCmp;
+use liquid_core::model::ValueViewCmp;
 use liquid_core::Expression;
 use liquid_core::Result;
 use liquid_core::Runtime;

--- a/crates/lib/src/stdlib/filters/date.rs
+++ b/crates/lib/src/stdlib/filters/date.rs
@@ -31,7 +31,7 @@ struct DateFilter {
 }
 
 impl Filter for DateFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let date = input.as_scalar().and_then(|s| s.to_date_time());

--- a/crates/lib/src/stdlib/filters/html.rs
+++ b/crates/lib/src/stdlib/filters/html.rs
@@ -75,7 +75,7 @@ pub struct Escape;
 struct EscapeFilter;
 
 impl Filter for EscapeFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         escape(input, false)
     }
 }
@@ -93,7 +93,7 @@ pub struct EscapeOnce;
 struct EscapeOnceFilter;
 
 impl Filter for EscapeOnceFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         escape(input, true)
     }
 }
@@ -120,7 +120,7 @@ static MATCHERS: once_cell::sync::Lazy<[Regex; 4]> = once_cell::sync::Lazy::new(
 });
 
 impl Filter for StripHtmlFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         let input = input.to_kstr().into_string();
 
         let result = MATCHERS.iter().fold(input, |acc, matcher| {
@@ -143,7 +143,7 @@ pub struct NewlineToBr;
 struct NewlineToBrFilter;
 
 impl Filter for NewlineToBrFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         // TODO handle windows line endings
         let input = input.to_kstr();
         Ok(Value::scalar(input.replace("\n", "<br />\n")))

--- a/crates/lib/src/stdlib/filters/math.rs
+++ b/crates/lib/src/stdlib/filters/math.rs
@@ -23,7 +23,7 @@ pub struct Abs;
 struct AbsFilter;
 
 impl Filter for AbsFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         let input = input
             .as_scalar()
             .ok_or_else(|| invalid_input("Number expected"))?;
@@ -58,7 +58,7 @@ struct AtLeastFilter {
 }
 
 impl Filter for AtLeastFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let input = input
@@ -107,7 +107,7 @@ struct AtMostFilter {
 }
 
 impl Filter for AtMostFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let input = input
@@ -156,7 +156,7 @@ struct PlusFilter {
 }
 
 impl Filter for PlusFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let input = input
@@ -205,7 +205,7 @@ struct MinusFilter {
 }
 
 impl Filter for MinusFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let input = input
@@ -254,7 +254,7 @@ struct TimesFilter {
 }
 
 impl Filter for TimesFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let input = input
@@ -303,7 +303,7 @@ struct DividedByFilter {
 }
 
 impl Filter for DividedByFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let input = input
@@ -362,7 +362,7 @@ struct ModuloFilter {
 }
 
 impl Filter for ModuloFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let input = input
@@ -424,7 +424,7 @@ struct RoundFilter {
 }
 
 impl Filter for RoundFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let n = args.decimal_places.unwrap_or(0);
@@ -461,7 +461,7 @@ pub struct Ceil;
 struct CeilFilter;
 
 impl Filter for CeilFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         let n = input
             .as_scalar()
             .and_then(|s| s.to_float())
@@ -483,7 +483,7 @@ pub struct Floor;
 struct FloorFilter;
 
 impl Filter for FloorFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         let n = input
             .as_scalar()
             .and_then(|s| s.to_float())

--- a/crates/lib/src/stdlib/filters/mod.rs
+++ b/crates/lib/src/stdlib/filters/mod.rs
@@ -43,7 +43,7 @@ pub struct Size;
 struct SizeFilter;
 
 impl Filter for SizeFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         if let Some(x) = input.as_scalar() {
             Ok(Value::scalar(x.to_kstr().len() as i64))
         } else if let Some(x) = input.as_array() {
@@ -79,7 +79,7 @@ struct DefaultFilter {
 }
 
 impl Filter for DefaultFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         if input.query_state(liquid_core::model::State::DefaultValue) {

--- a/crates/lib/src/stdlib/filters/slice.rs
+++ b/crates/lib/src/stdlib/filters/slice.rs
@@ -62,7 +62,7 @@ struct SliceFilter {
 }
 
 impl Filter for SliceFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let offset = args.offset as isize;

--- a/crates/lib/src/stdlib/filters/string/case.rs
+++ b/crates/lib/src/stdlib/filters/string/case.rs
@@ -18,7 +18,7 @@ pub struct Downcase;
 struct DowncaseFilter;
 
 impl Filter for DowncaseFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         let s = input.to_kstr();
         Ok(Value::scalar(s.to_lowercase()))
     }
@@ -37,7 +37,7 @@ pub struct Upcase;
 struct UpcaseFilter;
 
 impl Filter for UpcaseFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         let s = input.to_kstr();
         Ok(Value::scalar(s.to_uppercase()))
     }
@@ -56,7 +56,7 @@ pub struct Capitalize;
 struct CapitalizeFilter;
 
 impl Filter for CapitalizeFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         let s = input.to_kstr().to_owned();
         let mut chars = s.chars();
         let capitalized = match chars.next() {

--- a/crates/lib/src/stdlib/filters/string/mod.rs
+++ b/crates/lib/src/stdlib/filters/string/mod.rs
@@ -37,7 +37,7 @@ struct SplitFilter {
 }
 
 impl Filter for SplitFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let input = input.to_kstr();

--- a/crates/lib/src/stdlib/filters/string/operate.rs
+++ b/crates/lib/src/stdlib/filters/string/operate.rs
@@ -34,7 +34,7 @@ struct ReplaceFilter {
 }
 
 impl Filter for ReplaceFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let input = input.to_kstr();
@@ -75,7 +75,7 @@ struct ReplaceFirstFilter {
 }
 
 impl Filter for ReplaceFirstFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let input = input.to_kstr();
@@ -117,7 +117,7 @@ struct RemoveFilter {
 }
 
 impl Filter for RemoveFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let input = input.to_kstr();
@@ -149,7 +149,7 @@ struct RemoveFirstFilter {
 }
 
 impl Filter for RemoveFirstFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let input = input.to_kstr();
@@ -183,7 +183,7 @@ struct AppendFilter {
 }
 
 impl Filter for AppendFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let mut input = input.to_kstr().into_string();
@@ -216,7 +216,7 @@ struct PrependFilter {
 }
 
 impl Filter for PrependFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let input = input.to_kstr();

--- a/crates/lib/src/stdlib/filters/string/strip.rs
+++ b/crates/lib/src/stdlib/filters/string/strip.rs
@@ -23,7 +23,7 @@ pub struct Strip;
 struct StripFilter;
 
 impl Filter for StripFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         let input = input.to_kstr();
         Ok(Value::scalar(input.trim().to_owned()))
     }
@@ -48,7 +48,7 @@ pub struct Lstrip;
 struct LstripFilter;
 
 impl Filter for LstripFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         let input = input.to_kstr();
         Ok(Value::scalar(input.trim_start().to_owned()))
     }
@@ -73,7 +73,7 @@ pub struct Rstrip;
 struct RstripFilter;
 
 impl Filter for RstripFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         let input = input.to_kstr();
         Ok(Value::scalar(input.trim_end().to_owned()))
     }
@@ -92,7 +92,7 @@ pub struct StripNewlines;
 struct StripNewlinesFilter;
 
 impl Filter for StripNewlinesFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         let input = input.to_kstr();
         Ok(Value::scalar(
             input

--- a/crates/lib/src/stdlib/filters/string/truncate.rs
+++ b/crates/lib/src/stdlib/filters/string/truncate.rs
@@ -67,7 +67,7 @@ struct TruncateFilter {
 }
 
 impl Filter for TruncateFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let length = args.lenght.unwrap_or(50) as usize;
@@ -126,7 +126,7 @@ struct TruncateWordsFilter {
 }
 
 impl Filter for TruncateWordsFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let words = args.lenght.unwrap_or(50) as usize;

--- a/crates/lib/src/stdlib/filters/url.rs
+++ b/crates/lib/src/stdlib/filters/url.rs
@@ -23,7 +23,7 @@ pub struct UrlEncode;
 struct UrlEncodeFilter;
 
 impl Filter for UrlEncodeFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         if input.is_nil() {
             return Ok(Value::Nil);
         }
@@ -48,7 +48,7 @@ pub struct UrlDecode;
 struct UrlDecodeFilter;
 
 impl Filter for UrlDecodeFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         if input.is_nil() {
             return Ok(Value::Nil);
         }

--- a/crates/lib/src/stdlib/tags/assign_tag.rs
+++ b/crates/lib/src/stdlib/tags/assign_tag.rs
@@ -10,7 +10,7 @@ use liquid_core::{ParseTag, TagReflection, TagTokenIter};
 
 #[derive(Debug)]
 struct Assign {
-    dst: String,
+    dst: kstring::KString,
     src: FilterChain,
 }
 
@@ -21,13 +21,13 @@ impl Assign {
 }
 
 impl Renderable for Assign {
-    fn render_to(&self, _writer: &mut dyn Write, runtime: &mut Runtime<'_>) -> Result<()> {
+    fn render_to(&self, _writer: &mut dyn Write, runtime: &dyn Runtime) -> Result<()> {
         let value = self
             .src
             .evaluate(runtime)
             .trace_with(|| self.trace().into())?
             .into_owned();
-        runtime.stack_mut().set_global(self.dst.to_owned(), value);
+        runtime.set_global(self.dst.clone(), value);
         Ok(())
     }
 }
@@ -61,7 +61,8 @@ impl ParseTag for AssignTag {
             .expect_next("Identifier expected.")?
             .expect_identifier()
             .into_result()?
-            .to_string();
+            .to_string()
+            .into();
 
         arguments
             .expect_next("Assignment operator \"=\" expected.")?
@@ -92,6 +93,7 @@ mod test {
     use liquid_core::model::Value;
     use liquid_core::parser;
     use liquid_core::runtime;
+    use liquid_core::runtime::RuntimeBuilder;
 
     use crate::stdlib;
 
@@ -116,9 +118,9 @@ mod test {
             .map(runtime::Template::new)
             .unwrap();
 
-        let mut runtime = Runtime::new();
+        let runtime = RuntimeBuilder::new().build();
 
-        let output = template.render(&mut runtime).unwrap();
+        let output = template.render(&runtime).unwrap();
         assert_eq!(output, "false");
     }
 
@@ -130,9 +132,9 @@ mod test {
             .map(runtime::Template::new)
             .unwrap();
 
-        let mut runtime = Runtime::new();
-        runtime.stack_mut().set_global(
-            "tags",
+        let runtime = RuntimeBuilder::new().build();
+        runtime.set_global(
+            "tags".into(),
             Value::Array(vec![
                 Value::scalar("alpha"),
                 Value::scalar("beta"),
@@ -140,7 +142,7 @@ mod test {
             ]),
         );
 
-        let output = template.render(&mut runtime).unwrap();
+        let output = template.render(&runtime).unwrap();
         assert_eq!(output, "beta");
     }
 
@@ -155,9 +157,9 @@ mod test {
             .map(runtime::Template::new)
             .unwrap();
 
-        let mut runtime = Runtime::new();
-        runtime.stack_mut().set_global(
-            "tags",
+        let runtime = RuntimeBuilder::new().build();
+        runtime.set_global(
+            "tags".into(),
             Value::Object(
                 vec![("greek".into(), Value::scalar("alpha"))]
                     .into_iter()
@@ -165,7 +167,7 @@ mod test {
             ),
         );
 
-        let output = template.render(&mut runtime).unwrap();
+        let output = template.render(&runtime).unwrap();
         assert_eq!(output, "alpha");
     }
 
@@ -188,9 +190,9 @@ mod test {
 
         // test one: no matching value in `tags`
         {
-            let mut runtime = Runtime::new();
-            runtime.stack_mut().set_global(
-                "tags",
+            let runtime = RuntimeBuilder::new().build();
+            runtime.set_global(
+                "tags".into(),
                 Value::Array(vec![
                     Value::scalar("alpha"),
                     Value::scalar("beta"),
@@ -198,19 +200,16 @@ mod test {
                 ]),
             );
 
-            let output = template.render(&mut runtime).unwrap();
-            assert_eq!(
-                runtime.stack().get(&[Scalar::new("freestyle")]).unwrap(),
-                false
-            );
+            let output = template.render(&runtime).unwrap();
+            assert_eq!(runtime.get(&[Scalar::new("freestyle")]).unwrap(), false);
             assert_eq!(output, "");
         }
 
         // test two: matching value in `tags`
         {
-            let mut runtime = Runtime::new();
-            runtime.stack_mut().set_global(
-                "tags",
+            let runtime = RuntimeBuilder::new().build();
+            runtime.set_global(
+                "tags".into(),
                 Value::Array(vec![
                     Value::scalar("alpha"),
                     Value::scalar("beta"),
@@ -219,11 +218,8 @@ mod test {
                 ]),
             );
 
-            let output = template.render(&mut runtime).unwrap();
-            assert_eq!(
-                runtime.stack().get(&[Scalar::new("freestyle")]).unwrap(),
-                true
-            );
+            let output = template.render(&runtime).unwrap();
+            assert_eq!(runtime.get(&[Scalar::new("freestyle")]).unwrap(), true);
             assert_eq!(output, "<p>Freestyle!</p>");
         }
     }

--- a/crates/lib/src/stdlib/tags/assign_tag.rs
+++ b/crates/lib/src/stdlib/tags/assign_tag.rs
@@ -8,30 +8,6 @@ use liquid_core::Result;
 use liquid_core::Runtime;
 use liquid_core::{ParseTag, TagReflection, TagTokenIter};
 
-#[derive(Debug)]
-struct Assign {
-    dst: kstring::KString,
-    src: FilterChain,
-}
-
-impl Assign {
-    fn trace(&self) -> String {
-        format!("{{% assign {} = {}%}}", self.dst, self.src)
-    }
-}
-
-impl Renderable for Assign {
-    fn render_to(&self, _writer: &mut dyn Write, runtime: &dyn Runtime) -> Result<()> {
-        let value = self
-            .src
-            .evaluate(runtime)
-            .trace_with(|| self.trace().into())?
-            .into_owned();
-        runtime.set_global(self.dst.clone(), value);
-        Ok(())
-    }
-}
-
 #[derive(Copy, Clone, Debug, Default)]
 pub struct AssignTag;
 
@@ -82,6 +58,30 @@ impl ParseTag for AssignTag {
 
     fn reflection(&self) -> &dyn TagReflection {
         self
+    }
+}
+
+#[derive(Debug)]
+struct Assign {
+    dst: kstring::KString,
+    src: FilterChain,
+}
+
+impl Assign {
+    fn trace(&self) -> String {
+        format!("{{% assign {} = {}%}}", self.dst, self.src)
+    }
+}
+
+impl Renderable for Assign {
+    fn render_to(&self, _writer: &mut dyn Write, runtime: &dyn Runtime) -> Result<()> {
+        let value = self
+            .src
+            .evaluate(runtime)
+            .trace_with(|| self.trace().into())?
+            .into_owned();
+        runtime.set_global(self.dst.clone(), value);
+        Ok(())
     }
 }
 

--- a/crates/lib/src/stdlib/tags/include_tag.rs
+++ b/crates/lib/src/stdlib/tags/include_tag.rs
@@ -10,54 +10,6 @@ use liquid_core::{runtime::StackFrame, Runtime};
 use liquid_core::{Error, Result};
 use liquid_core::{ParseTag, TagReflection, TagTokenIter};
 
-#[derive(Debug)]
-struct Include {
-    partial: Expression,
-    vars: Vec<(KString, Expression)>,
-}
-
-impl Renderable for Include {
-    fn render_to(&self, writer: &mut dyn Write, runtime: &dyn Runtime) -> Result<()> {
-        let value = self.partial.evaluate(runtime)?;
-        if !value.is_scalar() {
-            return Error::with_msg("Can only `include` strings")
-                .context("partial", format!("{}", value.source()))
-                .into_err();
-        }
-        let name = value.to_kstr().into_owned();
-
-        {
-            // if there our additional variables creates a include object to access all the varaibles
-            // from e.g. { include 'image.html' path="foo.png" }
-            // then in image.html you could have <img src="{{include.path}}" />
-            let mut pass_through = std::collections::HashMap::new();
-            if !self.vars.is_empty() {
-                for (id, val) in &self.vars {
-                    let value = val
-                        .try_evaluate(runtime)
-                        .ok_or_else(|| Error::with_msg("failed to evaluate value"))?;
-
-                    pass_through.insert(id.as_ref(), value);
-                }
-            }
-
-            let scope = StackFrame::new(runtime, &pass_through);
-            let partial = scope
-                .partials()
-                .get(&name)
-                .trace_with(|| format!("{{% include {} %}}", self.partial).into())?;
-
-            partial
-                .render_to(writer, &scope)
-                .trace_with(|| format!("{{% include {} %}}", self.partial).into())
-                .context_key_with(|| self.partial.to_string().into())
-                .value_with(|| name.to_string().into())?;
-        }
-
-        Ok(())
-    }
-}
-
 #[derive(Copy, Clone, Debug, Default)]
 pub struct IncludeTag;
 
@@ -120,6 +72,54 @@ impl ParseTag for IncludeTag {
 
     fn reflection(&self) -> &dyn TagReflection {
         self
+    }
+}
+
+#[derive(Debug)]
+struct Include {
+    partial: Expression,
+    vars: Vec<(KString, Expression)>,
+}
+
+impl Renderable for Include {
+    fn render_to(&self, writer: &mut dyn Write, runtime: &dyn Runtime) -> Result<()> {
+        let value = self.partial.evaluate(runtime)?;
+        if !value.is_scalar() {
+            return Error::with_msg("Can only `include` strings")
+                .context("partial", format!("{}", value.source()))
+                .into_err();
+        }
+        let name = value.to_kstr().into_owned();
+
+        {
+            // if there our additional variables creates a include object to access all the varaibles
+            // from e.g. { include 'image.html' path="foo.png" }
+            // then in image.html you could have <img src="{{include.path}}" />
+            let mut pass_through = std::collections::HashMap::new();
+            if !self.vars.is_empty() {
+                for (id, val) in &self.vars {
+                    let value = val
+                        .try_evaluate(runtime)
+                        .ok_or_else(|| Error::with_msg("failed to evaluate value"))?;
+
+                    pass_through.insert(id.as_ref(), value);
+                }
+            }
+
+            let scope = StackFrame::new(runtime, &pass_through);
+            let partial = scope
+                .partials()
+                .get(&name)
+                .trace_with(|| format!("{{% include {} %}}", self.partial).into())?;
+
+            partial
+                .render_to(writer, &scope)
+                .trace_with(|| format!("{{% include {} %}}", self.partial).into())
+                .context_key_with(|| self.partial.to_string().into())
+                .value_with(|| name.to_string().into())?;
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/lib/src/stdlib/tags/include_tag.rs
+++ b/crates/lib/src/stdlib/tags/include_tag.rs
@@ -211,12 +211,12 @@ mod test {
         let partials = partials::OnDemandCompiler::<TestSource>::empty()
             .compile(::std::sync::Arc::new(options))
             .unwrap();
-        let mut runtime = RuntimeBuilder::new()
+        let runtime = RuntimeBuilder::new()
             .set_partials(partials.as_ref())
             .build();
         runtime.set_global("num".into(), Value::scalar(5f64));
         runtime.set_global("numTwo".into(), Value::scalar(10f64));
-        let output = template.render(&mut runtime).unwrap();
+        let output = template.render(&runtime).unwrap();
         assert_eq!(output, "5 wat wot");
     }
 
@@ -231,10 +231,10 @@ mod test {
         let partials = partials::OnDemandCompiler::<TestSource>::empty()
             .compile(::std::sync::Arc::new(options))
             .unwrap();
-        let mut runtime = RuntimeBuilder::new()
+        let runtime = RuntimeBuilder::new()
             .set_partials(partials.as_ref())
             .build();
-        let output = template.render(&mut runtime).unwrap();
+        let output = template.render(&runtime).unwrap();
         assert_eq!(output, "hello");
     }
 
@@ -249,10 +249,10 @@ mod test {
         let partials = partials::OnDemandCompiler::<TestSource>::empty()
             .compile(::std::sync::Arc::new(options))
             .unwrap();
-        let mut runtime = RuntimeBuilder::new()
+        let runtime = RuntimeBuilder::new()
             .set_partials(partials.as_ref())
             .build();
-        let output = template.render(&mut runtime).unwrap();
+        let output = template.render(&runtime).unwrap();
         assert_eq!(output, "hello world");
     }
 
@@ -267,10 +267,10 @@ mod test {
         let partials = partials::OnDemandCompiler::<TestSource>::empty()
             .compile(::std::sync::Arc::new(options))
             .unwrap();
-        let mut runtime = RuntimeBuilder::new()
+        let runtime = RuntimeBuilder::new()
             .set_partials(partials.as_ref())
             .build();
-        let output = template.render(&mut runtime).unwrap();
+        let output = template.render(&runtime).unwrap();
         assert_eq!(output, "hello dogs");
     }
 
@@ -288,12 +288,12 @@ mod test {
         let partials = partials::OnDemandCompiler::<TestSource>::empty()
             .compile(::std::sync::Arc::new(options))
             .unwrap();
-        let mut runtime = RuntimeBuilder::new()
+        let runtime = RuntimeBuilder::new()
             .set_partials(partials.as_ref())
             .build();
         runtime.set_global("num".into(), Value::scalar(5f64));
         runtime.set_global("numTwo".into(), Value::scalar(10f64));
-        let output = template.render(&mut runtime);
+        let output = template.render(&runtime);
         assert!(output.is_err());
     }
 }

--- a/crates/lib/src/stdlib/tags/include_tag.rs
+++ b/crates/lib/src/stdlib/tags/include_tag.rs
@@ -4,7 +4,6 @@ use kstring::KString;
 use liquid_core::error::ResultLiquidExt;
 use liquid_core::Expression;
 use liquid_core::Language;
-use liquid_core::Object;
 use liquid_core::Renderable;
 use liquid_core::ValueView;
 use liquid_core::{runtime::StackFrame, Runtime};
@@ -31,15 +30,14 @@ impl Renderable for Include {
             // if there our additional variables creates a include object to access all the varaibles
             // from e.g. { include 'image.html' path="foo.png" }
             // then in image.html you could have <img src="{{include.path}}" />
-            let mut pass_through = Object::new();
+            let mut pass_through = std::collections::HashMap::new();
             if !self.vars.is_empty() {
                 for (id, val) in &self.vars {
                     let value = val
                         .try_evaluate(runtime)
-                        .ok_or_else(|| Error::with_msg("failed to evaluate value"))?
-                        .into_owned();
+                        .ok_or_else(|| Error::with_msg("failed to evaluate value"))?;
 
-                    pass_through.insert(id.clone(), value);
+                    pass_through.insert(id.as_ref(), value);
                 }
             }
 

--- a/crates/lib/src/stdlib/tags/increment_tags.rs
+++ b/crates/lib/src/stdlib/tags/increment_tags.rs
@@ -8,25 +8,6 @@ use liquid_core::Result;
 use liquid_core::Runtime;
 use liquid_core::{ParseTag, TagReflection, TagTokenIter};
 
-#[derive(Clone, Debug)]
-struct Increment {
-    id: kstring::KString,
-}
-
-impl Renderable for Increment {
-    fn render_to(&self, writer: &mut dyn Write, runtime: &dyn Runtime) -> Result<()> {
-        let mut val = runtime
-            .get_index(&self.id)
-            .and_then(|i| i.as_scalar().and_then(|i| i.to_integer()))
-            .unwrap_or(0);
-
-        write!(writer, "{}", val).replace("Failed to render")?;
-        val += 1;
-        runtime.set_index(self.id.clone(), Value::scalar(val));
-        Ok(())
-    }
-}
-
 #[derive(Copy, Clone, Debug, Default)]
 pub struct IncrementTag;
 
@@ -71,19 +52,19 @@ impl ParseTag for IncrementTag {
 }
 
 #[derive(Clone, Debug)]
-struct Decrement {
+struct Increment {
     id: kstring::KString,
 }
 
-impl Renderable for Decrement {
+impl Renderable for Increment {
     fn render_to(&self, writer: &mut dyn Write, runtime: &dyn Runtime) -> Result<()> {
         let mut val = runtime
             .get_index(&self.id)
             .and_then(|i| i.as_scalar().and_then(|i| i.to_integer()))
             .unwrap_or(0);
 
-        val -= 1;
         write!(writer, "{}", val).replace("Failed to render")?;
+        val += 1;
         runtime.set_index(self.id.clone(), Value::scalar(val));
         Ok(())
     }
@@ -129,6 +110,25 @@ impl ParseTag for DecrementTag {
 
     fn reflection(&self) -> &dyn TagReflection {
         self
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Decrement {
+    id: kstring::KString,
+}
+
+impl Renderable for Decrement {
+    fn render_to(&self, writer: &mut dyn Write, runtime: &dyn Runtime) -> Result<()> {
+        let mut val = runtime
+            .get_index(&self.id)
+            .and_then(|i| i.as_scalar().and_then(|i| i.to_integer()))
+            .unwrap_or(0);
+
+        val -= 1;
+        write!(writer, "{}", val).replace("Failed to render")?;
+        runtime.set_index(self.id.clone(), Value::scalar(val));
+        Ok(())
     }
 }
 

--- a/crates/lib/src/stdlib/tags/interrupt_tags.rs
+++ b/crates/lib/src/stdlib/tags/interrupt_tags.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use liquid_core::runtime::Interrupt;
+use liquid_core::runtime::{Interrupt, InterruptRegister};
 use liquid_core::Language;
 use liquid_core::Renderable;
 use liquid_core::Result;
@@ -11,8 +11,11 @@ use liquid_core::{ParseTag, TagReflection, TagTokenIter};
 struct Break;
 
 impl Renderable for Break {
-    fn render_to(&self, _writer: &mut dyn Write, runtime: &mut Runtime<'_>) -> Result<()> {
-        runtime.interrupt_mut().set_interrupt(Interrupt::Break);
+    fn render_to(&self, _writer: &mut dyn Write, runtime: &dyn Runtime) -> Result<()> {
+        runtime
+            .registers()
+            .get_mut::<InterruptRegister>()
+            .set(Interrupt::Break);
         Ok(())
     }
 }
@@ -56,8 +59,11 @@ impl ParseTag for BreakTag {
 struct Continue;
 
 impl Renderable for Continue {
-    fn render_to(&self, _writer: &mut dyn Write, runtime: &mut Runtime<'_>) -> Result<()> {
-        runtime.interrupt_mut().set_interrupt(Interrupt::Continue);
+    fn render_to(&self, _writer: &mut dyn Write, runtime: &dyn Runtime) -> Result<()> {
+        runtime
+            .registers()
+            .get_mut::<InterruptRegister>()
+            .set(Interrupt::Continue);
         Ok(())
     }
 }
@@ -103,6 +109,7 @@ mod test {
 
     use liquid_core::parser;
     use liquid_core::runtime;
+    use liquid_core::runtime::RuntimeBuilder;
 
     use crate::stdlib;
 
@@ -134,8 +141,8 @@ mod test {
             .map(runtime::Template::new)
             .unwrap();
 
-        let mut rt = Runtime::new();
-        let output = template.render(&mut rt).unwrap();
+        let rt = RuntimeBuilder::new().build();
+        let output = template.render(&rt).unwrap();
         assert_eq!(
             output,
             concat!("enter-0;exit-0\n", "enter-1;exit-1\n", "enter-2;break-2\n")
@@ -159,8 +166,8 @@ mod test {
             .map(runtime::Template::new)
             .unwrap();
 
-        let mut rt = Runtime::new();
-        let output = template.render(&mut rt).unwrap();
+        let rt = RuntimeBuilder::new().build();
+        let output = template.render(&rt).unwrap();
         assert_eq!(
             output,
             concat!(
@@ -185,8 +192,8 @@ mod test {
             .map(runtime::Template::new)
             .unwrap();
 
-        let mut rt = Runtime::new();
-        let output = template.render(&mut rt).unwrap();
+        let rt = RuntimeBuilder::new().build();
+        let output = template.render(&rt).unwrap();
         assert_eq!(
             output,
             concat!(
@@ -217,8 +224,8 @@ mod test {
             .map(runtime::Template::new)
             .unwrap();
 
-        let mut rt = Runtime::new();
-        let output = template.render(&mut rt).unwrap();
+        let rt = RuntimeBuilder::new().build();
+        let output = template.render(&rt).unwrap();
         assert_eq!(
             output,
             concat!(

--- a/crates/lib/src/stdlib/tags/interrupt_tags.rs
+++ b/crates/lib/src/stdlib/tags/interrupt_tags.rs
@@ -7,19 +7,6 @@ use liquid_core::Result;
 use liquid_core::Runtime;
 use liquid_core::{ParseTag, TagReflection, TagTokenIter};
 
-#[derive(Copy, Clone, Debug)]
-struct Break;
-
-impl Renderable for Break {
-    fn render_to(&self, _writer: &mut dyn Write, runtime: &dyn Runtime) -> Result<()> {
-        runtime
-            .registers()
-            .get_mut::<InterruptRegister>()
-            .set(Interrupt::Break);
-        Ok(())
-    }
-}
-
 #[derive(Copy, Clone, Debug, Default)]
 pub struct BreakTag;
 
@@ -56,14 +43,14 @@ impl ParseTag for BreakTag {
 }
 
 #[derive(Copy, Clone, Debug)]
-struct Continue;
+struct Break;
 
-impl Renderable for Continue {
+impl Renderable for Break {
     fn render_to(&self, _writer: &mut dyn Write, runtime: &dyn Runtime) -> Result<()> {
         runtime
             .registers()
             .get_mut::<InterruptRegister>()
-            .set(Interrupt::Continue);
+            .set(Interrupt::Break);
         Ok(())
     }
 }
@@ -100,6 +87,19 @@ impl ParseTag for ContinueTag {
 
     fn reflection(&self) -> &dyn TagReflection {
         self
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+struct Continue;
+
+impl Renderable for Continue {
+    fn render_to(&self, _writer: &mut dyn Write, runtime: &dyn Runtime) -> Result<()> {
+        runtime
+            .registers()
+            .get_mut::<InterruptRegister>()
+            .set(Interrupt::Continue);
+        Ok(())
     }
 }
 

--- a/crates/lib/tests/test_helper.rs
+++ b/crates/lib/tests/test_helper.rs
@@ -2,7 +2,7 @@ pub use liquid_core::Value::Nil;
 
 #[allow(dead_code)]
 pub fn date(y: i32, m: u32, d: u32) -> liquid_core::Value {
-    use liquid_core::model::scalar::Date;
+    use liquid_core::model::Date;
     use liquid_core::model::Value;
     Value::scalar(Date::from_ymd(y, m, d))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,11 +38,11 @@ pub mod model {
 
 pub use crate::parser::*;
 pub use crate::template::*;
+pub use liquid_core::model::{_ObjectView as ObjectView, _ValueView as ValueView};
 pub use liquid_core::object;
 pub use liquid_core::to_object;
 pub use liquid_core::Error;
 pub use liquid_core::Object;
-pub use liquid_core::{ObjectView, ValueView};
 #[doc(hidden)]
 pub use liquid_derive::{ObjectView, ValueView};
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -28,8 +28,8 @@ impl Template {
             Some(ref partials) => runtime.set_partials(partials.as_ref()),
             None => runtime,
         };
-        let mut runtime = runtime.build();
-        self.template.render_to(writer, &mut runtime)
+        let runtime = runtime.build();
+        self.template.render_to(writer, &runtime)
     }
 }
 

--- a/tests/conformance_ruby/filter_test.rs
+++ b/tests/conformance_ruby/filter_test.rs
@@ -12,7 +12,7 @@ pub struct MoneyFilterParser;
 pub struct MoneyFilter;
 
 impl Filter for MoneyFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         Ok(Value::scalar(format!(" {}$ ", input.render())))
     }
 }
@@ -30,7 +30,7 @@ pub struct MoneyWithUnderscoreFilterParser;
 pub struct MoneyWithUnderscoreFilter;
 
 impl Filter for MoneyWithUnderscoreFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         Ok(Value::scalar(format!(" {}$ ", input.render())))
     }
 }
@@ -56,7 +56,7 @@ pub struct SubstituteFilterParser;
 pub struct SubstituteFilter;
 
 impl Filter for SubstituteFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         Ok(Value::scalar(format!(
             "No keyword argument support: {}",
             input.render()

--- a/tests/conformance_ruby/output_test.rs
+++ b/tests/conformance_ruby/output_test.rs
@@ -17,7 +17,7 @@ pub struct MakeFunnyFilterParser;
 pub struct MakeFunnyFilter;
 
 impl Filter for MakeFunnyFilter {
-    fn evaluate(&self, _input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, _input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         Ok(Value::scalar("LOL"))
     }
 }
@@ -35,7 +35,7 @@ pub struct CiteFunnyFilterParser;
 pub struct CiteFunnyFilter;
 
 impl Filter for CiteFunnyFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         Ok(Value::scalar(format!("LOL: {}", input.render())))
     }
 }
@@ -63,7 +63,7 @@ pub struct AddSmileyFilter {
 }
 
 impl Filter for AddSmileyFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
         let smiley = args.smiley.unwrap_or_else(|| ":-)".into()).to_string();
         Ok(Value::scalar(format!("{} {}", input.render(), smiley)))
@@ -96,7 +96,7 @@ pub struct AddTagFilter {
 }
 
 impl Filter for AddTagFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let tag = args.tag.unwrap_or_else(|| "p".into()).to_string();
@@ -124,7 +124,7 @@ pub struct ParagraphFilterParser;
 pub struct ParagraphFilter;
 
 impl Filter for ParagraphFilter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         Ok(Value::scalar(format!("<p>{}</p>", input.render())))
     }
 }
@@ -152,7 +152,7 @@ pub struct LinkToFilter {
 }
 
 impl Filter for LinkToFilter {
-    fn evaluate(&self, input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let name = input;

--- a/tests/derive_macros_test_filters/keyword.rs
+++ b/tests/derive_macros_test_filters/keyword.rs
@@ -40,7 +40,7 @@ pub struct TestKeywordFilter {
 }
 
 impl Filter for TestKeywordFilter {
-    fn evaluate(&self, _input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, _input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let required = args.required;

--- a/tests/derive_macros_test_filters/mixed.rs
+++ b/tests/derive_macros_test_filters/mixed.rs
@@ -53,7 +53,7 @@ pub struct TestMixedFilter {
 
 #[allow(clippy::many_single_char_names)]
 impl Filter for TestMixedFilter {
-    fn evaluate(&self, _input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, _input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let a = args

--- a/tests/derive_macros_test_filters/parameterless.rs
+++ b/tests/derive_macros_test_filters/parameterless.rs
@@ -16,7 +16,7 @@ pub struct TestParameterlessFilterParser;
 pub struct TestParameterlessFilter;
 
 impl Filter for TestParameterlessFilter {
-    fn evaluate(&self, _input: &dyn ValueView, _runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, _input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         let result = "<>";
 
         Ok(Value::scalar(result))

--- a/tests/derive_macros_test_filters/positional.rs
+++ b/tests/derive_macros_test_filters/positional.rs
@@ -35,7 +35,7 @@ pub struct TestPositionalFilter {
 }
 
 impl Filter for TestPositionalFilter {
-    fn evaluate(&self, _input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, _input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let pos1 = args.pos1.to_kstr();

--- a/tests/derive_macros_test_filters/stateful.rs
+++ b/tests/derive_macros_test_filters/stateful.rs
@@ -66,7 +66,7 @@ pub struct TestStatefulFilter {
 }
 
 impl Filter for TestStatefulFilter {
-    fn evaluate(&self, _input: &dyn ValueView, runtime: &Runtime<'_>) -> Result<Value> {
+    fn evaluate(&self, _input: &dyn ValueView, runtime: &dyn Runtime) -> Result<Value> {
         let args = self.args.evaluate(runtime)?;
 
         let result = match self.state {

--- a/tests/test_helper.rs
+++ b/tests/test_helper.rs
@@ -2,7 +2,7 @@ pub use liquid_core::Value::Nil;
 
 #[allow(dead_code)]
 pub fn date(y: i32, m: u32, d: u32) -> liquid_core::Value {
-    use liquid_core::model::scalar::Date;
+    use liquid_core::model::Date;
     use liquid_core::model::Value;
     Value::scalar(Date::from_ymd(y, m, d))
 }


### PR DESCRIPTION
Currently, the lifetimes don't work out to allow this.
- We push frames onto the stack, so Rust has no idea of the relative lifetimes and gets into the self-referential struct territory
- One of the frames of the stack is mutable

The downside is that when we do something like a for-loop, we have to `clone` the entire value we'll iterate on to ensure its lifetime. At least we get to reuse each element when we move it into the user-defined variable name.

This changes the stack frames to leverage Rust's stack which gives the compiler insights into the lifetimes, along with some `RefCell`s.

This also updates all but the iterated value in `forloop` / `tablerow` to take advantage of this feature.

Fixes #337