### PR TITLE
Lax rendering and parsing

### DIFF
--- a/crates/core/src/parser/filter.rs
+++ b/crates/core/src/parser/filter.rs
@@ -254,3 +254,19 @@ where
         Box::new(filter)
     }
 }
+
+/// A filter used internally when parsing is done in lax mode.
+#[derive(Debug, Default)]
+pub struct NoopFilter;
+
+impl Filter for NoopFilter {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
+        Ok(input.to_value())
+    }
+}
+
+impl Display for NoopFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        ::std::write!(f, "{}", "noop")
+    }
+}

--- a/crates/core/src/parser/lang.rs
+++ b/crates/core/src/parser/lang.rs
@@ -3,12 +3,25 @@ use super::ParseFilter;
 use super::ParseTag;
 use super::PluginRegistry;
 
+#[derive(Clone)]
+pub enum ParseMode {
+    Strict,
+    Lax,
+}
+
+impl Default for ParseMode {
+    fn default() -> Self {
+        Self::Strict
+    }
+}
+
 #[derive(Clone, Default)]
 #[non_exhaustive]
 pub struct Language {
     pub blocks: PluginRegistry<Box<dyn ParseBlock>>,
     pub tags: PluginRegistry<Box<dyn ParseTag>>,
     pub filters: PluginRegistry<Box<dyn ParseFilter>>,
+    pub mode: ParseMode,
 }
 
 impl Language {

--- a/crates/core/src/parser/parser.rs
+++ b/crates/core/src/parser/parser.rs
@@ -9,9 +9,9 @@ use crate::runtime::Expression;
 use crate::runtime::Renderable;
 use crate::runtime::Variable;
 
-use super::Language;
 use super::Text;
 use super::{Filter, FilterArguments, FilterChain};
+use super::{Language, ParseMode};
 
 use pest::Parser;
 
@@ -205,22 +205,38 @@ fn parse_filter(filter: Pair, options: &Language) -> Result<Box<dyn Filter>> {
         keyword: Box::new(keyword_args.into_iter()),
     };
 
-    let f = options.filters.get(name).ok_or_else(|| {
-        let mut available: Vec<_> = options.filters.plugin_names().collect();
-        available.sort_unstable();
-        let available = itertools::join(available, ", ");
-        Error::with_msg("Unknown filter")
-            .context("requested filter", name.to_owned())
-            .context("available filters", available)
-    })?;
+    match options.mode {
+        ParseMode::Strict => {
+            let f = options.filters.get(name).ok_or_else(|| {
+                let mut available: Vec<_> = options.filters.plugin_names().collect();
+                available.sort_unstable();
+                let available = itertools::join(available, ", ");
+                Error::with_msg("Unknown filter")
+                    .context("requested filter", name.to_owned())
+                    .context("available filters", available)
+            })?;
 
-    let f = f
-        .parse(args)
-        .trace("Filter parsing error")
-        .context_key("filter")
-        .value_with(|| filter_str.to_string().into())?;
+            let f = f
+                .parse(args)
+                .trace("Filter parsing error")
+                .context_key("filter")
+                .value_with(|| filter_str.to_string().into())?;
 
-    Ok(f)
+            Ok(f)
+        }
+        ParseMode::Lax => match options.filters.get(name) {
+            Some(f) => {
+                let f = f
+                    .parse(args)
+                    .trace("Filter parsing error")
+                    .context_key("filter")
+                    .value_with(|| filter_str.to_string().into())?;
+
+                Ok(f)
+            }
+            None => Ok(Box::new(super::NoopFilter {})),
+        },
+    }
 }
 
 /// Parses a `FilterChain` from a `Pair` with a filter chain.
@@ -1170,6 +1186,20 @@ mod test {
         let output = template.render(&runtime).unwrap();
 
         assert_eq!(output, "5");
+    }
+
+    #[test]
+    fn test_parse_mode_filters() {
+        let mut options = Language::default();
+        let text = "{{ exp | undefined }}";
+
+        options.mode = ParseMode::Strict;
+        let result = parse(text, &options);
+        assert_eq!(result.is_err(), true);
+
+        options.mode = ParseMode::Lax;
+        let result = parse(text, &options);
+        assert_eq!(result.is_err(), false);
     }
 
     /// Macro implementation of custom block test.

