### PR TITLE
Align if conditions with Ruby Liquid for missing values

### DIFF
--- a/crates/core/src/parser/filter_chain.rs
+++ b/crates/core/src/parser/filter_chain.rs
@@ -56,6 +56,24 @@ impl FilterChain {
         let entry = self.entry.try_evaluate(runtime).unwrap_or_default();
         self.apply_filters(entry, runtime)
     }
+
+    /// Process a comparison operand.
+    ///
+    /// Plain operands keep `evaluate`'s strict missing-variable behavior so
+    /// `{% if missing == 1 %}` still reports a render error. Filtered operands
+    /// use `try_evaluate` so a missing input becomes `nil` and the filter chain
+    /// still runs, matching Liquid behavior for cases like
+    /// `{% if missing | upcase == "" %}`.
+    pub fn evaluate_comparison_operand<'s>(
+        &'s self,
+        runtime: &'s dyn Runtime,
+    ) -> Result<ValueCow<'s>> {
+        if self.filters.is_empty() {
+            self.evaluate(runtime)
+        } else {
+            self.try_evaluate(runtime)
+        }
+    }
 }
 
 impl fmt::Display for FilterChain {

--- a/crates/core/src/parser/filter_chain.rs
+++ b/crates/core/src/parser/filter_chain.rs
@@ -41,6 +41,28 @@ impl FilterChain {
 
         Ok(entry)
     }
+
+    /// Process `Value` expression within `runtime`'s stack, returning `None` when the
+    /// chain entry does not resolve and propagating filter failures otherwise.
+    pub fn try_evaluate<'s>(&'s self, runtime: &'s dyn Runtime) -> Result<Option<ValueCow<'s>>> {
+        let Some(mut entry) = self.entry.try_evaluate(runtime) else {
+            return Ok(None);
+        };
+
+        for filter in &self.filters {
+            entry = ValueCow::Owned(
+                filter
+                    .evaluate(entry.as_view(), runtime)
+                    .trace("Filter error")
+                    .context_key("filter")
+                    .value_with(|| format!("{}", filter).into())
+                    .context_key("input")
+                    .value_with(|| format!("{}", entry.source()).into())?,
+            );
+        }
+
+        Ok(Some(entry))
+    }
 }
 
 impl fmt::Display for FilterChain {

--- a/crates/core/src/parser/filter_chain.rs
+++ b/crates/core/src/parser/filter_chain.rs
@@ -46,7 +46,7 @@ impl FilterChain {
     ///
     /// Missing entries are treated as `nil` so filters still run, matching Liquid's
     /// behavior for expressions like `{% if missing | upcase %}`.
-    pub fn try_evaluate<'s>(&'s self, runtime: &'s dyn Runtime) -> Result<Option<ValueCow<'s>>> {
+    pub fn try_evaluate<'s>(&'s self, runtime: &'s dyn Runtime) -> Result<ValueCow<'s>> {
         let mut entry = self.entry.try_evaluate(runtime).unwrap_or_default();
 
         for filter in &self.filters {
@@ -61,7 +61,7 @@ impl FilterChain {
             );
         }
 
-        Ok(Some(entry))
+        Ok(entry)
     }
 }
 

--- a/crates/core/src/parser/filter_chain.rs
+++ b/crates/core/src/parser/filter_chain.rs
@@ -21,12 +21,11 @@ impl FilterChain {
         Self { entry, filters }
     }
 
-    /// Process `Value` expression within `runtime`'s stack.
-    pub fn evaluate<'s>(&'s self, runtime: &'s dyn Runtime) -> Result<ValueCow<'s>> {
-        // take either the provided value or the value from the provided variable
-        let mut entry = self.entry.evaluate(runtime)?;
-
-        // apply all specified filters
+    fn apply_filters<'s>(
+        &'s self,
+        mut entry: ValueCow<'s>,
+        runtime: &'s dyn Runtime,
+    ) -> Result<ValueCow<'s>> {
         for filter in &self.filters {
             entry = ValueCow::Owned(
                 filter
@@ -42,26 +41,20 @@ impl FilterChain {
         Ok(entry)
     }
 
+    /// Process `Value` expression within `runtime`'s stack.
+    pub fn evaluate<'s>(&'s self, runtime: &'s dyn Runtime) -> Result<ValueCow<'s>> {
+        // take either the provided value or the value from the provided variable
+        let entry = self.entry.evaluate(runtime)?;
+        self.apply_filters(entry, runtime)
+    }
+
     /// Process `Value` expression within `runtime`'s stack for existence-style checks.
     ///
     /// Missing entries are treated as `nil` so filters still run, matching Liquid's
     /// behavior for expressions like `{% if missing | upcase %}`.
     pub fn try_evaluate<'s>(&'s self, runtime: &'s dyn Runtime) -> Result<ValueCow<'s>> {
-        let mut entry = self.entry.try_evaluate(runtime).unwrap_or_default();
-
-        for filter in &self.filters {
-            entry = ValueCow::Owned(
-                filter
-                    .evaluate(entry.as_view(), runtime)
-                    .trace("Filter error")
-                    .context_key("filter")
-                    .value_with(|| format!("{}", filter).into())
-                    .context_key("input")
-                    .value_with(|| format!("{}", entry.source()).into())?,
-            );
-        }
-
-        Ok(entry)
+        let entry = self.entry.try_evaluate(runtime).unwrap_or_default();
+        self.apply_filters(entry, runtime)
     }
 }
 

--- a/crates/core/src/parser/filter_chain.rs
+++ b/crates/core/src/parser/filter_chain.rs
@@ -45,12 +45,10 @@ impl FilterChain {
 
 impl fmt::Display for FilterChain {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{} | {}",
-            self.entry,
-            itertools::join(&self.filters, " | ")
-        )
+        write!(f, "{}", self.entry)?;
+        self.filters
+            .iter()
+            .try_for_each(|filter| write!(f, " | {}", filter))
     }
 }
 

--- a/crates/core/src/parser/filter_chain.rs
+++ b/crates/core/src/parser/filter_chain.rs
@@ -56,7 +56,6 @@ impl FilterChain {
         let entry = self.entry.try_evaluate(runtime).unwrap_or_default();
         self.apply_filters(entry, runtime)
     }
-
 }
 
 impl fmt::Display for FilterChain {

--- a/crates/core/src/parser/filter_chain.rs
+++ b/crates/core/src/parser/filter_chain.rs
@@ -68,6 +68,7 @@ impl FilterChain {
 impl fmt::Display for FilterChain {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.entry)?;
+        // The old join-based formatter produced a trailing " | " for zero-filter chains.
         self.filters
             .iter()
             .try_for_each(|filter| write!(f, " | {}", filter))

--- a/crates/core/src/parser/filter_chain.rs
+++ b/crates/core/src/parser/filter_chain.rs
@@ -57,23 +57,6 @@ impl FilterChain {
         self.apply_filters(entry, runtime)
     }
 
-    /// Process a comparison operand.
-    ///
-    /// Plain operands keep `evaluate`'s strict missing-variable behavior so
-    /// `{% if missing == 1 %}` still reports a render error. Filtered operands
-    /// use `try_evaluate` so a missing input becomes `nil` and the filter chain
-    /// still runs, matching Liquid behavior for cases like
-    /// `{% if missing | upcase == "" %}`.
-    pub fn evaluate_comparison_operand<'s>(
-        &'s self,
-        runtime: &'s dyn Runtime,
-    ) -> Result<ValueCow<'s>> {
-        if self.filters.is_empty() {
-            self.evaluate(runtime)
-        } else {
-            self.try_evaluate(runtime)
-        }
-    }
 }
 
 impl fmt::Display for FilterChain {

--- a/crates/core/src/parser/filter_chain.rs
+++ b/crates/core/src/parser/filter_chain.rs
@@ -21,6 +21,24 @@ impl FilterChain {
         Self { entry, filters }
     }
 
+    /// Process `Value` expression within `runtime`'s stack.
+    pub fn evaluate<'s>(&'s self, runtime: &'s dyn Runtime) -> Result<ValueCow<'s>> {
+        // take either the provided value or the value from the provided variable
+        let entry = self.entry.evaluate(runtime)?;
+        self.apply_filters(entry, runtime)
+    }
+
+    /// Process `Value` expression within `runtime`'s stack for existence-style checks.
+    ///
+    /// Missing entries are treated as `nil` so filters still run, matching Liquid's
+    /// behavior for expressions like `{% if missing | upcase %}`.
+    pub fn try_evaluate<'s>(&'s self, runtime: &'s dyn Runtime) -> Result<ValueCow<'s>> {
+        let entry = self.entry.try_evaluate(runtime).unwrap_or_default();
+        self.apply_filters(entry, runtime)
+    }
+
+    /// Apply each parsed filter in order, preserving the current value so filter
+    /// failures can report both the filter name and the input that triggered it.
     fn apply_filters<'s>(
         &'s self,
         mut entry: ValueCow<'s>,
@@ -39,22 +57,6 @@ impl FilterChain {
         }
 
         Ok(entry)
-    }
-
-    /// Process `Value` expression within `runtime`'s stack.
-    pub fn evaluate<'s>(&'s self, runtime: &'s dyn Runtime) -> Result<ValueCow<'s>> {
-        // take either the provided value or the value from the provided variable
-        let entry = self.entry.evaluate(runtime)?;
-        self.apply_filters(entry, runtime)
-    }
-
-    /// Process `Value` expression within `runtime`'s stack for existence-style checks.
-    ///
-    /// Missing entries are treated as `nil` so filters still run, matching Liquid's
-    /// behavior for expressions like `{% if missing | upcase %}`.
-    pub fn try_evaluate<'s>(&'s self, runtime: &'s dyn Runtime) -> Result<ValueCow<'s>> {
-        let entry = self.entry.try_evaluate(runtime).unwrap_or_default();
-        self.apply_filters(entry, runtime)
     }
 }
 

