### PR TITLE
Add support for indexmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +473,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,7 +524,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -641,6 +663,7 @@ name = "liquid-core"
 version = "0.26.4"
 dependencies = [
  "anymap2",
+ "indexmap 2.1.0",
  "itertools 0.12.0",
  "kstring",
  "liquid-derive",
@@ -980,7 +1003,7 @@ version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "ryu",
  "serde",
  "yaml-rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ pre-release-replacements = [
 [features]
 default = ["stdlib"]
 stdlib = ["liquid-lib/stdlib"]
+indexmap = ["liquid-core/indexmap"]
 
 [dependencies]
 doc-comment = "0.3"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -24,6 +24,7 @@ num-traits = "0.2"
 pest = "2.0"
 pest_derive = "2.0"
 regex = "1.5"
+indexmap = { version = "2.1.0", optional = true }
 
 # Exposed in API
 time = { version = "0.3", default-features = false, features = ["formatting", "macros", "parsing"] }
@@ -38,3 +39,4 @@ snapbox = "0.4.14"
 [features]
 default = []
 derive = ["liquid-derive"]
+indexmap = ["dep:indexmap"]


### PR DESCRIPTION
I added the possibility to enable the use of an `IndexMap` inside of the templates. I currently use liquid in a tool of mine, where I use an `IndexMap` to keep elements in the order they were inserted in, as re-ordering those could lead to bugs further down.