--- a/crates/core/src/runtime/stack.rs
+++ b/crates/core/src/runtime/stack.rs
@@ -87,6 +87,10 @@ impl<P: super::Runtime, O: ObjectView> super::Runtime for StackFrame<P, O> {
     fn registers(&self) -> &super::Registers {
         self.parent.registers()
     }
+
+    fn render_mode(&self) -> &super::RenderingMode {
+        self.parent.render_mode()
+    }
 }
 
 pub(crate) struct GlobalFrame<P> {
@@ -162,6 +166,10 @@ impl<P: super::Runtime> super::Runtime for GlobalFrame<P> {
     fn registers(&self) -> &super::Registers {
         self.parent.registers()
     }
+
+    fn render_mode(&self) -> &super::RenderingMode {
+        self.parent.render_mode()
+    }
 }
 
 pub(crate) struct IndexFrame<P> {
@@ -236,5 +244,9 @@ impl<P: super::Runtime> super::Runtime for IndexFrame<P> {
 
     fn registers(&self) -> &super::Registers {
         self.parent.registers()
+    }
+
+    fn render_mode(&self) -> &super::RenderingMode {
+        self.parent.render_mode()
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,6 +5,7 @@ use std::sync;
 
 use liquid_core::error::{Result, ResultLiquidExt, ResultLiquidReplaceExt};
 use liquid_core::parser;
+use liquid_core::parser::ParseMode;
 use liquid_core::runtime;
 
 use super::Template;
@@ -19,6 +20,7 @@ pub struct ParserBuilder<P = Partials>
 where
     P: partials::PartialCompiler,
 {
+    mode: parser::ParseMode,
     blocks: parser::PluginRegistry<Box<dyn parser::ParseBlock>>,
     tags: parser::PluginRegistry<Box<dyn parser::ParseTag>>,
     filters: parser::PluginRegistry<Box<dyn parser::ParseFilter>>,
@@ -110,6 +112,12 @@ where
             .filter(stdlib::Where)
     }
 
+    /// Sets the parse mode to lax.
+    pub fn in_lax_mode(mut self) -> Self {
+        self.mode = ParseMode::Lax;
+        self
+    }
+
     /// Inserts a new custom block into the parser
     pub fn block<B: Into<Box<dyn parser::ParseBlock>>>(mut self, block: B) -> Self {
         let block = block.into();
@@ -136,12 +144,14 @@ where
     /// Set which partial-templates will be available.
     pub fn partials<N: partials::PartialCompiler>(self, partials: N) -> ParserBuilder<N> {
         let Self {
+            mode,
             blocks,
             tags,
             filters,
             partials: _partials,
         } = self;
         ParserBuilder {
+            mode,
             blocks,
             tags,
             filters,
@@ -152,6 +162,7 @@ where
     /// Create a parser
     pub fn build(self) -> Result<Parser> {
         let Self {
+            mode,
             blocks,
             tags,
             filters,
@@ -159,6 +170,7 @@ where
         } = self;
 
         let mut options = parser::Language::empty();
+        options.mode = mode;
         options.blocks = blocks;
         options.tags = tags;
         options.filters = filters;
@@ -178,6 +190,7 @@ where
 {
     fn default() -> Self {
         Self {
+            mode: Default::default(),
             blocks: Default::default(),
             tags: Default::default(),
             filters: Default::default(),


### PR DESCRIPTION
- [X] Tests created for any new feature or regression tests for bugfixes.

Following up on the issue I created here:
https://github.com/cobalt-org/liquid-rust/issues/490

This PR introduces two functional changes. The first being supporting a "lax" parsing mode, the second being a "lax" rendering mode.  Each additional change extends the functionality, but does not change the default behavior. 

### Parsing Mode:
In lax parsing mode, an undefined filter will simply return an internal
noop filter. That filter will simply pass along the string to the next
filter, if one is provided.

In strict parsing mode, an undefined filter will continue to return an
error.

### Rendering Mode:
In lax rendering mode, an undefined variable will simply be rendered as
a `nil` value which will ultimately result in an empty string.

In strict rendering mode, an undefined variable will continue to return
an error.