--- a/crates/core/src/parser/filter_chain.rs
+++ b/crates/core/src/parser/filter_chain.rs
@@ -42,12 +42,12 @@ impl FilterChain {
         Ok(entry)
     }
 
-    /// Process `Value` expression within `runtime`'s stack, returning `None` when the
-    /// chain entry does not resolve and propagating filter failures otherwise.
+    /// Process `Value` expression within `runtime`'s stack for existence-style checks.
+    ///
+    /// Missing entries are treated as `nil` so filters still run, matching Liquid's
+    /// behavior for expressions like `{% if missing | upcase %}`.
     pub fn try_evaluate<'s>(&'s self, runtime: &'s dyn Runtime) -> Result<Option<ValueCow<'s>>> {
-        let Some(mut entry) = self.entry.try_evaluate(runtime) else {
-            return Ok(None);
-        };
+        let mut entry = self.entry.try_evaluate(runtime).unwrap_or_default();
 
         for filter in &self.filters {
             entry = ValueCow::Owned(

--- a/crates/core/src/parser/parser.rs
+++ b/crates/core/src/parser/parser.rs
@@ -1165,6 +1165,17 @@ mod test {
     }
 
     #[test]
+    fn zero_filter_chain_display_has_no_trailing_separator() {
+        let filter_chain = LiquidParser::parse(Rule::FilterChain, "foo")
+            .unwrap()
+            .next()
+            .unwrap();
+
+        let filter_chain = parse_filter_chain(filter_chain, &Language::default()).unwrap();
+        assert_eq!(filter_chain.to_string(), "foo");
+    }
+
+    #[test]
     fn test_whitespace_control() {
         let options = Language::default();
 

--- a/crates/core/src/parser/parser.rs
+++ b/crates/core/src/parser/parser.rs
@@ -958,12 +958,24 @@ impl<'a> TagToken<'a> {
         }
     }
 
+    /// Obtains a `FilterChain` from this token, preserving parser errors such as unknown filters.
+    pub fn expect_filter_chain_result(mut self, options: &Language) -> Result<FilterChain> {
+        let token = match self.unwrap_filter_chain() {
+            Ok(token) => token,
+            Err(_) => {
+                self.expected.push(Rule::FilterChain);
+                return self.raise_error().into_err();
+            }
+        };
+
+        parse_filter_chain(token, options)
+    }
+
     fn expect_filter_chain_err(&mut self, options: &Language) -> Result<FilterChain> {
-        let t = self
+        let token = self
             .unwrap_filter_chain()
             .map_err(|_| Error::with_msg("failed to parse"))?;
-        let f = parse_filter_chain(t, options)?;
-        Ok(f)
+        parse_filter_chain(token, options)
     }
 
     /// Tries to obtain a value from this token.

--- a/crates/core/src/parser/parser.rs
+++ b/crates/core/src/parser/parser.rs
@@ -959,7 +959,7 @@ impl<'a> TagToken<'a> {
     }
 
     /// Obtains a `FilterChain` from this token, preserving parser errors such as unknown filters.
-    pub fn expect_filter_chain_result(mut self, options: &Language) -> Result<FilterChain> {
+    pub fn parse_filter_chain(mut self, options: &Language) -> Result<FilterChain> {
         let token = match self.unwrap_filter_chain() {
             Ok(token) => token,
             Err(_) => {

--- a/crates/core/src/parser/parser.rs
+++ b/crates/core/src/parser/parser.rs
@@ -958,8 +958,8 @@ impl<'a> TagToken<'a> {
         }
     }
 
-    /// Obtains a `FilterChain` from this token, preserving parser errors such as unknown filters.
-    pub fn parse_filter_chain(mut self, options: &Language) -> Result<FilterChain> {
+    /// Parses this token as a `FilterChain`, preserving parser errors such as unknown filters.
+    pub fn parse_as_filter_chain(mut self, options: &Language) -> Result<FilterChain> {
         let token = match self.unwrap_filter_chain() {
             Ok(token) => token,
             Err(_) => {

--- a/crates/lib/src/stdlib/blocks/if_block.rs
+++ b/crates/lib/src/stdlib/blocks/if_block.rs
@@ -4,7 +4,9 @@ use std::io::Write;
 use liquid_core::error::ResultLiquidExt;
 use liquid_core::model::{ValueView, ValueViewCmp};
 use liquid_core::parser::BlockElement;
+use liquid_core::parser::FilterChain;
 use liquid_core::parser::TagToken;
+use liquid_core::parser::TryMatchToken;
 use liquid_core::Expression;
 use liquid_core::Language;
 use liquid_core::Renderable;
@@ -59,7 +61,7 @@ fn parse_if(
     tokens: &mut TagBlock<'_, '_>,
     options: &Language,
 ) -> Result<Box<dyn Renderable>> {
-    let condition = parse_condition(arguments)?;
+    let condition = parse_condition(arguments, options)?;
 
     let mut if_true = Vec::new();
     let mut if_false = None;
@@ -122,7 +124,7 @@ impl ParseBlock for UnlessBlock {
         mut tokens: TagBlock<'_, '_>,
         options: &Language,
     ) -> Result<Box<dyn Renderable>> {
-        let condition = parse_condition(arguments)?;
+        let condition = parse_condition(arguments, options)?;
 
         let mut if_true = Vec::new();
         let mut if_false = None;
@@ -195,7 +197,7 @@ impl Renderable for Conditional {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 enum Condition {
     Binary(BinaryCondition),
     Existence(ExistenceCondition),
@@ -229,11 +231,45 @@ impl fmt::Display for Condition {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
+enum ConditionValue {
+    Simple(Expression),
+    Filtered(FilterChain),
+}
+
+impl ConditionValue {
+    fn evaluate<'s>(&'s self, runtime: &'s dyn Runtime) -> Result<liquid_core::ValueCow<'s>> {
+        match self {
+            ConditionValue::Simple(expr) => expr.evaluate(runtime),
+            ConditionValue::Filtered(chain) => chain.evaluate(runtime),
+        }
+    }
+
+    fn try_evaluate<'s>(
+        &'s self,
+        runtime: &'s dyn Runtime,
+    ) -> Option<liquid_core::ValueCow<'s>> {
+        match self {
+            ConditionValue::Simple(expr) => expr.try_evaluate(runtime),
+            ConditionValue::Filtered(chain) => chain.evaluate(runtime).ok(),
+        }
+    }
+}
+
+impl fmt::Display for ConditionValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConditionValue::Simple(expr) => write!(f, "{}", expr),
+            ConditionValue::Filtered(chain) => write!(f, "{}", chain),
+        }
+    }
+}
+
+#[derive(Debug)]
 struct BinaryCondition {
-    lh: Expression,
+    lh: ConditionValue,
     comparison: ComparisonOperator,
-    rh: Expression,
+    rh: ConditionValue,
 }
 
 impl BinaryCondition {
@@ -329,9 +365,9 @@ impl ComparisonOperator {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 struct ExistenceCondition {
-    lh: Expression,
+    lh: ConditionValue,
 }
 
 impl ExistenceCondition {
@@ -382,11 +418,25 @@ impl<'a> PeekableTagTokenIter<'a> {
     }
 }
 
-fn parse_atom_condition(arguments: &mut PeekableTagTokenIter<'_>) -> Result<Condition> {
-    let lh = arguments
-        .expect_next("Value expected.")?
-        .expect_value()
-        .into_result()?;
+fn parse_condition_value(
+    token: TagToken<'_>,
+    options: &Language,
+) -> Result<ConditionValue> {
+    match token.expect_filter_chain(options) {
+        TryMatchToken::Matches(chain) => Ok(ConditionValue::Filtered(chain)),
+        TryMatchToken::Fails(token) => {
+            let expr = token.expect_value().into_result()?;
+            Ok(ConditionValue::Simple(expr))
+        }
+    }
+}
+
+fn parse_atom_condition(
+    arguments: &mut PeekableTagTokenIter<'_>,
+    options: &Language,
+) -> Result<Condition> {
+    let token = arguments.expect_next("Value expected.")?;
+    let lh = parse_condition_value(token, options)?;
     let cond = match arguments
         .peek()
         .map(TagToken::as_str)
@@ -394,10 +444,8 @@ fn parse_atom_condition(arguments: &mut PeekableTagTokenIter<'_>) -> Result<Cond
     {
         Some(op) => {
             arguments.next();
-            let rh = arguments
-                .expect_next("Value expected.")?
-                .expect_value()
-                .into_result()?;
+            let token = arguments.expect_next("Value expected.")?;
+            let rh = parse_condition_value(token, options)?;
             Condition::Binary(BinaryCondition {
                 lh,
                 comparison: op,
@@ -410,12 +458,15 @@ fn parse_atom_condition(arguments: &mut PeekableTagTokenIter<'_>) -> Result<Cond
     Ok(cond)
 }
 
-fn parse_conjunction_chain(arguments: &mut PeekableTagTokenIter<'_>) -> Result<Condition> {
-    let mut lh = parse_atom_condition(arguments)?;
+fn parse_conjunction_chain(
+    arguments: &mut PeekableTagTokenIter<'_>,
+    options: &Language,
+) -> Result<Condition> {
+    let mut lh = parse_atom_condition(arguments, options)?;
 
     while let Some("and") = arguments.peek().map(TagToken::as_str) {
         arguments.next();
-        let rh = parse_atom_condition(arguments)?;
+        let rh = parse_atom_condition(arguments, options)?;
         lh = Condition::Conjunction(Box::new(lh), Box::new(rh));
     }
 
@@ -423,19 +474,19 @@ fn parse_conjunction_chain(arguments: &mut PeekableTagTokenIter<'_>) -> Result<C
 }
 
 /// Common parsing for "if" and "unless" condition
-fn parse_condition(arguments: TagTokenIter<'_>) -> Result<Condition> {
+fn parse_condition(arguments: TagTokenIter<'_>, options: &Language) -> Result<Condition> {
     let mut arguments = PeekableTagTokenIter {
         iter: arguments,
         peeked: None,
     };
-    let mut lh = parse_conjunction_chain(&mut arguments)?;
+    let mut lh = parse_conjunction_chain(&mut arguments, options)?;
 
     while let Some(token) = arguments.next() {
         token
             .expect_str("or")
             .into_result_custom_msg("\"and\" or \"or\" expected.")?;
 
-        let rh = parse_conjunction_chain(&mut arguments)?;
+        let rh = parse_conjunction_chain(&mut arguments, options)?;
         lh = Condition::Disjunction(Box::new(lh), Box::new(rh));
     }
 
@@ -461,6 +512,7 @@ mod test {
     use liquid_core::model::Value;
     use liquid_core::parser;
     use liquid_core::runtime::RuntimeBuilder;
+    use liquid_core::{Display_filter, Filter, FilterReflection, ParseFilter};
 
     fn options() -> Language {
         let mut options = Language::default();
@@ -468,6 +520,53 @@ mod test {
         options
             .blocks
             .register("unless".to_owned(), UnlessBlock.into());
+        options
+    }
+
+    #[derive(Clone, ParseFilter, FilterReflection)]
+    #[filter(name = "upcase", description = "test helper", parsed(UpcaseFilter))]
+    struct UpcaseFilterParser;
+
+    #[derive(Debug, Default, Display_filter)]
+    #[name = "upcase"]
+    struct UpcaseFilter;
+
+    impl Filter for UpcaseFilter {
+        fn evaluate(
+            &self,
+            input: &dyn ValueView,
+            _runtime: &dyn Runtime,
+        ) -> Result<Value> {
+            Ok(Value::scalar(input.to_kstr().to_uppercase()))
+        }
+    }
+
+    #[derive(Clone, ParseFilter, FilterReflection)]
+    #[filter(name = "downcase", description = "test helper", parsed(DowncaseFilter))]
+    struct DowncaseFilterParser;
+
+    #[derive(Debug, Default, Display_filter)]
+    #[name = "downcase"]
+    struct DowncaseFilter;
+
+    impl Filter for DowncaseFilter {
+        fn evaluate(
+            &self,
+            input: &dyn ValueView,
+            _runtime: &dyn Runtime,
+        ) -> Result<Value> {
+            Ok(Value::scalar(input.to_kstr().to_lowercase()))
+        }
+    }
+
+    fn options_with_filters() -> Language {
+        let mut options = options();
+        options
+            .filters
+            .register("upcase".to_owned(), Box::new(UpcaseFilterParser));
+        options
+            .filters
+            .register("downcase".to_owned(), Box::new(DowncaseFilterParser));
         options
     }
 
@@ -753,5 +852,122 @@ mod test {
         let runtime = RuntimeBuilder::new().build();
         let output = template.render(&runtime).unwrap();
         assert_eq!(output, "if true");
+    }
+
+    #[test]
+    fn filter_chain_both_sides_of_comparison() {
+        let text = r#"{% if a | upcase == b | upcase %}match{% else %}no match{% endif %}"#;
+        let options = options_with_filters();
+        let template = parser::parse(text, &options).map(Template::new).unwrap();
+
+        let runtime = RuntimeBuilder::new().build();
+        runtime.set_global("a".into(), Value::scalar("hello"));
+        runtime.set_global("b".into(), Value::scalar("HELLO"));
+        let output = template.render(&runtime).unwrap();
+        assert_eq!(output, "match");
+
+        let runtime = RuntimeBuilder::new().build();
+        runtime.set_global("a".into(), Value::scalar("hello"));
+        runtime.set_global("b".into(), Value::scalar("world"));
+        let output = template.render(&runtime).unwrap();
+        assert_eq!(output, "no match");
+    }
+
+    #[test]
+    fn filter_chain_on_left_side_only() {
+        let text = r#"{% if name | upcase == "HELLO" %}match{% else %}no match{% endif %}"#;
+        let options = options_with_filters();
+        let template = parser::parse(text, &options).map(Template::new).unwrap();
+
+        let runtime = RuntimeBuilder::new().build();
+        runtime.set_global("name".into(), Value::scalar("hello"));
+        let output = template.render(&runtime).unwrap();
+        assert_eq!(output, "match");
+    }
+
+    #[test]
+    fn filter_chain_on_right_side_only() {
+        let text = r#"{% if "HELLO" == name | upcase %}match{% else %}no match{% endif %}"#;
+        let options = options_with_filters();
+        let template = parser::parse(text, &options).map(Template::new).unwrap();
+
+        let runtime = RuntimeBuilder::new().build();
+        runtime.set_global("name".into(), Value::scalar("hello"));
+        let output = template.render(&runtime).unwrap();
+        assert_eq!(output, "match");
+    }
+
+    #[test]
+    fn filter_chain_with_and_or() {
+        let text = concat!(
+            "{% if a | upcase == b | upcase and c | downcase == d | downcase %}",
+            "match",
+            "{% else %}",
+            "no match",
+            "{% endif %}"
+        );
+        let options = options_with_filters();
+        let template = parser::parse(text, &options).map(Template::new).unwrap();
+
+        let runtime = RuntimeBuilder::new().build();
+        runtime.set_global("a".into(), Value::scalar("hello"));
+        runtime.set_global("b".into(), Value::scalar("HELLO"));
+        runtime.set_global("c".into(), Value::scalar("WORLD"));
+        runtime.set_global("d".into(), Value::scalar("World"));
+        let output = template.render(&runtime).unwrap();
+        assert_eq!(output, "match");
+
+        let runtime = RuntimeBuilder::new().build();
+        runtime.set_global("a".into(), Value::scalar("hello"));
+        runtime.set_global("b".into(), Value::scalar("HELLO"));
+        runtime.set_global("c".into(), Value::scalar("WORLD"));
+        runtime.set_global("d".into(), Value::scalar("other"));
+        let output = template.render(&runtime).unwrap();
+        assert_eq!(output, "no match");
+    }
+
+    #[test]
+    fn filter_chain_existence_check() {
+        let text = r#"{% if name | upcase %}truthy{% else %}falsy{% endif %}"#;
+        let options = options_with_filters();
+        let template = parser::parse(text, &options).map(Template::new).unwrap();
+
+        let runtime = RuntimeBuilder::new().build();
+        runtime.set_global("name".into(), Value::scalar("hello"));
+        let output = template.render(&runtime).unwrap();
+        assert_eq!(output, "truthy");
+    }
+
+    #[test]
+    fn filter_chain_in_unless() {
+        let text = r#"{% unless a | upcase == b | upcase %}not equal{% endunless %}"#;
+        let options = options_with_filters();
+        let template = parser::parse(text, &options).map(Template::new).unwrap();
+
+        let runtime = RuntimeBuilder::new().build();
+        runtime.set_global("a".into(), Value::scalar("hello"));
+        runtime.set_global("b".into(), Value::scalar("world"));
+        let output = template.render(&runtime).unwrap();
+        assert_eq!(output, "not equal");
+
+        let runtime = RuntimeBuilder::new().build();
+        runtime.set_global("a".into(), Value::scalar("hello"));
+        runtime.set_global("b".into(), Value::scalar("HELLO"));
+        let output = template.render(&runtime).unwrap();
+        assert_eq!(output, "");
+    }
+
+    #[test]
+    fn multiple_filters_in_condition() {
+        let text =
+            r#"{% if a | upcase | downcase == b | upcase | downcase %}match{% else %}no match{% endif %}"#;
+        let options = options_with_filters();
+        let template = parser::parse(text, &options).map(Template::new).unwrap();
+
+        let runtime = RuntimeBuilder::new().build();
+        runtime.set_global("a".into(), Value::scalar("Hello"));
+        runtime.set_global("b".into(), Value::scalar("HELLO"));
+        let output = template.render(&runtime).unwrap();
+        assert_eq!(output, "match");
     }
 }

--- a/crates/lib/src/stdlib/blocks/if_block.rs
+++ b/crates/lib/src/stdlib/blocks/if_block.rs
@@ -387,7 +387,7 @@ impl<'a> PeekableTagTokenIter<'a> {
 /// so all `if` / `unless` operands can be parsed uniformly through `FilterChain`.
 fn parse_condition_value(token: TagToken<'_>, options: &Language) -> Result<FilterChain> {
     // Preserve filter parser errors here (for example, unknown filters in if/unless conditions).
-    token.parse_filter_chain(options)
+    token.parse_as_filter_chain(options)
 }
 
 fn parse_atom_condition(

--- a/crates/lib/src/stdlib/blocks/if_block.rs
+++ b/crates/lib/src/stdlib/blocks/if_block.rs
@@ -386,7 +386,8 @@ impl<'a> PeekableTagTokenIter<'a> {
 /// The grammar rule `FilterChain = Value ~ ("|" ~ Filter)*` also matches plain values,
 /// so all `if` / `unless` operands can be parsed uniformly through `FilterChain`.
 fn parse_condition_value(token: TagToken<'_>, options: &Language) -> Result<FilterChain> {
-    token.expect_filter_chain_result(options)
+    // Preserve filter parser errors here (for example, unknown filters in if/unless conditions).
+    token.parse_filter_chain(options)
 }
 
 fn parse_atom_condition(

--- a/crates/lib/src/stdlib/blocks/if_block.rs
+++ b/crates/lib/src/stdlib/blocks/if_block.rs
@@ -245,11 +245,16 @@ impl ConditionValue {
         }
     }
 
-    /// Non-failing evaluate, used for existence checks like `{% if x | upcase %}`.
-    fn try_evaluate<'s>(&'s self, runtime: &'s dyn Runtime) -> Option<liquid_core::ValueCow<'s>> {
+    /// Evaluate for existence checks like `{% if x | upcase %}`.
+    ///
+    /// Missing variables remain falsy, but filter execution failures still propagate.
+    fn try_evaluate<'s>(
+        &'s self,
+        runtime: &'s dyn Runtime,
+    ) -> Result<Option<liquid_core::ValueCow<'s>>> {
         match self {
-            ConditionValue::Simple(expr) => expr.try_evaluate(runtime),
-            ConditionValue::Filtered(chain) => chain.evaluate(runtime).ok(),
+            ConditionValue::Simple(expr) => Ok(expr.try_evaluate(runtime)),
+            ConditionValue::Filtered(chain) => chain.try_evaluate(runtime),
         }
     }
 }
@@ -370,7 +375,7 @@ struct ExistenceCondition {
 
 impl ExistenceCondition {
     pub(crate) fn evaluate(&self, runtime: &dyn Runtime) -> Result<bool> {
-        let a = self.lh.try_evaluate(runtime);
+        let a = self.lh.try_evaluate(runtime)?;
         let a = a.unwrap_or_default();
         let is_truthy = a.query_state(liquid_core::model::State::Truthy);
         Ok(is_truthy)
@@ -511,6 +516,7 @@ mod test {
     use liquid_core::model::Value;
     use liquid_core::parser;
     use liquid_core::runtime::RuntimeBuilder;
+    use liquid_core::Error;
     use liquid_core::{Display_filter, Filter, FilterReflection, ParseFilter};
 
     fn options() -> Language {
@@ -550,6 +556,20 @@ mod test {
         }
     }
 
+    #[derive(Clone, ParseFilter, FilterReflection)]
+    #[filter(name = "fail", description = "test helper", parsed(FailFilter))]
+    struct FailFilterParser;
+
+    #[derive(Debug, Default, Display_filter)]
+    #[name = "fail"]
+    struct FailFilter;
+
+    impl Filter for FailFilter {
+        fn evaluate(&self, _input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
+            Err(Error::with_msg("filter failed"))
+        }
+    }
+
     fn options_with_filters() -> Language {
         let mut options = options();
         options
@@ -558,6 +578,9 @@ mod test {
         options
             .filters
             .register("downcase".to_owned(), Box::new(DowncaseFilterParser));
+        options
+            .filters
+            .register("fail".to_owned(), Box::new(FailFilterParser));
         options
     }
 
@@ -927,6 +950,29 @@ mod test {
         runtime.set_global("name".into(), Value::scalar("hello"));
         let output = template.render(&runtime).unwrap();
         assert_eq!(output, "truthy");
+    }
+
+    #[test]
+    fn filter_chain_existence_check_with_missing_value_is_falsy() {
+        let text = r#"{% if name | upcase %}truthy{% else %}falsy{% endif %}"#;
+        let options = options_with_filters();
+        let template = parser::parse(text, &options).map(Template::new).unwrap();
+
+        let runtime = RuntimeBuilder::new().build();
+        let output = template.render(&runtime).unwrap();
+        assert_eq!(output, "falsy");
+    }
+
+    #[test]
+    fn filter_chain_existence_check_propagates_filter_errors() {
+        let text = r#"{% if name | fail %}truthy{% else %}falsy{% endif %}"#;
+        let options = options_with_filters();
+        let template = parser::parse(text, &options).map(Template::new).unwrap();
+
+        let runtime = RuntimeBuilder::new().build();
+        runtime.set_global("name".into(), Value::scalar("hello"));
+        let output = template.render(&runtime);
+        assert!(output.is_err());
     }
 
     #[test]

--- a/crates/lib/src/stdlib/blocks/if_block.rs
+++ b/crates/lib/src/stdlib/blocks/if_block.rs
@@ -245,6 +245,7 @@ impl ConditionValue {
         }
     }
 
+    /// Non-failing evaluate, used for existence checks like `{% if x | upcase %}`.
     fn try_evaluate<'s>(
         &'s self,
         runtime: &'s dyn Runtime,
@@ -418,6 +419,10 @@ impl<'a> PeekableTagTokenIter<'a> {
     }
 }
 
+/// Parse a condition operand as a filter chain (e.g. `x | upcase`) or a plain value (e.g. `x`).
+///
+/// Tries filter chain first since the grammar rule `FilterChain = Value ~ ("|" ~ Filter)*`
+/// also matches plain values (zero filters). Falls back to plain value parsing on failure.
 fn parse_condition_value(
     token: TagToken<'_>,
     options: &Language,

--- a/crates/lib/src/stdlib/blocks/if_block.rs
+++ b/crates/lib/src/stdlib/blocks/if_block.rs
@@ -384,15 +384,6 @@ impl<'a> PeekableTagTokenIter<'a> {
     }
 }
 
-/// Parse a condition operand as a filter chain.
-///
-/// The grammar rule `FilterChain = Value ~ ("|" ~ Filter)*` also matches plain values,
-/// so all `if` / `unless` operands can be parsed uniformly through `FilterChain`.
-fn parse_condition_value(token: TagToken<'_>, options: &Language) -> Result<FilterChain> {
-    // Preserve filter parser errors here (for example, unknown filters in if/unless conditions).
-    token.parse_as_filter_chain(options)
-}
-
 fn parse_atom_condition(
     arguments: &mut PeekableTagTokenIter<'_>,
     options: &Language,
@@ -418,6 +409,15 @@ fn parse_atom_condition(
     };
 
     Ok(cond)
+}
+
+/// Parse a condition operand as a filter chain.
+///
+/// The grammar rule `FilterChain = Value ~ ("|" ~ Filter)*` also matches plain values,
+/// so all `if` / `unless` operands can be parsed uniformly through `FilterChain`.
+fn parse_condition_value(token: TagToken<'_>, options: &Language) -> Result<FilterChain> {
+    // Preserve filter parser errors here (for example, unknown filters in if/unless conditions).
+    token.parse_as_filter_chain(options)
 }
 
 fn parse_conjunction_chain(

--- a/crates/lib/src/stdlib/blocks/if_block.rs
+++ b/crates/lib/src/stdlib/blocks/if_block.rs
@@ -238,9 +238,9 @@ struct BinaryCondition {
 
 impl BinaryCondition {
     pub(crate) fn evaluate(&self, runtime: &dyn Runtime) -> Result<bool> {
-        let a = self.lh.evaluate(runtime)?;
+        let a = self.lh.try_evaluate(runtime)?;
         let ca = ValueViewCmp::new(a.as_view());
-        let b = self.rh.evaluate(runtime)?;
+        let b = self.rh.try_evaluate(runtime)?;
         let cb = ValueViewCmp::new(b.as_view());
 
         let result = match self.comparison {
@@ -920,6 +920,28 @@ mod test {
     #[test]
     fn filter_chain_existence_check_with_missing_value_applies_filters() {
         let text = r#"{% if name | upcase %}truthy{% else %}falsy{% endif %}"#;
+        let options = options_with_filters();
+        let template = parser::parse(text, &options).map(Template::new).unwrap();
+
+        let runtime = RuntimeBuilder::new().build();
+        let output = template.render(&runtime).unwrap();
+        assert_eq!(output, "truthy");
+    }
+
+    #[test]
+    fn missing_value_comparison_treats_missing_as_nil() {
+        let text = r#"{% if name == nil %}truthy{% else %}falsy{% endif %}"#;
+        let options = options_with_filters();
+        let template = parser::parse(text, &options).map(Template::new).unwrap();
+
+        let runtime = RuntimeBuilder::new().build();
+        let output = template.render(&runtime).unwrap();
+        assert_eq!(output, "truthy");
+    }
+
+    #[test]
+    fn missing_value_comparison_with_filters_applies_filters() {
+        let text = r#"{% if name | upcase == "" %}truthy{% else %}falsy{% endif %}"#;
         let options = options_with_filters();
         let template = parser::parse(text, &options).map(Template::new).unwrap();
 

--- a/crates/lib/src/stdlib/blocks/if_block.rs
+++ b/crates/lib/src/stdlib/blocks/if_block.rs
@@ -337,7 +337,6 @@ struct ExistenceCondition {
 impl ExistenceCondition {
     pub(crate) fn evaluate(&self, runtime: &dyn Runtime) -> Result<bool> {
         let a = self.lh.try_evaluate(runtime)?;
-        let a = a.unwrap_or_default();
         let is_truthy = a.query_state(liquid_core::model::State::Truthy);
         Ok(is_truthy)
     }

--- a/crates/lib/src/stdlib/blocks/if_block.rs
+++ b/crates/lib/src/stdlib/blocks/if_block.rs
@@ -246,10 +246,7 @@ impl ConditionValue {
     }
 
     /// Non-failing evaluate, used for existence checks like `{% if x | upcase %}`.
-    fn try_evaluate<'s>(
-        &'s self,
-        runtime: &'s dyn Runtime,
-    ) -> Option<liquid_core::ValueCow<'s>> {
+    fn try_evaluate<'s>(&'s self, runtime: &'s dyn Runtime) -> Option<liquid_core::ValueCow<'s>> {
         match self {
             ConditionValue::Simple(expr) => expr.try_evaluate(runtime),
             ConditionValue::Filtered(chain) => chain.evaluate(runtime).ok(),
@@ -423,10 +420,7 @@ impl<'a> PeekableTagTokenIter<'a> {
 ///
 /// Tries filter chain first since the grammar rule `FilterChain = Value ~ ("|" ~ Filter)*`
 /// also matches plain values (zero filters). Falls back to plain value parsing on failure.
-fn parse_condition_value(
-    token: TagToken<'_>,
-    options: &Language,
-) -> Result<ConditionValue> {
+fn parse_condition_value(token: TagToken<'_>, options: &Language) -> Result<ConditionValue> {
     match token.expect_filter_chain(options) {
         TryMatchToken::Matches(chain) => Ok(ConditionValue::Filtered(chain)),
         TryMatchToken::Fails(token) => {
@@ -537,11 +531,7 @@ mod test {
     struct UpcaseFilter;
 
     impl Filter for UpcaseFilter {
-        fn evaluate(
-            &self,
-            input: &dyn ValueView,
-            _runtime: &dyn Runtime,
-        ) -> Result<Value> {
+        fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
             Ok(Value::scalar(input.to_kstr().to_uppercase()))
         }
     }
@@ -555,11 +545,7 @@ mod test {
     struct DowncaseFilter;
 
     impl Filter for DowncaseFilter {
-        fn evaluate(
-            &self,
-            input: &dyn ValueView,
-            _runtime: &dyn Runtime,
-        ) -> Result<Value> {
+        fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
             Ok(Value::scalar(input.to_kstr().to_lowercase()))
         }
     }
@@ -964,8 +950,7 @@ mod test {
 
     #[test]
     fn multiple_filters_in_condition() {
-        let text =
-            r#"{% if a | upcase | downcase == b | upcase | downcase %}match{% else %}no match{% endif %}"#;
+        let text = r#"{% if a | upcase | downcase == b | upcase | downcase %}match{% else %}no match{% endif %}"#;
         let options = options_with_filters();
         let template = parser::parse(text, &options).map(Template::new).unwrap();
 

--- a/crates/lib/src/stdlib/blocks/if_block.rs
+++ b/crates/lib/src/stdlib/blocks/if_block.rs
@@ -6,8 +6,6 @@ use liquid_core::model::{ValueView, ValueViewCmp};
 use liquid_core::parser::BlockElement;
 use liquid_core::parser::FilterChain;
 use liquid_core::parser::TagToken;
-use liquid_core::parser::TryMatchToken;
-use liquid_core::Expression;
 use liquid_core::Language;
 use liquid_core::Renderable;
 use liquid_core::Runtime;
@@ -232,47 +230,10 @@ impl fmt::Display for Condition {
 }
 
 #[derive(Debug)]
-enum ConditionValue {
-    Simple(Expression),
-    Filtered(FilterChain),
-}
-
-impl ConditionValue {
-    fn evaluate<'s>(&'s self, runtime: &'s dyn Runtime) -> Result<liquid_core::ValueCow<'s>> {
-        match self {
-            ConditionValue::Simple(expr) => expr.evaluate(runtime),
-            ConditionValue::Filtered(chain) => chain.evaluate(runtime),
-        }
-    }
-
-    /// Evaluate for existence checks like `{% if x | upcase %}`.
-    ///
-    /// Missing variables remain falsy, but filter execution failures still propagate.
-    fn try_evaluate<'s>(
-        &'s self,
-        runtime: &'s dyn Runtime,
-    ) -> Result<Option<liquid_core::ValueCow<'s>>> {
-        match self {
-            ConditionValue::Simple(expr) => Ok(expr.try_evaluate(runtime)),
-            ConditionValue::Filtered(chain) => chain.try_evaluate(runtime),
-        }
-    }
-}
-
-impl fmt::Display for ConditionValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ConditionValue::Simple(expr) => write!(f, "{}", expr),
-            ConditionValue::Filtered(chain) => write!(f, "{}", chain),
-        }
-    }
-}
-
-#[derive(Debug)]
 struct BinaryCondition {
-    lh: ConditionValue,
+    lh: FilterChain,
     comparison: ComparisonOperator,
-    rh: ConditionValue,
+    rh: FilterChain,
 }
 
 impl BinaryCondition {
@@ -370,7 +331,7 @@ impl ComparisonOperator {
 
 #[derive(Debug)]
 struct ExistenceCondition {
-    lh: ConditionValue,
+    lh: FilterChain,
 }
 
 impl ExistenceCondition {
@@ -421,18 +382,12 @@ impl<'a> PeekableTagTokenIter<'a> {
     }
 }
 
-/// Parse a condition operand as a filter chain (e.g. `x | upcase`) or a plain value (e.g. `x`).
+/// Parse a condition operand as a filter chain.
 ///
-/// Tries filter chain first since the grammar rule `FilterChain = Value ~ ("|" ~ Filter)*`
-/// also matches plain values (zero filters). Falls back to plain value parsing on failure.
-fn parse_condition_value(token: TagToken<'_>, options: &Language) -> Result<ConditionValue> {
-    match token.expect_filter_chain(options) {
-        TryMatchToken::Matches(chain) => Ok(ConditionValue::Filtered(chain)),
-        TryMatchToken::Fails(token) => {
-            let expr = token.expect_value().into_result()?;
-            Ok(ConditionValue::Simple(expr))
-        }
-    }
+/// The grammar rule `FilterChain = Value ~ ("|" ~ Filter)*` also matches plain values,
+/// so all `if` / `unless` operands can be parsed uniformly through `FilterChain`.
+fn parse_condition_value(token: TagToken<'_>, options: &Language) -> Result<FilterChain> {
+    token.expect_filter_chain_result(options)
 }
 
 fn parse_atom_condition(
@@ -973,6 +928,16 @@ mod test {
         runtime.set_global("name".into(), Value::scalar("hello"));
         let output = template.render(&runtime);
         assert!(output.is_err());
+    }
+
+    #[test]
+    fn unknown_filter_in_condition_reports_filter_error() {
+        let text = r#"{% if name | nonexistent_filter == "HELLO" %}match{% endif %}"#;
+        let options = options_with_filters();
+
+        let error = parser::parse(text, &options).unwrap_err().to_string();
+        assert!(error.contains("Unknown filter"));
+        assert!(error.contains("requested filter=nonexistent_filter"));
     }
 
     #[test]

--- a/crates/lib/src/stdlib/blocks/if_block.rs
+++ b/crates/lib/src/stdlib/blocks/if_block.rs
@@ -238,9 +238,9 @@ struct BinaryCondition {
 
 impl BinaryCondition {
     pub(crate) fn evaluate(&self, runtime: &dyn Runtime) -> Result<bool> {
-        let a = self.lh.try_evaluate(runtime)?;
+        let a = self.lh.evaluate_comparison_operand(runtime)?;
         let ca = ValueViewCmp::new(a.as_view());
-        let b = self.rh.try_evaluate(runtime)?;
+        let b = self.rh.evaluate_comparison_operand(runtime)?;
         let cb = ValueViewCmp::new(b.as_view());
 
         let result = match self.comparison {
@@ -930,14 +930,14 @@ mod test {
     }
 
     #[test]
-    fn missing_value_comparison_treats_missing_as_nil() {
+    fn plain_missing_value_comparison_propagates_render_error() {
         let text = r#"{% if name == nil %}truthy{% else %}falsy{% endif %}"#;
         let options = options_with_filters();
         let template = parser::parse(text, &options).map(Template::new).unwrap();
 
         let runtime = RuntimeBuilder::new().build();
-        let output = template.render(&runtime).unwrap();
-        assert_eq!(output, "truthy");
+        let output = template.render(&runtime);
+        assert!(output.is_err());
     }
 
     #[test]

--- a/crates/lib/src/stdlib/blocks/if_block.rs
+++ b/crates/lib/src/stdlib/blocks/if_block.rs
@@ -908,14 +908,25 @@ mod test {
     }
 
     #[test]
-    fn filter_chain_existence_check_with_missing_value_is_falsy() {
-        let text = r#"{% if name | upcase %}truthy{% else %}falsy{% endif %}"#;
+    fn plain_existence_check_with_missing_value_is_falsy() {
+        let text = r#"{% if name %}truthy{% else %}falsy{% endif %}"#;
         let options = options_with_filters();
         let template = parser::parse(text, &options).map(Template::new).unwrap();
 
         let runtime = RuntimeBuilder::new().build();
         let output = template.render(&runtime).unwrap();
         assert_eq!(output, "falsy");
+    }
+
+    #[test]
+    fn filter_chain_existence_check_with_missing_value_applies_filters() {
+        let text = r#"{% if name | upcase %}truthy{% else %}falsy{% endif %}"#;
+        let options = options_with_filters();
+        let template = parser::parse(text, &options).map(Template::new).unwrap();
+
+        let runtime = RuntimeBuilder::new().build();
+        let output = template.render(&runtime).unwrap();
+        assert_eq!(output, "truthy");
     }
 
     #[test]

--- a/crates/lib/src/stdlib/blocks/if_block.rs
+++ b/crates/lib/src/stdlib/blocks/if_block.rs
@@ -238,9 +238,9 @@ struct BinaryCondition {
 
 impl BinaryCondition {
     pub(crate) fn evaluate(&self, runtime: &dyn Runtime) -> Result<bool> {
-        let a = self.lh.evaluate_comparison_operand(runtime)?;
+        let a = self.lh.try_evaluate(runtime)?;
         let ca = ValueViewCmp::new(a.as_view());
-        let b = self.rh.evaluate_comparison_operand(runtime)?;
+        let b = self.rh.try_evaluate(runtime)?;
         let cb = ValueViewCmp::new(b.as_view());
 
         let result = match self.comparison {
@@ -930,14 +930,25 @@ mod test {
     }
 
     #[test]
-    fn plain_missing_value_comparison_propagates_render_error() {
+    fn missing_value_comparison_treats_missing_as_nil() {
         let text = r#"{% if name == nil %}truthy{% else %}falsy{% endif %}"#;
         let options = options_with_filters();
         let template = parser::parse(text, &options).map(Template::new).unwrap();
 
         let runtime = RuntimeBuilder::new().build();
-        let output = template.render(&runtime);
-        assert!(output.is_err());
+        let output = template.render(&runtime).unwrap();
+        assert_eq!(output, "truthy");
+    }
+
+    #[test]
+    fn missing_value_comparison_to_number_is_false() {
+        let text = r#"{% if name == 1 %}truthy{% else %}falsy{% endif %}"#;
+        let options = options_with_filters();
+        let template = parser::parse(text, &options).map(Template::new).unwrap();
+
+        let runtime = RuntimeBuilder::new().build();
+        let output = template.render(&runtime).unwrap();
+        assert_eq!(output, "falsy");
     }
 
     #[test]

--- a/crates/lib/src/stdlib/blocks/if_block.rs
+++ b/crates/lib/src/stdlib/blocks/if_block.rs
@@ -264,7 +264,10 @@ impl fmt::Display for BinaryCondition {
 }
 
 fn contains_check(a: &dyn ValueView, b: &dyn ValueView) -> Result<bool> {
-    if let Some(a) = a.as_scalar() {
+    if a.is_nil() {
+        // Shopify Liquid treats `nil contains x` as false rather than an error.
+        Ok(false)
+    } else if let Some(a) = a.as_scalar() {
         let b = b.to_kstr();
         Ok(a.to_kstr().contains(b.as_str()))
     } else if let Some(a) = a.as_object() {
@@ -777,6 +780,26 @@ mod test {
         runtime.set_global("movies".into(), Value::Array(arr));
         let output = template.render(&runtime).unwrap();
         assert_eq!(output, "if false");
+    }
+
+    #[test]
+    fn contains_with_missing_value_is_false() {
+        let text = r#"{% if missing contains "foo" %}yes{% else %}no{% endif %}"#;
+        let template = parser::parse(text, &options()).map(Template::new).unwrap();
+
+        let runtime = RuntimeBuilder::new().build();
+        let output = template.render(&runtime).unwrap();
+        assert_eq!(output, "no");
+    }
+
+    #[test]
+    fn contains_with_nil_value_is_false() {
+        let text = r#"{% if nil contains "foo" %}yes{% else %}no{% endif %}"#;
+        let template = parser::parse(text, &options()).map(Template::new).unwrap();
+
+        let runtime = RuntimeBuilder::new().build();
+        let output = template.render(&runtime).unwrap();
+        assert_eq!(output, "no");
     }
 
     #[test]

--- a/tests/conformance_ruby/tags/if_else_tag_test.rs
+++ b/tests/conformance_ruby/tags/if_else_tag_test.rs
@@ -284,9 +284,7 @@ fn test_else_if() {
 
 #[test]
 fn test_syntax_error_no_variable() {
-    // Modified: since missing variables are render errors, we would hit a syntax error due to no
-    // close block, preventing us from testing the real thing.
-    assert_render_error!("{% if jerry == 1 %}{% endif %}");
+    assert_template_result!("", "{% if jerry == 1 %}{% endif %}");
 }
 
 #[test]

--- a/tests/conformance_ruby/tags/if_else_tag_test.rs
+++ b/tests/conformance_ruby/tags/if_else_tag_test.rs
@@ -283,7 +283,9 @@ fn test_else_if() {
 }
 
 #[test]
-fn test_syntax_error_no_variable() {
+fn test_missing_variable_comparison_renders_false() {
+    // Shopify Liquid treats missing variables in comparisons as `nil` by
+    // default, so this evaluates false rather than raising a render error.
     assert_template_result!("", "{% if jerry == 1 %}{% endif %}");
 }
 


### PR DESCRIPTION
Ruby Liquid treats missing variables in condition expressions as nil, and still applies filters on them. liquid-rust did not fully match that behavior.

Before this PR in liquid-rust:
`{% if missing | upcase %}` skipped filter application and evaluated as falsy
`{% if missing == nil %} and {% if missing | upcase == "" %}` could raise at runtime
unknown filters inside conditions could degrade into a generic parse error
This PR brings if / unless behavior closer to the Ruby Liquid implementation by:

treating missing values in conditions as nil
applying filters to missing values in condition paths
making binary comparisons use the same nil-tolerant evaluation as existence checks
preserving proper Unknown filter errors in conditions
Existing targeted tests continued to pass as expected. I re-ran:

cargo test -p liquid-lib if_block
cargo test -p liquid-lib assign
cargo fmt --all --check
Added / updated test coverage:

plain_existence_check_with_missing_value_is_falsy
filter_chain_existence_check_with_missing_value_applies_filters
missing_value_comparison_treats_missing_as_nil
missing_value_comparison_with_filters_applies_filters
unknown_filter_in_condition_reports_filter_error
This improves Shopify/Ruby Liquid compatibility and makes condition behavior more predictable for template authors.

- [x ] Tests created for any new feature or regression tests for bugfixes.
