### PR TITLE
Remove Dependency Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ liquid-rust
 > [Liquid templating](http://liquidmarkup.org/) for Rust
 
 [![Crates Status](https://img.shields.io/crates/v/liquid.svg)](https://crates.io/crates/liquid)
-[![Dependency Status](https://dependencyci.com/github/cobalt-org/liquid-rust/badge)](https://dependencyci.com/github/cobalt-org/liquid-rust)
 
 Goals:
 1. Conformant. Incompatibilities with [strict shopify/liquid][shopify-liquid] are [bugs to be fixed][shopify-compat].


### PR DESCRIPTION
It looks like https://dependencyci.com got acquired by https://tidelift.com/ and the link 404s now