### PR TITLE
fix(liquid-core)!: allow block tags not in the `<name>`-`end<name>` format

### DIFF
--- a/crates/core/src/parser/parser.rs
+++ b/crates/core/src/parser/parser.rs
@@ -355,8 +355,8 @@ impl<'a, 'b> TagBlock<'a, 'b> {
                 return error_from_pair(
                     element,
                     format!(
-                        "Unclosed block. {{% end{} %}} tag expected.",
-                        self.start_tag
+                        "Unclosed block. {{% {} %}} tag expected.",
+                        self.end_tag
                     ),
                 )
                 .into_err();

--- a/crates/core/src/parser/parser.rs
+++ b/crates/core/src/parser/parser.rs
@@ -354,10 +354,7 @@ impl<'a, 'b> TagBlock<'a, 'b> {
             if element.as_rule() == Rule::EOI {
                 return error_from_pair(
                     element,
-                    format!(
-                        "Unclosed block. {{% {} %}} tag expected.",
-                        self.end_tag
-                    ),
+                    format!("Unclosed block. {{% {} %}} tag expected.", self.end_tag),
                 )
                 .into_err();
             }
@@ -548,11 +545,8 @@ impl<'a> Tag<'a> {
         if let Some(plugin) = options.tags.get(name) {
             plugin.parse(tokens, options)
         } else if let Some(plugin) = options.blocks.get(name) {
-            let (start_tag, end_tag) = {
-                let reflection = plugin.reflection();
-                (reflection.start_tag(), reflection.end_tag())
-            };
-            let block = TagBlock::new(start_tag, end_tag, next_elements);
+            let reflection = plugin.reflection();
+            let block = TagBlock::new(reflection.start_tag(), reflection.end_tag(), next_elements);
             let renderables = plugin.parse(tokens, block, options)?;
             Ok(renderables)
         } else {

--- a/crates/core/src/parser/parser.rs
+++ b/crates/core/src/parser/parser.rs
@@ -372,11 +372,8 @@ impl<'a, 'b> TagBlock<'a, 'b> {
                 let name = tag.next().expect("Tags start by their identifier.");
                 let name_str = name.as_str();
 
-                // The name of the closing tag is "end" followed by the tag's name.
-                if name_str.len() > 3
-                    && &name_str[0..3] == "end"
-                    && &name_str[3..] == self.start_tag
-                {
+                // Check if this tag is the same as the block's reflected end-tag.
+                if name_str == self.end_tag {
                     // No more arguments should be supplied. If they are, it is
                     // assumed not to be a tag closer.
                     if tag.next().is_none() {


### PR DESCRIPTION
# This PR
This PR makes changes to `TagBlock` so that it checks ending tags against the block's `BlockReflection::end_tag()` instead of `end<name>` where `<name>` is the tag name the block plugin was registered under.

This PR also changes `TagBlock` so that it compares starting tags in nested `escape_liquid` blocks against `BlockReflection::start_tag()` instead of the tag name the block plugin was registered under. Block plugins are normally registered under their `BlockReflection::start_tag()` value, but anything registering block plugins under a different name than the block's `start_tag()` value will experience strange behavior.

This PR also adds unit tests to `parser.rs` that check to make sure both `<name>`-`end<name>` and non-`<name>`-`end<name>` block tags parse as expected. These tests are implemented as a macro to reduce code-duplication. If you would like me to implement these tests differently or move them to another file, please let me know.

If you would like me to squash the commits or re-order them for clarity, please let me know.

# PR Checklist
- [x] `cargo test --workspace` passes under rust nightly.
- [x] Tests created for any new feature or regression tests for bugfixes.
- [x] This change adds no new `cargo clippy` warnings and no errors.
- [x] `cargo fmt` has been run.

# Related Issues
This PR fixes #452.