### PR TITLE
Update crate version mentioned in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To include liquid in your project add the following to your Cargo.toml:
 
 ```toml
 [dependencies]
-liquid = "0.20"
+liquid = "0.23"
 ```
 
 Example:


### PR DESCRIPTION
The README mentions to add `liquid = "0.20"` to Cargo.toml but the current crate version is 0.23.1

