### PR TITLE
Support millisecond precision on date variables

### DIFF
--- a/crates/core/src/model/scalar/datetime.rs
+++ b/crates/core/src/model/scalar/datetime.rs
@@ -140,12 +140,15 @@ const DATE_TIME_FORMAT_SUBSEC: &[time::format_description::FormatItem<'static>] 
 
 impl fmt::Display for DateTime {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let date_format = match self.inner.nanosecond() {
+            0 => DATE_TIME_FORMAT,
+            _ => DATE_TIME_FORMAT_SUBSEC,
+        };
+
         write!(
             f,
             "{}",
-            self.inner
-                .format(DATE_TIME_FORMAT)
-                .map_err(|_e| fmt::Error)?
+            self.inner.format(date_format).map_err(|_e| fmt::Error)?
         )
     }
 }


### PR DESCRIPTION
- [X] Tests created for any new feature or regression tests for bugfixes.

Closes #493 

To sum up, the problem describe on the issue is the following:
* Variables get serialized, in particular, datetime variables were being serialized with the following format:

```
const DATE_TIME_FORMAT: &[time::format_description::FormatItem<'static>] = time::macros::format_description!(
    "[year]-[month]-[day] [hour]:[minute]:[second] [offset_hour sign:mandatory][offset_minute]"
);
```

This format format doesn't include the subsecond component, so when a variable was being serialized, the subseconds were lost.

This PR introduces a new format for serialization and uses it for that purpose:

```
const DATE_TIME_FORMAT_SUBSEC: &[time::format_description::FormatItem<'static>] = time::macros::format_description!(
    "[year]-[month]-[day] [hour]:[minute]:[second].[subsecond] [offset_hour sign:mandatory][offset_minute]"
);
```

I also added it to the list of supported parsing date formats