### PR TITLE
Allow filter chains to start with a missing variable

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -13,7 +13,7 @@ pub mod parser;
 pub mod partials;
 pub mod runtime;
 
-pub use error::{Error, Result};
+pub use error::{Error, ErrorKind, Result};
 #[cfg(feature = "derive")]
 #[doc(hidden)]
 pub use liquid_derive::{

--- a/crates/core/src/model/find.rs
+++ b/crates/core/src/model/find.rs
@@ -219,7 +219,7 @@ pub fn find<'o>(value: &'o dyn ValueView, path: &[ScalarCow<'_>]) -> Result<Valu
                     Vec::new()
                 };
                 let available = itertools::join(available.iter(), ", ");
-                return Error::with_msg("Unknown index")
+                return Error::with_kind(crate::ErrorKind::UnknownIndex)
                     .context("variable", subpath)
                     .context("requested index", format!("{}", requested.render()))
                     .context("available indexes", available)

--- a/crates/core/src/parser/filter_chain.rs
+++ b/crates/core/src/parser/filter_chain.rs
@@ -7,7 +7,7 @@ use crate::model::{ValueCow, ValueView};
 use crate::runtime::Expression;
 use crate::runtime::Renderable;
 use crate::runtime::Runtime;
-use crate::Value;
+use crate::{ErrorKind, Value};
 
 /// A `Value` expression.
 #[derive(Debug)]
@@ -25,22 +25,31 @@ impl FilterChain {
     /// Process `Value` expression within `runtime`'s stack.
     pub fn evaluate<'s>(&'s self, runtime: &'s dyn Runtime) -> Result<ValueCow<'s>> {
         // take either the provided value or the value from the provided variable
-        let mut entry = self.entry.evaluate(runtime);
+        let mut entry = match self.entry.evaluate(runtime) {
+            Ok(v) => v,
+            Err(err) if self.filters.is_empty() => return Err(err),
+            Err(err) => match err.kind() {
+                // a missing value is not an error if there are filters
+                // that come next to process it. They will decide if this
+                // is appropriate or not (eg: the default filter)
+                ErrorKind::UnknownIndex | ErrorKind::UnknownVariable => ValueCow::Owned(Value::Nil),
+                _ => return Err(err),
+            },
+        };
 
         // apply all specified filters
         for filter in &self.filters {
-            let value = entry.unwrap_or_else(|_| ValueCow::Owned(Value::Nil));
             entry = filter
-                .evaluate(value.as_view(), runtime)
+                .evaluate(entry.as_view(), runtime)
                 .trace("Filter error")
                 .context_key("filter")
                 .value_with(|| format!("{}", filter).into())
                 .context_key("input")
-                .value_with(|| format!("{}", value.source()).into())
-                .map(ValueCow::Owned);
+                .value_with(|| format!("{}", entry.source()).into())
+                .map(ValueCow::Owned)?;
         }
 
-        entry
+        Ok(entry)
     }
 }
 

--- a/crates/core/src/parser/parser.rs
+++ b/crates/core/src/parser/parser.rs
@@ -773,7 +773,7 @@ impl<'a> TagTokenIter<'a> {
             ::pest::error::ErrorVariant::CustomError {
                 message: error_msg.to_string(),
             },
-            self.position,
+            self.position.to_owned(),
         );
         convert_pest_error(pest_error)
     }

--- a/crates/core/src/runtime/runtime.rs
+++ b/crates/core/src/runtime/runtime.rs
@@ -244,9 +244,7 @@ impl<'g> Runtime for RuntimeCore<'g> {
 
     fn get(&self, path: &[ScalarCow<'_>]) -> Result<ValueCow<'_>> {
         let key = path.first().cloned().unwrap_or_else(|| Scalar::new("nil"));
-        Error::with_msg("Unknown variable")
-            .context("requested variable", key.to_kstr())
-            .into_err()
+        Error::unknown_variable(key.to_kstr()).into_err()
     }
 
     fn set_global(

--- a/crates/core/src/runtime/stack.rs
+++ b/crates/core/src/runtime/stack.rs
@@ -56,9 +56,7 @@ impl<P: super::Runtime, O: ObjectView> super::Runtime for StackFrame<P, O> {
     }
 
     fn get(&self, path: &[ScalarCow<'_>]) -> Result<ValueCow<'_>> {
-        let key = path.first().ok_or_else(|| {
-            Error::with_msg("Unknown variable").context("requested variable", "nil")
-        })?;
+        let key = path.first().ok_or_else(|| Error::unknown_variable("nil"))?;
         let key = key.to_kstr();
         let data = &self.data;
         if data.contains_key(key.as_str()) {
@@ -130,9 +128,7 @@ impl<P: super::Runtime> super::Runtime for GlobalFrame<P> {
     }
 
     fn get(&self, path: &[ScalarCow<'_>]) -> Result<ValueCow<'_>> {
-        let key = path.first().ok_or_else(|| {
-            Error::with_msg("Unknown variable").context("requested variable", "nil")
-        })?;
+        let key = path.first().ok_or_else(|| Error::unknown_variable("nil"))?;
         let key = key.to_kstr();
         let data = self.data.borrow();
         if data.contains_key(key.as_str()) {
@@ -205,9 +201,7 @@ impl<P: super::Runtime> super::Runtime for IndexFrame<P> {
     }
 
     fn get(&self, path: &[ScalarCow<'_>]) -> Result<ValueCow<'_>> {
-        let key = path.first().ok_or_else(|| {
-            Error::with_msg("Unknown variable").context("requested variable", "nil")
-        })?;
+        let key = path.first().ok_or_else(|| Error::unknown_variable("nil"))?;
         let key = key.to_kstr();
         let data = self.data.borrow();
         if data.contains_key(key.as_str()) {

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -539,3 +539,32 @@ fn test_compact() {
     let output = template.render(&globals).unwrap();
     assert_eq!(output, "A C".to_string());
 }
+
+#[test]
+fn indexed_variable_default() {
+    let text = "{{ does.not.exist | default: 'default' }}";
+    let globals = liquid::object!({});
+
+    let template = liquid::ParserBuilder::with_stdlib()
+        .build()
+        .unwrap()
+        .parse(text)
+        .unwrap();
+    let output = template.render(&globals).unwrap();
+    assert_eq!(output, "default".to_string());
+}
+
+#[test]
+fn indexed_variable_no_default() {
+    let text = "{{ does.not.exist }}";
+    let globals = liquid::object!({});
+
+    let template = liquid::ParserBuilder::with_stdlib()
+        .build()
+        .unwrap()
+        .parse(text)
+        .unwrap();
+    template
+        .render(&globals)
+        .expect_err("should fail when the filter ends with a missing value");
+}


### PR DESCRIPTION
- [x] Tests created for any new feature or regression tests for bugfixes.

Following up on #477, this change treats missing variables and indexes as `nil` when they appear at the start of a filter chain. As far as I can tell, this is in line with the [shopify implementation](https://shopify.dev/docs/api/liquid/filters/default).

I needed a way to properly identify when an error identified a missing index or variable, and so introduced the concept of an `ErrorKind` to handle this. If there is a better or preferred way, please let me know! 

closes #477 