### PR TITLE
docs(README) Correct typo "suite" -> "suit"

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Customizing Liquid
 ### Language Variants
 
 By default, `liquid-rust` has no filters, tags, or blocks.  You can enable the
-default set or pick and choose which to add to suite your application.
+default set or pick and choose which to add to suit your application.
 
 ### Create your own filters
 


### PR DESCRIPTION
I was trying out this crate and noticed a little typo.

- [ ] Tests created for any new feature or regression tests for bugfixes.
